### PR TITLE
Sru/19.2.24 lxc kvm

### DIFF
--- a/bin/sru-get-jenkins-logs
+++ b/bin/sru-get-jenkins-logs
@@ -1,17 +1,24 @@
 #!/bin/bash
 if [ $# -lt 1 ]; then
   script_name=`basename $0`
-  echo "usage: $script_name <sru_version>"
+  echo "usage: $script_name <sru_version> <sru_bug_num>"
   exit 1
 fi
 SRU_VERSION=$1
+SRU_BUG=$2
+if [ -z "$SRU_BUG" ]; then
+  script_name=`basename $0`
+  echo "usage: $script_name <sru_version> <sru_bug_num>"
+  exit 1
+fi
+
 echo "Grabbing all jenkins logs for SRU verification for version: $1"
 rm -rf jenkins;
 for platform in lxd kvm; do
   manuallog=manual/nocloud-$platform-sru-$SRU_VERSION.txt
   rm -f $manuallog;
-  for series in x b c d; do
-    jenkins-get-job cloud-init-integration-proposed-$series-$platform -v;
+  for series in x b d; do
+    jenkins-get-job cloud-init-integration-proposed-$series-$platform -v -s;
   done
   for log in `find jenkins/ -name '*console.log' | grep $platform`; do
     series=`echo $log | awk -F '-' '{print $5}'`
@@ -19,6 +26,6 @@ for platform in lxd kvm; do
     cat $log >> $manuallog;
     echo "=== End series $series ===" >> $manuallog;
   done
-  echo "Wrote $manuallog. Upload with lp-attach-file <SRU_BUG_NUM> $manuallog"
+  echo "Wrote $manuallog. Upload with lp-attach-file $SRU_BUG $manuallog"
 done
 

--- a/manual/nocloud-kvm-sru-19.2.24.txt
+++ b/manual/nocloud-kvm-sru-19.2.24.txt
@@ -1,0 +1,7108 @@
+=== Begin series b ===
+Started by remote host 10.247.8.15
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm
+[cloud-init-integration-proposed-b-kvm] $ /bin/sh -xe /tmp/jenkins16606540035720026290.sh
++ release=bionic
++ release_ver=18.04
++ platform=nocloud-kvm
++ set -e
++ sudo rm -Rf cloud-init
++ git clone https://git.launchpad.net/cloud-init
+Cloning into 'cloud-init'...
++ cd cloud-init
++ git tag --list
++ grep 18.04
++ tail -1
++ tag=ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
++ echo Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
+Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
++ git checkout ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
+Note: checking out 'ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at 22acf15e releasing cloud-init version 19.2-24-ge7881d5c-0ubuntu1~18.04.1
++ mirror=http://archive.ubuntu.com/ubuntu/
++ hostname
++ [ -z  -a torkoal = torkoal ]
++ export TMPDIR=/var/lib/jenkins/tmp/
++ set +e
++ no_proxy=launchpad.net https_proxy=http://squid.internal:3128 tox -e citest -- run --os-name=bionic --platform=nocloud-kvm --repo='deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main' --preserve-data --data-dir=./results --verbose
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/setup.py
+citest create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/.tox/citest
+citest installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/integration-requirements.txt
+citest inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/.tox/dist/cloud-init-19.2.zip
+citest installed: asn1crypto==0.24.0,attrs==19.1.0,bcrypt==3.1.7,boto3==1.5.9,botocore==1.8.50,certifi==2019.6.16,cffi==1.12.3,chardet==3.0.4,cloud-init==19.2,configobj==5.0.6,cryptography==2.4.2,docutils==0.15.2,idna==2.8,Jinja2==2.10.1,jmespath==0.9.4,jsonpatch==1.24,jsonpointer==2.0,jsonschema==3.0.2,linecache2==1.0.0,MarkupSafe==1.1.1,oauthlib==3.1.0,paramiko==2.4.2,pbr==5.4.3,pkg-resources==0.0.0,pyasn1==0.4.7,pycparser==2.19,pylxd==2.2.7,PyNaCl==1.3.0,pyrsistent==0.15.4,python-dateutil==2.8.0,python-simplestreams==0.1.0,PyYAML==5.1.2,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,s3transfer==0.1.13,six==1.12.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.3,ws4py==0.5.1
+citest runtests: PYTHONHASHSEED='4225936269'
+citest runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=bionic --platform=nocloud-kvm --repo=deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main --preserve-data --data-dir=./results --verbose
+2019-09-09 10:52:28,344 - tests.cloud_tests - DEBUG - running with args: Namespace(data_dir='/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results', deb=None, feature_override={}, os_name=['bionic'], platform=['nocloud-kvm'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo='deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main', result=None, rpm=None, script=None, subcmd='run', test_config=['/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1511485.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1611074.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1628337.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/add_apt_repositories.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/alter_completion_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/configure_instance_trusted_ca_certificates.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/configure_instances_ssh_keys.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/including_user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/install_arbitrary_packages.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/install_run_chef_recipes.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_apt_upgrade.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_commands.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_commands_first_boot.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/setup_run_puppet.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/examples/writing_out_arbitrary_files.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/main/command_output_simple.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_conf.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_disable_suites.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_primary.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_proxy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_security.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_key.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_keyserver.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_os.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/bootcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/byobu.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ca_certs.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/debug_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/debug_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/final_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/keys_to_console.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/landscape.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/locale.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/lxd_bridge.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/lxd_dir.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_chrony.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_pools.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_servers.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_timesyncd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/package_update_upgrade_install.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/runcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/seed_random_command.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/seed_random_data.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_hostname.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_hostname_fqdn.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_expire.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_list_string.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/snap.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/snappy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_import_id.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_generate.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_provided.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/timezone.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/tests/cloud_tests/testcases/modules/write_files.yaml'], upgrade=True, upgrade_full=False, verbose=True)
+2019-09-09 10:52:28,345 - tests.cloud_tests - DEBUG - using tmpdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results
+2019-09-09 10:52:28,353 - tests.cloud_tests - DEBUG - platform config: {'enabled': True, 'get_image_timeout': 300, 'create_instance_timeout': 60, 'private_key': 'cloud_init_rsa', 'public_key': 'cloud_init_rsa.pub', 'cache_mode': 'cache=none,aio=native', 'data_dir': '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results'}
+2019-09-09 10:52:28,353 - tests.cloud_tests - INFO - setting up platform: nocloud-kvm
+2019-09-09 10:52:29,235 - tests.cloud_tests - DEBUG - os config: {'enabled': True, 'boot_timeout': 120, 'boot_clean_script': '#!/bin/bash\nrm -rf /var/log/cloud-init.log /var/log/cloud-init-output.log \\\n    /var/lib/cloud/ /run/cloud-init/ /var/log/syslog\n', 'system_ready_script': "# permit running or degraded state as both indicate complete boot\n[ $(systemctl is-system-running) = 'running' -o\n  $(systemctl is-system-running) = 'degraded' ]\n", 'cloud_init_ready_script': "[ -f '/run/cloud-init/result.json' ]\n", 'feature_groups': ['base', 'debian_base', 'ubuntu_specific'], 'features': {'apt': True, 'byobu': True, 'landscape': True, 'lxd': True, 'ppa': True, 'rpm': None, 'snap': True, 'hostname': True, 'apt_src_cont': True, 'apt_hist_fmt': True, 'daylight_time': True, 'apt_up_out': True, 'engb_locale': True, 'locale_gen': True, 'no_ntpdate': True, 'no_file_fmt_e': True, 'ppa_file_name': True, 'sshd': True, 'ssh_key_fmt': True, 'syslog': True, 'ubuntu_ntp': True, 'ubuntu_repos': True, 'ubuntu_user': True, 'lsb_release': True, 'sudo': True}, 'mirror_url': 'https://cloud-images.ubuntu.com/daily', 'mirror_dir': '/srv/citest/images', 'keyring': '/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg', 'version': 18.04, 'setup_overrides': None, 'override_templates': False, 'release': 'bionic', 'os': 'ubuntu', 'arch': 'amd64'}
+2019-09-09 10:52:29,235 - tests.cloud_tests - INFO - acquiring image for os: bionic
+2019-09-09 10:52:35,771 - tests.cloud_tests - DEBUG - updating args for setup with: None
+2019-09-09 10:52:36,681 - tests.cloud_tests - INFO - setting up ubuntu-bionic (build_name=server serial=20190905)
+2019-09-09 10:52:36,682 - tests.cloud_tests - DEBUG - enable repo: "deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main" in target
+2019-09-09 10:52:36,682 - tests.cloud_tests - DEBUG - executing "enable repo: "deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main" in target"
+2019-09-09 10:52:44,705 - tests.cloud_tests - DEBUG - upgrading cloud-init
+2019-09-09 10:52:44,705 - tests.cloud_tests - DEBUG - executing "upgrading cloud-init"
+2019-09-09 10:52:51,144 - tests.cloud_tests - DEBUG - creating snapshot for bionic
+2019-09-09 10:52:51,298 - tests.cloud_tests - INFO - collecting test data for os: bionic
+2019-09-09 10:52:51,302 - tests.cloud_tests - WARNING - test config bugs/lp1511485 is not enabled, skipping
+2019-09-09 10:52:51,305 - tests.cloud_tests - WARNING - test config bugs/lp1611074 is not enabled, skipping
+2019-09-09 10:52:51,340 - tests.cloud_tests - INFO - collecting test data for test: bugs/lp1628337
+2019-09-09 10:52:52,365 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:53:07,433 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:53:16,851 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:53:22,206 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:53:22,207 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:53:22,266 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:53:22,267 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:53:22,362 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:53:22,362 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:53:22,454 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:53:22,454 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:53:22,550 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:53:22,550 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:53:22,643 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:53:22,643 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:53:22,736 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:53:22,736 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:53:22,840 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:53:22,840 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:53:22,930 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:53:22,930 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:53:23,278 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 24023 to end
+2019-09-09 10:53:23,749 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-bugs-lp1628337-wes16hzb4l5441vovpplfja to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/bugs/lp1628337/console.log
+2019-09-09 10:53:23,760 - tests.cloud_tests - WARNING - test config examples/add_apt_repositories is not enabled, skipping
+2019-09-09 10:53:23,767 - tests.cloud_tests - WARNING - test config examples/alter_completion_message is not enabled, skipping
+2019-09-09 10:53:23,780 - tests.cloud_tests - WARNING - test config examples/configure_instance_trusted_ca_certificates is not enabled, skipping
+2019-09-09 10:53:23,796 - tests.cloud_tests - WARNING - test config examples/configure_instances_ssh_keys is not enabled, skipping
+2019-09-09 10:53:23,807 - tests.cloud_tests - WARNING - test config examples/including_user_groups is not enabled, skipping
+2019-09-09 10:53:23,812 - tests.cloud_tests - WARNING - test config examples/install_arbitrary_packages is not enabled, skipping
+2019-09-09 10:53:23,820 - tests.cloud_tests - WARNING - test config examples/install_run_chef_recipes is not enabled, skipping
+2019-09-09 10:53:23,824 - tests.cloud_tests - WARNING - test config examples/run_apt_upgrade is not enabled, skipping
+2019-09-09 10:53:23,829 - tests.cloud_tests - WARNING - test config examples/run_commands is not enabled, skipping
+2019-09-09 10:53:23,834 - tests.cloud_tests - WARNING - test config examples/run_commands_first_boot is not enabled, skipping
+2019-09-09 10:53:23,842 - tests.cloud_tests - WARNING - test config examples/setup_run_puppet is not enabled, skipping
+2019-09-09 10:53:23,852 - tests.cloud_tests - WARNING - test config examples/writing_out_arbitrary_files is not enabled, skipping
+2019-09-09 10:53:23,909 - tests.cloud_tests - INFO - collecting test data for test: main/command_output_simple
+2019-09-09 10:53:24,939 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:53:39,963 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:53:49,312 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:53:53,637 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:53:53,638 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:53:53,732 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:53:53,733 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:53:53,822 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:53:53,822 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:53:53,914 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:53:53,914 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:53:54,006 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:53:54,006 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:53:54,098 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:53:54,098 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:53:54,190 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:53:54,191 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:53:54,292 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:53:54,293 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:53:54,382 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:53:54,382 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:53:54,555 - tests.cloud_tests - DEBUG - running collect script: cloud-init-test-output
+2019-09-09 10:53:54,555 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-test-output"
+2019-09-09 10:53:54,801 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 1424 to end
+2019-09-09 10:53:55,281 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-main-command-output-simple-d7klei68yzv to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/main/command_output_simple/console.log
+2019-09-09 10:53:55,322 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_conf
+2019-09-09 10:53:56,353 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:54:11,378 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:54:20,785 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:54:26,309 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:54:26,309 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:54:26,365 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:54:26,365 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:54:26,454 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:54:26,454 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:54:26,546 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:54:26,546 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:54:26,638 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:54:26,638 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:54:26,730 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:54:26,731 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:54:26,822 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:54:26,823 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:54:26,933 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:54:26,934 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:54:27,026 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:54:27,026 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:54:27,201 - tests.cloud_tests - DEBUG - running collect script: 94cloud-init-config
+2019-09-09 10:54:27,201 - tests.cloud_tests - DEBUG - executing "collect: 94cloud-init-config"
+2019-09-09 10:54:27,430 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 6840 to end
+2019-09-09 10:54:27,873 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-conf-sbhve82a1zn to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_conf/console.log
+2019-09-09 10:54:27,913 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_disable_suites
+2019-09-09 10:54:28,945 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:54:43,970 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:54:53,578 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:54:56,582 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:54:59,586 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 10:55:02,589 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:55:03,653 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:55:03,653 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:55:03,750 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:55:03,750 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:55:03,843 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:55:03,843 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:55:03,934 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:55:03,935 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:55:04,030 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:55:04,031 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:55:04,122 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:55:04,123 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:55:04,217 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:55:04,217 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:55:04,315 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:55:04,316 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:55:04,406 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:55:04,407 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:55:04,571 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:55:04,571 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:55:04,803 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 13400 to end
+2019-09-09 10:55:05,377 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-disable--zg8yv06 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_disable_suites/console.log
+2019-09-09 10:55:05,413 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_primary
+2019-09-09 10:55:06,438 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:55:21,466 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:55:39,494 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:55:49,212 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:55:52,213 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 10:55:55,216 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:56:00,020 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:56:00,020 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:56:00,078 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:56:00,078 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:56:00,171 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:56:00,171 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:56:00,367 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:56:00,367 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:56:00,752 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:56:00,752 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:56:00,889 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:56:00,889 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:56:01,071 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:56:01,071 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:56:01,431 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:56:01,431 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:56:01,578 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:56:01,578 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:56:01,872 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:56:01,873 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:56:02,329 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19262 to end
+2019-09-09 10:56:02,953 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-primary-9w7qdr32 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_primary/console.log
+2019-09-09 10:56:02,993 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_proxy
+2019-09-09 10:56:04,020 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:56:19,044 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:56:37,073 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:56:42,848 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:56:42,849 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:56:42,946 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:56:42,946 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:56:43,042 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:56:43,042 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:56:43,137 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:56:43,137 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:56:43,228 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:56:43,229 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:56:43,319 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:56:43,319 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:56:43,411 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:56:43,411 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:56:43,524 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:56:43,524 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:56:43,615 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:56:43,615 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:56:43,791 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-aptproxy
+2019-09-09 10:56:43,792 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-aptproxy"
+2019-09-09 10:56:44,068 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 28251 to end
+2019-09-09 10:56:44,741 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-proxy-59cnho1884 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_proxy/console.log
+2019-09-09 10:56:44,783 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_security
+2019-09-09 10:56:45,813 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:57:00,838 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:57:10,108 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:57:14,335 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:57:14,335 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:57:14,432 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:57:14,432 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:57:14,522 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:57:14,523 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:57:14,614 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:57:14,614 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:57:14,706 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:57:14,706 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:57:14,799 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:57:14,799 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:57:14,895 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:57:14,896 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:57:14,997 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:57:14,997 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:57:15,087 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:57:15,087 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:57:15,264 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:57:15,264 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:57:15,576 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 3111 to end
+2019-09-09 10:57:16,109 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-security-1kgo29r to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_security/console.log
+2019-09-09 10:57:16,150 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_key
+2019-09-09 10:57:17,179 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:57:32,204 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:57:41,337 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:57:44,443 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:57:47,445 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 10:57:50,448 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:58:22,981 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:58:22,981 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:58:23,087 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:58:23,088 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:58:23,179 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:58:23,179 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:58:23,270 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:58:23,270 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:58:23,364 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:58:23,364 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:58:23,455 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:58:23,455 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:58:23,547 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:58:23,547 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:58:23,653 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:58:23,653 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:58:23,747 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:58:23,747 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:58:23,924 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:58:23,924 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:58:24,019 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:58:24,020 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:58:24,208 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:58:24,393 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 7424 to end
+2019-09-09 10:58:24,889 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--efupkio to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_sources_key/console.log
+2019-09-09 10:58:24,936 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_keyserver
+2019-09-09 10:58:26,013 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:58:41,038 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:58:59,066 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:59:13,978 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:59:13,978 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:59:14,032 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:59:14,032 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:59:14,122 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:59:14,122 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:59:14,215 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:59:14,215 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:59:14,314 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:59:14,314 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:59:14,406 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:59:14,406 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:59:14,502 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:59:14,503 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:59:14,603 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:59:14,604 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:59:14,694 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:59:14,694 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:59:14,863 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:59:14,863 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:59:14,955 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:59:14,956 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:59:15,151 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:59:15,185 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18870 to end
+2019-09-09 10:59:15,857 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--ofz6jqi to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_sources_keyserver/console.log
+2019-09-09 10:59:15,896 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_list
+2019-09-09 10:59:16,922 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:59:31,948 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:59:41,038 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:59:45,181 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:59:45,181 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:59:45,237 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:59:45,237 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:59:45,332 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:59:45,332 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:59:45,431 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:59:45,431 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:59:45,527 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:59:45,527 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:59:45,618 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:59:45,619 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:59:45,711 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:59:45,711 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:59:45,813 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:59:45,814 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:59:45,902 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:59:45,902 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:59:46,074 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:59:46,075 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:59:46,361 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 30058 to end
+2019-09-09 10:59:46,829 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--eyx2s11 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_sources_list/console.log
+2019-09-09 10:59:46,869 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_ppa
+2019-09-09 10:59:47,897 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:00:02,923 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:00:12,094 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:00:28,448 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:00:28,448 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:00:28,506 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:00:28,506 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:00:28,599 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:00:28,599 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:00:28,690 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:00:28,691 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:00:28,782 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:00:28,783 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:00:28,875 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:00:28,875 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:00:28,967 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:00:28,967 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:00:29,076 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:00:29,076 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:00:29,168 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:00:29,168 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:00:29,339 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 11:00:29,339 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 11:00:29,431 - tests.cloud_tests - DEBUG - running collect script: apt-key
+2019-09-09 11:00:29,431 - tests.cloud_tests - DEBUG - executing "collect: apt-key"
+2019-09-09 11:00:29,627 - tests.cloud_tests - DEBUG - collect script apt-key exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 11:00:29,628 - tests.cloud_tests - DEBUG - running collect script: sources_full
+2019-09-09 11:00:29,628 - tests.cloud_tests - DEBUG - executing "collect: sources_full"
+2019-09-09 11:00:29,795 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 3054 to end
+2019-09-09 11:00:32,565 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--j3h9rdb to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_configure_sources_ppa/console.log
+2019-09-09 11:00:32,602 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_disable
+2019-09-09 11:00:33,628 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:00:48,658 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:00:58,379 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:01:02,619 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:01:02,620 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:01:02,716 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:01:02,716 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:01:02,812 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:01:02,812 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:01:02,904 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:01:02,904 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:01:02,996 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:01:02,996 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:01:03,086 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:01:03,087 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:01:03,179 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:01:03,179 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:01:03,281 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:01:03,281 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:01:03,372 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:01:03,372 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:01:03,546 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining
+2019-09-09 11:01:03,546 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining"
+2019-09-09 11:01:03,808 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14609 to end
+2019-09-09 11:01:05,345 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-pipelining-disable-25398o9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_pipelining_disable/console.log
+2019-09-09 11:01:05,383 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_os
+2019-09-09 11:01:06,411 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:01:21,435 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:01:31,056 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:01:35,152 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:01:35,152 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:01:35,209 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:01:35,210 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:01:35,298 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:01:35,298 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:01:35,391 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:01:35,391 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:01:35,482 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:01:35,482 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:01:35,578 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:01:35,578 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:01:35,674 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:01:35,674 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:01:35,783 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:01:35,783 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:01:35,874 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:01:35,875 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:01:36,043 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining_not_written
+2019-09-09 11:01:36,043 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining_not_written"
+2019-09-09 11:01:36,136 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining_not_written exited 'b"ls: cannot access '/etc/apt/apt.conf.d/90cloud-init-pipelining': No such file or directory\n"' and had stderr: 0
+2019-09-09 11:01:36,287 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 21836 to end
+2019-09-09 11:01:36,781 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-pipelining-os-t65z2x5r4bkn to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/apt_pipelining_os/console.log
+2019-09-09 11:01:36,818 - tests.cloud_tests - INFO - collecting test data for test: modules/bootcmd
+2019-09-09 11:01:37,844 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:01:52,868 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:02:01,906 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:02:07,352 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:02:07,353 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:02:07,410 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:02:07,410 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:02:07,506 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:02:07,507 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:02:07,598 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:02:07,598 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:02:07,690 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:02:07,690 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:02:07,782 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:02:07,782 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:02:07,874 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:02:07,874 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:02:07,974 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:02:07,974 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:02:08,067 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:02:08,067 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:02:08,231 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 11:02:08,232 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 11:02:08,427 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 27384 to end
+2019-09-09 11:02:08,849 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-bootcmd-8csi1443mzvxtywvlyz86k to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/bootcmd/console.log
+2019-09-09 11:02:08,884 - tests.cloud_tests - INFO - collecting test data for test: modules/byobu
+2019-09-09 11:02:09,910 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:02:24,936 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:02:34,043 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:02:42,314 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:02:42,314 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:02:42,370 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:02:42,370 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:02:42,459 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:02:42,459 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:02:42,550 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:02:42,551 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:02:42,643 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:02:42,643 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:02:42,734 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:02:42,734 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:02:42,826 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:02:42,827 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:02:42,928 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:02:42,928 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:02:43,018 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:02:43,018 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:02:43,187 - tests.cloud_tests - DEBUG - running collect script: byobu_profile_enabled
+2019-09-09 11:02:43,187 - tests.cloud_tests - DEBUG - executing "collect: byobu_profile_enabled"
+2019-09-09 11:02:43,280 - tests.cloud_tests - DEBUG - running collect script: byobu_launch_exists
+2019-09-09 11:02:43,280 - tests.cloud_tests - DEBUG - executing "collect: byobu_launch_exists"
+2019-09-09 11:02:43,440 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 32424 to end
+2019-09-09 11:02:44,169 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-byobu-v6s0u22zpfdggm8pbrw72wq8 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/byobu/console.log
+2019-09-09 11:02:44,211 - tests.cloud_tests - INFO - collecting test data for test: modules/ca_certs
+2019-09-09 11:02:45,258 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:03:00,286 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:03:09,511 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:03:12,515 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:03:15,517 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:03:18,520 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:03:19,630 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:03:19,630 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:03:19,688 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:03:19,688 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:03:19,778 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:03:19,779 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:03:19,870 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:03:19,870 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:03:19,964 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:03:19,964 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:03:20,054 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:03:20,055 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:03:20,148 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:03:20,148 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:03:20,260 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:03:20,260 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:03:20,355 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:03:20,355 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:03:20,912 - tests.cloud_tests - DEBUG - running collect script: cert_links
+2019-09-09 11:03:20,912 - tests.cloud_tests - DEBUG - executing "collect: cert_links"
+2019-09-09 11:03:21,633 - tests.cloud_tests - DEBUG - running collect script: cert
+2019-09-09 11:03:21,633 - tests.cloud_tests - DEBUG - executing "collect: cert"
+2019-09-09 11:03:22,783 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 5654 to end
+2019-09-09 11:03:23,797 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ca-certs-pqzt55jm0mtsou8bxdz8q to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ca_certs/console.log
+2019-09-09 11:03:23,837 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_disable
+2019-09-09 11:03:24,864 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:03:39,891 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:03:48,896 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:03:53,199 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:03:53,200 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:03:53,293 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:03:53,293 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:03:53,382 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:03:53,383 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:03:53,474 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:03:53,474 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:03:53,571 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:03:53,571 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:03:53,663 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:03:53,664 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:03:53,759 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:03:53,759 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:03:53,865 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:03:53,865 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:03:53,954 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:03:53,955 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:03:54,317 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 13989 to end
+2019-09-09 11:03:54,821 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-debug-disable-kr2j5649hxph1dmj to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/debug_disable/console.log
+2019-09-09 11:03:54,869 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_enable
+2019-09-09 11:03:55,897 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:04:10,922 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:04:20,137 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:04:24,273 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:04:24,273 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:04:24,370 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:04:24,370 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:04:24,459 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:04:24,459 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:04:24,551 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:04:24,551 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:04:24,643 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:04:24,643 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:04:24,735 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:04:24,735 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:04:24,827 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:04:24,827 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:04:24,937 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:04:24,937 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:04:25,029 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:04:25,029 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:04:25,301 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19058 to end
+2019-09-09 11:04:25,877 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-debug-enable-thr0eob6lhwc4tsee to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/debug_enable/console.log
+2019-09-09 11:04:25,917 - tests.cloud_tests - INFO - collecting test data for test: modules/final_message
+2019-09-09 11:04:26,944 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:04:41,968 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:04:51,079 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:04:55,216 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:04:55,216 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:04:55,310 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:04:55,310 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:04:55,402 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:04:55,402 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:04:55,494 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:04:55,495 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:04:55,587 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:04:55,587 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:04:55,678 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:04:55,679 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:04:55,771 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:04:55,771 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:04:55,873 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:04:55,874 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:04:55,966 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:04:55,967 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:04:56,397 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22316 to end
+2019-09-09 11:04:56,857 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-final-message-7tglzalgt2e26qqe to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/final_message/console.log
+2019-09-09 11:04:56,896 - tests.cloud_tests - INFO - collecting test data for test: modules/keys_to_console
+2019-09-09 11:04:57,925 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:05:12,951 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:05:22,100 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:05:26,604 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:05:26,604 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:05:26,702 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:05:26,702 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:05:26,790 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:05:26,791 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:05:26,882 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:05:26,883 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:05:26,974 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:05:26,974 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:05:27,066 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:05:27,067 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:05:27,158 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:05:27,159 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:05:27,261 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:05:27,261 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:05:27,359 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:05:27,359 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:05:27,612 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 11:05:27,612 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 11:05:27,793 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23702 to end
+2019-09-09 11:05:28,277 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-keys-to-console-20xklbipsqnmdh to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/keys_to_console/console.log
+2019-09-09 11:05:28,283 - tests.cloud_tests - WARNING - test config modules/landscape is not enabled, skipping
+2019-09-09 11:05:28,317 - tests.cloud_tests - INFO - collecting test data for test: modules/locale
+2019-09-09 11:05:29,342 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:05:44,367 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:05:53,911 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:05:57,998 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:05:57,998 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:05:58,052 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:05:58,052 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:05:58,142 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:05:58,142 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:05:58,234 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:05:58,234 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:05:58,326 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:05:58,326 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:05:58,418 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:05:58,418 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:05:58,511 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:05:58,511 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:05:58,613 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:05:58,613 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:05:58,702 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:05:58,702 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:05:58,888 - tests.cloud_tests - DEBUG - running collect script: locale_default
+2019-09-09 11:05:58,888 - tests.cloud_tests - DEBUG - executing "collect: locale_default"
+2019-09-09 11:05:59,013 - tests.cloud_tests - DEBUG - running collect script: locale_a
+2019-09-09 11:05:59,013 - tests.cloud_tests - DEBUG - executing "collect: locale_a"
+2019-09-09 11:05:59,176 - tests.cloud_tests - DEBUG - running collect script: locale_gen
+2019-09-09 11:05:59,176 - tests.cloud_tests - DEBUG - executing "collect: locale_gen"
+2019-09-09 11:05:59,392 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 27532 to end
+2019-09-09 11:05:59,821 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-locale-qfzi4pgvdq5wp74lygwb6gt to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/locale/console.log
+2019-09-09 11:05:59,858 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_bridge
+2019-09-09 11:06:00,885 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:06:15,910 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:06:24,838 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:06:40,431 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:06:40,431 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:06:40,485 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:06:40,485 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:06:40,575 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:06:40,575 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:06:40,667 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:06:40,667 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:06:40,759 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:06:40,759 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:06:40,851 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:06:40,851 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:06:40,942 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:06:40,943 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:06:41,056 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:06:41,056 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:06:41,146 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:06:41,147 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:06:41,317 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 11:06:41,317 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 11:06:41,412 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 11:06:41,412 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 11:06:41,503 - tests.cloud_tests - DEBUG - running collect script: lxc-bridge
+2019-09-09 11:06:41,503 - tests.cloud_tests - DEBUG - executing "collect: lxc-bridge"
+2019-09-09 11:06:41,674 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 27851 to end
+2019-09-09 11:06:42,369 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-lxd-bridge-ohln7bab42ma096zoyf to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/lxd_bridge/console.log
+2019-09-09 11:06:42,407 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_dir
+2019-09-09 11:06:43,433 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:06:58,457 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:07:08,084 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:07:28,666 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:07:28,667 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:07:28,723 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:07:28,724 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:07:28,816 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:07:28,816 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:07:28,907 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:07:28,907 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:07:29,003 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:07:29,003 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:07:29,095 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:07:29,095 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:07:29,188 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:07:29,188 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:07:29,293 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:07:29,293 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:07:29,388 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:07:29,389 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:07:29,566 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 11:07:29,566 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 11:07:29,668 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 11:07:29,668 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 11:07:29,900 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 5204 to end
+2019-09-09 11:07:30,657 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-lxd-dir-wot7ufc4ljzt0jjxmjvw9d to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/lxd_dir/console.log
+2019-09-09 11:07:30,698 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp
+2019-09-09 11:07:31,825 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:07:46,850 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:07:55,922 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:07:58,927 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:08:01,929 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:08:04,932 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:08:31,101 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:08:31,102 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:08:31,158 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:08:31,158 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:08:31,251 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:08:31,251 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:08:31,342 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:08:31,343 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:08:31,439 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:08:31,439 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:08:31,531 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:08:31,531 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:08:31,623 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:08:31,623 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:08:31,724 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:08:31,724 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:08:31,814 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:08:31,814 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:08:31,992 - tests.cloud_tests - DEBUG - running collect script: ntp_installed
+2019-09-09 11:08:31,992 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed"
+2019-09-09 11:08:32,089 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_empty
+2019-09-09 11:08:32,090 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_empty"
+2019-09-09 11:08:32,183 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_empty exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 11:08:32,184 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pool_list
+2019-09-09 11:08:32,184 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pool_list"
+2019-09-09 11:08:32,444 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19491 to end
+2019-09-09 11:08:33,109 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-3i91yurde0562pi5raavac9ck2 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ntp/console.log
+2019-09-09 11:08:33,152 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_chrony
+2019-09-09 11:08:34,181 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:08:49,206 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:09:07,234 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:09:37,637 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:09:37,638 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:09:37,699 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:09:37,699 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:09:37,791 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:09:37,792 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:09:37,887 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:09:37,887 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:09:37,979 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:09:37,979 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:09:38,075 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:09:38,075 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:09:38,171 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:09:38,171 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:09:38,274 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:09:38,274 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:09:38,371 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:09:38,371 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:09:38,548 - tests.cloud_tests - DEBUG - running collect script: chrony_conf
+2019-09-09 11:09:38,548 - tests.cloud_tests - DEBUG - executing "collect: chrony_conf"
+2019-09-09 11:09:38,826 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 2964 to end
+2019-09-09 11:09:39,541 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-chrony-txab9gvut0qne3zng8c to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ntp_chrony/console.log
+2019-09-09 11:09:39,581 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_pools
+2019-09-09 11:09:40,636 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:09:55,662 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:10:04,800 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:10:19,213 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:10:19,213 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:10:19,268 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:10:19,269 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:10:19,358 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:10:19,359 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:10:19,455 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:10:19,455 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:10:19,546 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:10:19,546 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:10:19,638 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:10:19,638 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:10:19,730 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:10:19,730 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:10:19,832 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:10:19,833 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:10:19,923 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:10:19,923 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:10:20,100 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_pools
+2019-09-09 11:10:20,100 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_pools"
+2019-09-09 11:10:20,196 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_pools
+2019-09-09 11:10:20,196 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_pools"
+2019-09-09 11:10:20,287 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_pools exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 11:10:20,288 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pools
+2019-09-09 11:10:20,288 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pools"
+2019-09-09 11:10:20,379 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 11:10:20,379 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 11:10:20,564 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19581 to end
+2019-09-09 11:10:21,445 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-pools-2dnt6sk8jl3jzelgcpck to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ntp_pools/console.log
+2019-09-09 11:10:21,484 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_servers
+2019-09-09 11:10:22,512 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:10:37,538 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:10:55,564 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:11:39,138 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:11:39,138 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:11:39,194 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:11:39,194 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:11:39,287 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:11:39,287 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:11:39,379 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:11:39,379 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:11:39,471 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:11:39,471 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:11:39,562 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:11:39,563 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:11:39,658 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:11:39,658 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:11:39,761 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:11:39,761 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:11:39,862 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:11:39,862 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:11:40,057 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_servers
+2019-09-09 11:11:40,057 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_servers"
+2019-09-09 11:11:40,148 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_servers
+2019-09-09 11:11:40,148 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_servers"
+2019-09-09 11:11:40,238 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_servers exited 'b'cat: /etc/ntp.conf.dist: No such file or directory\n'' and had stderr: 0
+2019-09-09 11:11:40,239 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_servers
+2019-09-09 11:11:40,239 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_servers"
+2019-09-09 11:11:40,331 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 11:11:40,331 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 11:11:40,654 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 31779 to end
+2019-09-09 11:11:41,193 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-servers-wzzhreflca7u7ipycq to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ntp_servers/console.log
+2019-09-09 11:11:41,236 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_timesyncd
+2019-09-09 11:11:42,263 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:11:57,288 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:12:07,145 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:12:10,150 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:12:13,153 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:12:16,156 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:12:17,442 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:12:17,442 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:12:17,499 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:12:17,499 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:12:17,591 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:12:17,591 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:12:17,683 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:12:17,683 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:12:17,775 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:12:17,775 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:12:17,871 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:12:17,871 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:12:17,966 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:12:17,966 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:12:18,069 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:12:18,069 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:12:18,163 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:12:18,163 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:12:18,363 - tests.cloud_tests - DEBUG - running collect script: timesyncd_conf
+2019-09-09 11:12:18,363 - tests.cloud_tests - DEBUG - executing "collect: timesyncd_conf"
+2019-09-09 11:12:18,558 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16313 to end
+2019-09-09 11:12:19,197 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-timesyncd-w6s10ug1ffsn0j8u to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ntp_timesyncd/console.log
+2019-09-09 11:12:19,247 - tests.cloud_tests - INFO - collecting test data for test: modules/package_update_upgrade_install
+2019-09-09 11:12:20,273 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:12:35,298 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:12:44,207 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:12:58,042 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:12:58,042 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:12:58,097 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:12:58,097 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:12:58,188 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:12:58,188 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:12:58,279 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:12:58,279 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:12:58,372 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:12:58,372 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:12:58,468 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:12:58,468 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:12:58,563 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:12:58,563 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:12:58,672 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:12:58,672 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:12:58,763 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:12:58,763 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:12:58,941 - tests.cloud_tests - DEBUG - running collect script: apt_history_cmdline
+2019-09-09 11:12:58,941 - tests.cloud_tests - DEBUG - executing "collect: apt_history_cmdline"
+2019-09-09 11:12:59,037 - tests.cloud_tests - DEBUG - running collect script: dpkg_show
+2019-09-09 11:12:59,037 - tests.cloud_tests - DEBUG - executing "collect: dpkg_show"
+2019-09-09 11:12:59,274 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 26139 to end
+2019-09-09 11:12:59,969 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-package-update-upgrade-yz3cers to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/package_update_upgrade_install/console.log
+2019-09-09 11:13:00,008 - tests.cloud_tests - INFO - collecting test data for test: modules/runcmd
+2019-09-09 11:13:01,035 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:13:16,060 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:13:24,962 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:13:29,339 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:13:29,340 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:13:29,397 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:13:29,397 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:13:29,487 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:13:29,487 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:13:29,583 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:13:29,583 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:13:29,675 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:13:29,675 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:13:29,767 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:13:29,767 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:13:29,859 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:13:29,859 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:13:29,961 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:13:29,961 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:13:30,051 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:13:30,051 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:13:30,242 - tests.cloud_tests - DEBUG - running collect script: run_cmd
+2019-09-09 11:13:30,243 - tests.cloud_tests - DEBUG - executing "collect: run_cmd"
+2019-09-09 11:13:30,954 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 5252 to end
+2019-09-09 11:13:31,409 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-runcmd-lfm3t0v4qytwe9juatybozp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/runcmd/console.log
+2019-09-09 11:13:31,417 - tests.cloud_tests - WARNING - test config modules/seed_random_command is not enabled, skipping
+2019-09-09 11:13:31,456 - tests.cloud_tests - INFO - collecting test data for test: modules/seed_random_data
+2019-09-09 11:13:32,485 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:13:47,511 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:13:56,847 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:14:01,165 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:14:01,166 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:14:01,261 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:14:01,262 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:14:01,351 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:14:01,351 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:14:01,443 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:14:01,444 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:14:01,534 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:14:01,534 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:14:01,631 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:14:01,631 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:14:01,724 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:14:01,724 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:14:01,832 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:14:01,832 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:14:01,922 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:14:01,922 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:14:02,097 - tests.cloud_tests - DEBUG - running collect script: seed_data
+2019-09-09 11:14:02,097 - tests.cloud_tests - DEBUG - executing "collect: seed_data"
+2019-09-09 11:14:03,022 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14519 to end
+2019-09-09 11:14:03,577 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-seed-random-data-hlppf9exd33wu to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/seed_random_data/console.log
+2019-09-09 11:14:03,618 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname
+2019-09-09 11:14:04,645 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:14:19,673 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:14:28,962 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:14:33,725 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:14:33,726 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:14:33,781 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:14:33,781 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:14:33,880 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:14:33,880 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:14:33,971 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:14:33,971 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:14:34,063 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:14:34,063 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:14:34,159 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:14:34,159 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:14:34,251 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:14:34,251 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:14:34,367 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:14:34,367 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:14:34,458 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:14:34,458 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:14:34,659 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 11:14:34,659 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 11:14:34,762 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 11:14:34,762 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 11:14:34,859 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 11:14:34,860 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 11:14:35,155 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 24609 to end
+2019-09-09 11:14:35,721 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-hostname-t9b6x1uabs0orb3a2 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/set_hostname/console.log
+2019-09-09 11:14:35,769 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname_fqdn
+2019-09-09 11:14:36,796 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:14:51,825 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:15:01,109 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:15:06,391 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:15:06,392 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:15:06,448 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:15:06,448 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:15:06,538 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:15:06,538 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:15:06,631 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:15:06,631 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:15:06,726 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:15:06,726 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:15:06,818 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:15:06,818 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:15:06,910 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:15:06,911 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:15:07,013 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:15:07,013 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:15:07,106 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:15:07,106 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:15:07,277 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 11:15:07,277 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 11:15:07,368 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 11:15:07,368 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 11:15:07,459 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 11:15:07,460 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 11:15:07,745 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 2803 to end
+2019-09-09 11:15:08,169 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-hostname-fqdn-au3mi9hqnc09 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/set_hostname_fqdn/console.log
+2019-09-09 11:15:08,232 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password
+2019-09-09 11:15:09,264 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:15:24,292 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:15:34,111 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:15:38,171 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:15:38,171 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:15:38,267 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:15:38,268 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:15:38,358 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:15:38,358 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:15:38,450 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:15:38,450 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:15:38,542 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:15:38,542 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:15:38,634 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:15:38,634 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:15:38,726 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:15:38,726 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:15:38,828 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:15:38,829 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:15:38,918 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:15:38,919 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:15:39,094 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:15:39,094 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:15:39,252 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:15:39,252 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:15:39,396 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 12758 to end
+2019-09-09 11:15:39,917 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-p3uasav3cc622z6vj to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/set_password/console.log
+2019-09-09 11:15:39,956 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_expire
+2019-09-09 11:15:40,981 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:15:56,006 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:16:05,076 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:16:14,806 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:16:14,806 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:16:14,865 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:16:14,866 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:16:14,956 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:16:14,956 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:16:15,047 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:16:15,047 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:16:15,139 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:16:15,139 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:16:15,231 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:16:15,231 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:16:15,323 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:16:15,323 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:16:15,425 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:16:15,425 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:16:15,515 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:16:15,515 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:16:15,687 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:16:15,687 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:16:15,780 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:16:15,780 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:16:16,027 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 20938 to end
+2019-09-09 11:16:16,533 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-expire-wtizfo7i6w to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/set_password_expire/console.log
+2019-09-09 11:16:16,580 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list
+2019-09-09 11:16:17,612 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:16:32,636 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:16:50,662 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:16:54,782 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:16:54,782 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:16:54,838 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:16:54,838 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:16:54,931 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:16:54,931 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:16:55,023 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:16:55,023 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:16:55,117 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:16:55,118 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:16:55,212 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:16:55,212 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:16:55,304 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:16:55,304 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:16:55,411 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:16:55,411 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:16:55,502 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:16:55,503 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:16:55,717 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:16:55,717 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:16:55,847 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:16:55,847 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:16:56,030 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25802 to end
+2019-09-09 11:16:57,993 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-list-f9n7wlfbfzvn to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/set_password_list/console.log
+2019-09-09 11:16:58,034 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list_string
+2019-09-09 11:16:59,063 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:17:14,088 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:17:23,065 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:17:27,637 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:17:27,638 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:17:27,693 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:17:27,693 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:17:27,782 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:17:27,782 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:17:27,874 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:17:27,874 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:17:27,966 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:17:27,966 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:17:28,058 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:17:28,058 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:17:28,150 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:17:28,150 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:17:28,252 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:17:28,252 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:17:28,342 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:17:28,342 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:17:28,618 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:17:28,618 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:17:28,671 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:17:28,671 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:17:28,868 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 26379 to end
+2019-09-09 11:17:29,313 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-list-stri-88azez4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/set_password_list_string/console.log
+2019-09-09 11:17:29,319 - tests.cloud_tests - WARNING - test config modules/snap is not enabled, skipping
+2019-09-09 11:17:29,323 - tests.cloud_tests - WARNING - test config modules/snappy is not enabled, skipping
+2019-09-09 11:17:29,356 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_disable
+2019-09-09 11:17:30,386 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:17:45,411 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:17:55,354 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:17:59,352 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:17:59,352 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:17:59,451 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:17:59,452 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:17:59,544 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:17:59,544 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:17:59,634 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:17:59,634 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:17:59,726 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:17:59,726 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:17:59,823 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:17:59,823 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:17:59,915 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:17:59,915 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:18:00,017 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:18:00,017 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:18:00,110 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:18:00,110 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:18:00,287 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 11:18:00,287 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 11:18:00,540 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 31935 to end
+2019-09-09 11:18:00,977 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-f51mdxs to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ssh_auth_key_fingerprints_disable/console.log
+2019-09-09 11:18:01,016 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_enable
+2019-09-09 11:18:02,045 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:18:17,068 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:18:26,221 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:18:30,419 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:18:30,419 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:18:30,472 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:18:30,473 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:18:30,563 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:18:30,563 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:18:30,654 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:18:30,655 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:18:30,747 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:18:30,747 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:18:30,839 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:18:30,840 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:18:30,936 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:18:30,936 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:18:31,038 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:18:31,038 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:18:31,130 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:18:31,130 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:18:31,301 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 11:18:31,301 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 11:18:31,524 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 5327 to end
+2019-09-09 11:18:32,045 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-leyn4w4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ssh_auth_key_fingerprints_enable/console.log
+2019-09-09 11:18:32,081 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_import_id
+2019-09-09 11:18:33,106 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:18:48,131 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:18:57,270 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:19:00,378 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:19:03,381 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:19:06,384 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:19:07,685 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:19:07,686 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:19:07,785 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:19:07,785 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:19:07,875 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:19:07,875 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:19:07,966 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:19:07,967 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:19:08,059 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:19:08,059 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:19:08,150 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:19:08,151 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:19:08,243 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:19:08,243 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:19:08,345 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:19:08,345 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:19:08,436 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:19:08,436 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:19:08,631 - tests.cloud_tests - DEBUG - running collect script: auth_keys_ubuntu
+2019-09-09 11:19:08,631 - tests.cloud_tests - DEBUG - executing "collect: auth_keys_ubuntu"
+2019-09-09 11:19:09,015 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 11152 to end
+2019-09-09 11:19:09,469 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-import-id-gvh4pt1b9uybzgrq to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ssh_import_id/console.log
+2019-09-09 11:19:09,509 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_keys_generate
+2019-09-09 11:19:10,538 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:19:25,563 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:19:43,588 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:19:47,878 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:19:47,878 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:19:47,974 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:19:47,974 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:19:48,320 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:19:48,320 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:19:48,381 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:19:48,381 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:19:48,659 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:19:48,659 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:19:48,761 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:19:48,761 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:19:49,515 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:19:49,516 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:19:49,895 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:19:49,895 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:19:49,953 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:19:49,953 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:19:50,490 - tests.cloud_tests - DEBUG - running collect script: dsa_public
+2019-09-09 11:19:50,490 - tests.cloud_tests - DEBUG - executing "collect: dsa_public"
+2019-09-09 11:19:50,547 - tests.cloud_tests - DEBUG - collect script dsa_public exited 'b'cat: /etc/ssh/ssh_host_dsa_key.pub: No such file or directory\n'' and had stderr: 1
+2019-09-09 11:19:50,549 - tests.cloud_tests - DEBUG - running collect script: dsa_private
+2019-09-09 11:19:50,549 - tests.cloud_tests - DEBUG - executing "collect: dsa_private"
+2019-09-09 11:19:50,688 - tests.cloud_tests - DEBUG - collect script dsa_private exited 'b'cat: /etc/ssh/ssh_host_dsa_key: No such file or directory\n'' and had stderr: 1
+2019-09-09 11:19:50,690 - tests.cloud_tests - DEBUG - running collect script: rsa_public
+2019-09-09 11:19:50,690 - tests.cloud_tests - DEBUG - executing "collect: rsa_public"
+2019-09-09 11:19:50,917 - tests.cloud_tests - DEBUG - collect script rsa_public exited 'b'cat: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory\n'' and had stderr: 1
+2019-09-09 11:19:50,918 - tests.cloud_tests - DEBUG - running collect script: rsa_private
+2019-09-09 11:19:50,918 - tests.cloud_tests - DEBUG - executing "collect: rsa_private"
+2019-09-09 11:19:51,229 - tests.cloud_tests - DEBUG - collect script rsa_private exited 'b'cat: /etc/ssh/ssh_host_rsa_key: No such file or directory\n'' and had stderr: 1
+2019-09-09 11:19:51,230 - tests.cloud_tests - DEBUG - running collect script: ecdsa_public
+2019-09-09 11:19:51,230 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_public"
+2019-09-09 11:19:51,407 - tests.cloud_tests - DEBUG - running collect script: ecdsa_private
+2019-09-09 11:19:51,407 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_private"
+2019-09-09 11:19:51,650 - tests.cloud_tests - DEBUG - running collect script: ed25519_public
+2019-09-09 11:19:51,650 - tests.cloud_tests - DEBUG - executing "collect: ed25519_public"
+2019-09-09 11:19:52,084 - tests.cloud_tests - DEBUG - running collect script: ed25519_private
+2019-09-09 11:19:52,084 - tests.cloud_tests - DEBUG - executing "collect: ed25519_private"
+2019-09-09 11:19:53,224 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16938 to end
+2019-09-09 11:19:53,877 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-keys-generate-d79xmiinp0a3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/ssh_keys_generate/console.log
+2019-09-09 11:19:53,889 - tests.cloud_tests - WARNING - test config modules/ssh_keys_provided is not enabled, skipping
+2019-09-09 11:19:53,926 - tests.cloud_tests - INFO - collecting test data for test: modules/timezone
+2019-09-09 11:19:54,955 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:20:09,979 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:20:19,625 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:20:22,630 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:20:25,633 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:20:28,636 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:20:30,538 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:20:30,538 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:20:30,597 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:20:30,597 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:20:30,691 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:20:30,691 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:20:30,976 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:20:30,976 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:20:31,149 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:20:31,149 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:20:31,281 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:20:31,281 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:20:31,789 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:20:31,790 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:20:32,221 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:20:32,221 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:20:32,303 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:20:32,303 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:20:33,029 - tests.cloud_tests - DEBUG - running collect script: timezone
+2019-09-09 11:20:33,029 - tests.cloud_tests - DEBUG - executing "collect: timezone"
+2019-09-09 11:20:33,558 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 24206 to end
+2019-09-09 11:20:34,533 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-timezone-2tcq0riino308l4dmlrvy to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/timezone/console.log
+2019-09-09 11:20:34,577 - tests.cloud_tests - INFO - collecting test data for test: modules/user_groups
+2019-09-09 11:20:35,611 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:20:50,638 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:08,671 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:11,674 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:14,677 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:21:17,681 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:21:17,851 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:23,468 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:21:23,468 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:21:23,526 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:21:23,526 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:21:23,620 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:21:23,620 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:21:23,711 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:21:23,711 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:21:23,808 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:21:23,809 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:21:23,904 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:21:23,904 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:21:24,000 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:21:24,001 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:21:24,101 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:21:24,101 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:21:24,191 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:21:24,191 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:21:24,369 - tests.cloud_tests - DEBUG - running collect script: group_ubuntu
+2019-09-09 11:21:24,369 - tests.cloud_tests - DEBUG - executing "collect: group_ubuntu"
+2019-09-09 11:21:24,461 - tests.cloud_tests - DEBUG - running collect script: group_cloud_users
+2019-09-09 11:21:24,461 - tests.cloud_tests - DEBUG - executing "collect: group_cloud_users"
+2019-09-09 11:21:24,649 - tests.cloud_tests - DEBUG - running collect script: user_ubuntu
+2019-09-09 11:21:24,649 - tests.cloud_tests - DEBUG - executing "collect: user_ubuntu"
+2019-09-09 11:21:24,740 - tests.cloud_tests - DEBUG - running collect script: user_foobar
+2019-09-09 11:21:24,740 - tests.cloud_tests - DEBUG - executing "collect: user_foobar"
+2019-09-09 11:21:24,836 - tests.cloud_tests - DEBUG - running collect script: user_barfoo
+2019-09-09 11:21:24,837 - tests.cloud_tests - DEBUG - executing "collect: user_barfoo"
+2019-09-09 11:21:24,928 - tests.cloud_tests - DEBUG - running collect script: user_cloudy
+2019-09-09 11:21:24,928 - tests.cloud_tests - DEBUG - executing "collect: user_cloudy"
+2019-09-09 11:21:25,024 - tests.cloud_tests - DEBUG - running collect script: root_groups
+2019-09-09 11:21:25,024 - tests.cloud_tests - DEBUG - executing "collect: root_groups"
+2019-09-09 11:21:25,262 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 32124 to end
+2019-09-09 11:21:26,001 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-user-groups-7russfur305qp03f1e to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/user_groups/console.log
+2019-09-09 11:21:26,043 - tests.cloud_tests - INFO - collecting test data for test: modules/write_files
+2019-09-09 11:21:27,071 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:21:42,099 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:51,272 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:54,344 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 11:21:57,347 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 11:22:00,349 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:22:06,826 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:22:06,827 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:22:06,882 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:22:06,882 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:22:06,975 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:22:06,975 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:22:07,067 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:22:07,067 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:22:07,399 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:22:07,400 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:22:07,589 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:22:07,589 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:22:07,890 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:22:07,890 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:22:08,303 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:22:08,303 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:22:08,475 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:22:08,475 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:22:08,959 - tests.cloud_tests - DEBUG - running collect script: file_b64
+2019-09-09 11:22:08,960 - tests.cloud_tests - DEBUG - executing "collect: file_b64"
+2019-09-09 11:22:09,951 - tests.cloud_tests - DEBUG - running collect script: file_text
+2019-09-09 11:22:09,951 - tests.cloud_tests - DEBUG - executing "collect: file_text"
+2019-09-09 11:22:10,195 - tests.cloud_tests - DEBUG - running collect script: file_binary
+2019-09-09 11:22:10,195 - tests.cloud_tests - DEBUG - executing "collect: file_binary"
+2019-09-09 11:22:10,356 - tests.cloud_tests - DEBUG - running collect script: file_gzip
+2019-09-09 11:22:10,356 - tests.cloud_tests - DEBUG - executing "collect: file_gzip"
+2019-09-09 11:22:11,032 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 9140 to end
+2019-09-09 11:22:11,581 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-write-files-9z7l1iwpti1y7361ms to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results/nocloud-kvm/bionic/modules/write_files/console.log
+2019-09-09 11:22:11,616 - tests.cloud_tests - DEBUG - collect stages: {'name': 'collect data', 'time': 1783.2710282802582, 'errors': [], 'stages': [{'name': 'collect for platform: nocloud-kvm', 'time': 1782.4172599315643, 'errors': [], 'stages': [{'name': 'set up and collect data for os: bionic', 'time': 1775.8186032772064, 'errors': [], 'stages': [{'name': 'set up for ubuntu-bionic', 'time': 14.461673498153687, 'errors': [], 'stages': [{'name': 'setup func for --repo, enable repo', 'time': 8.022692918777466, 'errors': [], 'success': True}, {'name': 'setup func for --upgrade, upgrade cloud-init', 'time': 6.438952922821045, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect test data for bionic', 'time': 1760.2845861911774, 'errors': [], 'stages': [{}, {}, {'name': 'collect for test: bugs/lp1628337', 'time': 31.755742073059082, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.858306884765625, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06047248840332031, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09587430953979492, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09173274040222168, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09610438346862793, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09249138832092285, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09302926063537598, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10465598106384277, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08976960182189941, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1731724739074707, 'errors': [], 'success': True}], 'success': True}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {'name': 'collect for test: main/command_output_simple', 'time': 30.746349811553955, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.720155715942383, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09485530853271484, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08978748321533203, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09201264381408691, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09203267097473145, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09183740615844727, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09228706359863281, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10209894180297852, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08980154991149902, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1729736328125, 'errors': [], 'success': True}, {'name': 'script cloud-init-test-output', 'time': 0.10834574699401855, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_conf', 'time': 31.964298486709595, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.97819495201111, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.055562496185302734, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08974194526672363, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09203362464904785, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09188628196716309, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09222817420959473, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09188294410705566, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.11095762252807617, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09298014640808105, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1744709014892578, 'errors': [], 'success': True}, {'name': 'script 94cloud-init-config', 'time': 0.09419012069702148, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_disable_suites', 'time': 36.741666078567505, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.7306432723999, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09734725952148438, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09323406219482422, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09131479263305664, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09594154357910156, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09199714660644531, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09424519538879395, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.09875154495239258, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09096002578735352, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.16468572616577148, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09240317344665527, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_primary', 'time': 56.5992157459259, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 54.599886417388916, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05751323699951172, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09306597709655762, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.19620203971862793, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.3848607540130615, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13737201690673828, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.18216419219970703, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.3594024181365967, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14726948738098145, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2944164276123047, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.1468801498413086, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_proxy', 'time': 40.91603350639343, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 39.847407579422, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09757447242736816, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0958707332611084, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09524226188659668, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09130740165710449, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09032201766967773, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09217596054077148, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.11263370513916016, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09131479263305664, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1764662265777588, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-aptproxy', 'time': 0.12552571296691895, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_security', 'time': 30.600585460662842, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.54336190223694, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09727621078491211, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09024620056152344, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09165239334106445, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09208250045776367, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09244632720947266, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09683346748352051, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10176372528076172, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08952450752258301, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1771082878112793, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.12810969352722168, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_key', 'time': 68.05094146728516, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 66.822509765625, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.10686588287353516, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09133696556091309, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09147500991821289, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0939176082611084, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09091591835021973, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09144115447998047, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10608410835266113, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09408020973205566, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1768350601196289, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09583044052124023, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.18946099281311035, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_keyserver', 'time': 50.20813250541687, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 49.03375554084778, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05459737777709961, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08990144729614258, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0923759937286377, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09974861145019531, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0917656421661377, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09634709358215332, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10087132453918457, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09065747261047363, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.16927695274353027, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09206867218017578, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.1965956687927246, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_list', 'time': 30.2898006439209, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.2758686542511, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05552220344543457, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09483861923217773, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09932827949523926, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09595394134521484, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09162330627441406, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09228134155273438, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10253763198852539, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08877754211425781, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17236804962158203, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.12053108215332031, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_ppa', 'time': 42.80647134780884, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 41.57015347480774, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0581512451171875, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09312987327575684, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0913848876953125, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0919797420501709, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09239816665649414, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09167909622192383, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10957694053649902, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09161877632141113, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17121195793151855, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09228014945983887, 'errors': [], 'success': True}, {'name': 'script apt-key', 'time': 0.19702863693237305, 'errors': [], 'success': True}, {'name': 'script sources_full', 'time': 0.05570530891418457, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_disable', 'time': 31.055795192718506, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.009442806243896, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09666562080383301, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09608054161071777, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09154844284057617, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09209394454956055, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09063100814819336, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0920858383178711, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10258865356445312, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09081912040710449, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17365646362304688, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining', 'time': 0.12003302574157715, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_os', 'time': 30.745959520339966, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.760546445846558, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05759072303771973, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08868169784545898, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09284162521362305, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09101653099060059, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09624505043029785, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09588837623596191, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10864758491516113, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09151673316955566, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.16867637634277344, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining_not_written', 'time': 0.09416007995605469, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/bootcmd', 'time': 31.496381044387817, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.526055335998535, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05782151222229004, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09626603126525879, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09134435653686523, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0921781063079834, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0920560359954834, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09199714660644531, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10010242462158203, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09244489669799805, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.16478300094604492, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.09119415283203125, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/byobu', 'time': 34.47880673408508, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 33.42148494720459, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05605053901672363, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08907699584960938, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09164142608642578, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09229779243469238, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09153318405151367, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09216070175170898, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10143733024597168, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09024858474731445, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1685185432434082, 'errors': [], 'success': True}, {'name': 'script byobu_profile_enabled', 'time': 0.09313726425170898, 'errors': [], 'success': True}, {'name': 'script byobu_launch_exists', 'time': 0.09102869033813477, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ca_certs', 'time': 37.598456382751465, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.39297080039978, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.058168649673461914, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0902094841003418, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09181833267211914, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0939645767211914, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09019827842712402, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0936892032623291, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.11176514625549316, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09523892402648926, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.5568101406097412, 'errors': [], 'success': True}, {'name': 'script cert_links', 'time': 0.7206714153289795, 'errors': [], 'success': True}, {'name': 'script cert', 'time': 0.20278239250183105, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_disable', 'time': 30.298433780670166, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.35436487197876, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09376955032348633, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08916592597961426, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09169220924377441, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09712696075439453, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0921781063079834, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09576940536499023, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10562515258789062, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08951282501220703, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18909144401550293, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_enable', 'time': 30.343743085861206, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.394851684570312, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09710979461669922, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08943581581115723, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09163641929626465, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0917351245880127, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09200716018676758, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09201622009277344, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.11006832122802734, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09176397323608398, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.19292259216308594, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/final_message', 'time': 30.232014894485474, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.291218042373657, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09402751922607422, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0923759937286377, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09212303161621094, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09210610389709473, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09193277359008789, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0922393798828125, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10274600982666016, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09288692474365234, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1902313232421875, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/keys_to_console', 'time': 30.76860237121582, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.699464559555054, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09754252433776855, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08873248100280762, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09191274642944336, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09193539619445801, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0921471118927002, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0919950008392334, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1024324893951416, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09826016426086426, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2530198097229004, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.06099438667297363, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/locale', 'time': 30.945627212524414, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.67324924468994, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05419468879699707, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08994245529174805, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09178590774536133, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09186911582946777, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0918722152709961, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09340119361877441, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10219025611877441, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08845162391662598, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1864306926727295, 'errors': [], 'success': True}, {'name': 'script locale_default', 'time': 0.12511849403381348, 'errors': [], 'success': True}, {'name': 'script locale_a', 'time': 0.16254615783691406, 'errors': [], 'success': True}, {'name': 'script locale_gen', 'time': 0.09440732002258301, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_bridge', 'time': 41.731332778930664, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 40.564239501953125, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05440020561218262, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08957862854003906, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09229731559753418, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09232139587402344, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09201407432556152, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09125208854675293, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1131899356842041, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09081816673278809, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17032885551452637, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.0950632095336914, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.09108591079711914, 'errors': [], 'success': True}, {'name': 'script lxc-bridge', 'time': 0.09456276893615723, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_dir', 'time': 47.34449291229248, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 46.2513267993927, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05715203285217285, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09250593185424805, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09103941917419434, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09584951400756836, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09238409996032715, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09285855293273926, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10484433174133301, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09531903266906738, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17795133590698242, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.10166692733764648, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.0914146900177002, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp', 'time': 61.54664349555969, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 60.36667084693909, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05646514892578125, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09308028221130371, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09142565727233887, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09619808197021484, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0919492244720459, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09250450134277344, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10108184814453125, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09013724327087402, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17720651626586914, 'errors': [], 'success': True}, {'name': 'script ntp_installed', 'time': 0.09782719612121582, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_empty', 'time': 0.09459066390991211, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pool_list', 'time': 0.09730029106140137, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_chrony', 'time': 65.48032426834106, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 64.47739601135254, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06190299987792969, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09236001968383789, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09568095207214355, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09199047088623047, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09560632705688477, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09636831283569336, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1024787425994873, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09723663330078125, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17702412605285645, 'errors': [], 'success': True}, {'name': 'script chrony_conf', 'time': 0.09211206436157227, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_pools', 'time': 40.88692331314087, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 39.623716831207275, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0553126335144043, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08991694450378418, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09624910354614258, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0915689468383789, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09209299087524414, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09180545806884766, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10219621658325195, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0901632308959961, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17728114128112793, 'errors': [], 'success': True}, {'name': 'script ntp_installed_pools', 'time': 0.09641051292419434, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_pools', 'time': 0.09162259101867676, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pools', 'time': 0.09133267402648926, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.09707903861999512, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_servers', 'time': 78.93537473678589, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 77.64560770988464, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.056149959564208984, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09271836280822754, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09230756759643555, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09149694442749023, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09181809425354004, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0957949161529541, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10267329216003418, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1011345386505127, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.19487214088439941, 'errors': [], 'success': True}, {'name': 'script ntp_installed_servers', 'time': 0.09072375297546387, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_servers', 'time': 0.09143924713134766, 'errors': [], 'success': True}, {'name': 'script ntp_conf_servers', 'time': 0.0918433666229248, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.09659671783447266, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_timesyncd', 'time': 37.21096086502075, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 36.1976203918457, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05698370933532715, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09187984466552734, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09256482124328613, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09165763854980469, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09591102600097656, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09498858451843262, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10349917411804199, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09345865249633789, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.20040512084960938, 'errors': [], 'success': True}, {'name': 'script timesyncd_conf', 'time': 0.09180045127868652, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/package_update_upgrade_install', 'time': 39.88929605484009, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 38.78743577003479, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05493521690368652, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09098482131958008, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0904536247253418, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09307456016540527, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09589958190917969, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09554505348205566, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10889482498168945, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0909574031829834, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17744088172912598, 'errors': [], 'success': True}, {'name': 'script apt_history_cmdline', 'time': 0.09637761116027832, 'errors': [], 'success': True}, {'name': 'script dpkg_show', 'time': 0.10711407661437988, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/runcmd', 'time': 30.550191164016724, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.32350182533264, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.057600975036621094, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08999991416931152, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09614753723144531, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09185504913330078, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09171223640441895, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09180974960327148, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10208582878112793, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08987092971801758, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.19164013862609863, 'errors': [], 'success': True}, {'name': 'script run_cmd', 'time': 0.3236815929412842, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/seed_random_data', 'time': 30.942933797836304, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.700678825378418, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09590864181518555, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08917903900146484, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0928187370300293, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0908975601196289, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09693717956542969, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09233760833740234, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10815262794494629, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09052634239196777, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17450380325317383, 'errors': [], 'success': True}, {'name': 'script seed_data', 'time': 0.3108539581298828, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname', 'time': 31.4474356174469, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.099137783050537, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.055547475814819336, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09876394271850586, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09110331535339355, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0921943187713623, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09554767608642578, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09260129928588867, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.11575937271118164, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09135174751281738, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.20046210289001465, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.10286688804626465, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.09765267372131348, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.21424531936645508, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname_fqdn', 'time': 31.775362968444824, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.614284992218018, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05675911903381348, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0898280143737793, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09274578094482422, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09548068046569824, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09200191497802734, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09214496612548828, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10251736640930176, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09301590919494629, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17065978050231934, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.09102058410644531, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.09180545806884766, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.09291648864746094, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password', 'time': 31.06795310974121, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.929182052612305, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09688925743103027, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09071159362792969, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09198212623596191, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09187912940979004, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09200763702392578, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09211254119873047, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10214042663574219, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09010958671569824, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1753551959991455, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.1580660343170166, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.05735325813293457, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_expire', 'time': 35.90975332260132, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 34.842018365859985, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.059586286544799805, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09054064750671387, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09057354927062988, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09245538711547852, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09180641174316406, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09179496765136719, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10187363624572754, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09002494812011719, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1726207733154297, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.09254074096679688, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.09372401237487793, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list', 'time': 39.31808829307556, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 38.192867279052734, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05552029609680176, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09341931343078613, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09194254875183105, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09437918663024902, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09471321105957031, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09213852882385254, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10648369789123535, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09172511100769043, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.21425414085388184, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.12998175621032715, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.06043434143066406, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list_string', 'time': 30.71973490715027, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.594385862350464, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.055069923400878906, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08920097351074219, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09214544296264648, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0922999382019043, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09187674522399902, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09171533584594727, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10187864303588867, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.090179443359375, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2760508060455322, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.05285143852233887, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.09191298484802246, 'errors': [], 'success': True}], 'success': True}, {}, {}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_disable', 'time': 31.094754934310913, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.986594438552856, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09974217414855957, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09248661994934082, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09015989303588867, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09203720092773438, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09651017189025879, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09183073043823242, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10190844535827637, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09377098083496094, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17698431015014648, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.1725606918334961, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_enable', 'time': 30.373987197875977, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.39451551437378, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05380105972290039, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09042048454284668, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09149670600891113, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0927886962890625, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09216070175170898, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09650373458862305, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10207915306091309, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09222626686096191, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17099404335021973, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.09684109687805176, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_import_id', 'time': 36.791298389434814, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.59728145599365, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09921789169311523, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09019041061401367, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09155559539794922, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09209322929382324, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09191298484802246, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09251976013183594, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10186409950256348, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09082698822021484, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1955101490020752, 'errors': [], 'success': True}, {'name': 'script auth_keys_ubuntu', 'time': 0.24814558029174805, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_keys_generate', 'time': 42.62860178947449, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 38.360175371170044, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09614992141723633, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.34572768211364746, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0612490177154541, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2779574394226074, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.10235095024108887, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.7541749477386475, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.37911081314086914, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05832481384277344, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.5372138023376465, 'errors': [], 'success': True}, {'name': 'script dsa_public', 'time': 0.05849099159240723, 'errors': [], 'success': True}, {'name': 'script dsa_private', 'time': 0.1413271427154541, 'errors': [], 'success': True}, {'name': 'script rsa_public', 'time': 0.22823500633239746, 'errors': [], 'success': True}, {'name': 'script rsa_private', 'time': 0.31195521354675293, 'errors': [], 'success': True}, {'name': 'script ecdsa_public', 'time': 0.17644381523132324, 'errors': [], 'success': True}, {'name': 'script ecdsa_private', 'time': 0.2430558204650879, 'errors': [], 'success': True}, {'name': 'script ed25519_public', 'time': 0.4342312812805176, 'errors': [], 'success': True}, {'name': 'script ed25519_private', 'time': 0.06208348274230957, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/timezone', 'time': 39.42890000343323, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 36.603214502334595, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05920863151550293, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0942070484161377, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.28508639335632324, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1722726821899414, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13238954544067383, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.5083937644958496, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.43154096603393555, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0820462703704834, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.7258555889129639, 'errors': [], 'success': True}, {'name': 'script timezone', 'time': 0.3344991207122803, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/user_groups', 'time': 50.53506875038147, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 48.88193726539612, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05765891075134277, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09387731552124023, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09148740768432617, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09728217124938965, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09587717056274414, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09617495536804199, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10065174102783203, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08997678756713867, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17795634269714355, 'errors': [], 'success': True}, {'name': 'script group_ubuntu', 'time': 0.09210777282714844, 'errors': [], 'success': True}, {'name': 'script group_cloud_users', 'time': 0.18793773651123047, 'errors': [], 'success': True}, {'name': 'script user_ubuntu', 'time': 0.09101557731628418, 'errors': [], 'success': True}, {'name': 'script user_foobar', 'time': 0.09613871574401855, 'errors': [], 'success': True}, {'name': 'script user_barfoo', 'time': 0.09179496765136719, 'errors': [], 'success': True}, {'name': 'script user_cloudy', 'time': 0.09611272811889648, 'errors': [], 'success': True}, {'name': 'script root_groups', 'time': 0.09678244590759277, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/write_files', 'time': 44.489328145980835, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 40.77470302581787, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05535316467285156, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09294605255126953, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09216475486755371, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.33257579803466797, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1893460750579834, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.30081987380981445, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.41341257095336914, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17233562469482422, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.484088659286499, 'errors': [], 'success': True}, {'name': 'script file_b64', 'time': 0.9915256500244141, 'errors': [], 'success': True}, {'name': 'script file_text', 'time': 0.2436225414276123, 'errors': [], 'success': True}, {'name': 'script file_binary', 'time': 0.16150665283203125, 'errors': [], 'success': True}, {'name': 'script file_gzip', 'time': 0.18472862243652344, 'errors': [], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}
+2019-09-09 11:22:11,622 - tests.cloud_tests - DEBUG - found test data: {'nocloud-kvm': {'bionic': ['bugs/lp1628337', 'modules/apt_configure_sources_list', 'modules/locale', 'modules/apt_configure_primary', 'modules/lxd_bridge', 'modules/apt_configure_security', 'modules/apt_pipelining_os', 'modules/ssh_import_id', 'modules/ntp_pools', 'modules/ssh_keys_generate', 'modules/ssh_auth_key_fingerprints_enable', 'modules/apt_configure_sources_keyserver', 'modules/bootcmd', 'modules/set_hostname_fqdn', 'modules/ssh_auth_key_fingerprints_disable', 'modules/final_message', 'modules/apt_configure_sources_key', 'modules/ntp_servers', 'modules/ntp_chrony', 'modules/write_files', 'modules/set_password', 'modules/ntp', 'modules/timezone', 'modules/keys_to_console', 'modules/debug_enable', 'modules/seed_random_data', 'modules/set_password_list', 'modules/user_groups', 'modules/debug_disable', 'modules/byobu', 'modules/apt_configure_proxy', 'modules/apt_configure_sources_ppa', 'modules/package_update_upgrade_install', 'modules/ntp_timesyncd', 'modules/lxd_dir', 'modules/apt_pipelining_disable', 'modules/runcmd', 'modules/set_hostname', 'modules/apt_configure_conf', 'modules/apt_configure_disable_suites', 'modules/set_password_list_string', 'modules/set_password_expire', 'modules/ca_certs', 'main/command_output_simple']}}
+
+2019-09-09 11:22:11,622 - tests.cloud_tests - INFO - test: platform='nocloud-kvm', os='bionic' verifying test data
+2019-09-09 11:22:11,622 - tests.cloud_tests - DEBUG - verifying test data for bugs/lp1628337
+test_fetch_indices (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify no apt errors. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify can find ntp and install it. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:11,691 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Unexpected warnings should not be found in the log. ... ok
+test_sources_list (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Test sources.list includes sources. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:11,755 - tests.cloud_tests - DEBUG - verifying test data for modules/locale
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_locale (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale is set properly. ... ok
+test_locale_a (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale -a has both options. ... ok
+test_locale_gen (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test local.gen file has all entries. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:11,808 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_primary
+test_gatech_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test GaTech entries exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Unexpected warnings should not be found in the log. ... ok
+test_ubuntu_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test no default Ubuntu entries exist. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:11,853 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_bridge
+test_bridge (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test bridge config. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_lxc (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:11,895 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_security
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Unexpected warnings should not be found in the log. ... ok
+test_security_mirror (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Test security lines added and uncommented in source.list. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:11,935 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_os
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Unexpected warnings should not be found in the log. ... ok
+test_os_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+test 'os' settings does not write apt config file. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:11,978 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_import_id
+test_authorized_keys (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Test that ssh keys were imported. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,020 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_pools
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test dist config file is empty ... ok
+test_ntp_entires (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 11:22:12,064 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_keys_generate
+test_dsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa private key not generated. ... ok
+test_dsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa public key not generated. ... ok
+test_ecdsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ecdsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ed25519_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_ed25519_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Unexpected warnings should not be found in the log. ... ok
+test_rsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+test_rsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+
+----------------------------------------------------------------------
+Ran 13 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,104 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_enable
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Unexpected warnings should not be found in the log. ... ok
+test_syslog (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Verify output of syslog. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:12,146 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_keyserver
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test specific key added. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,190 - tests.cloud_tests - DEBUG - verifying test data for modules/bootcmd
+test_bootcmd_host (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Test boot cmd worked. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,231 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname_fqdn
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname output. ... ok
+test_hostname_fqdn (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname fqdn output. ... ok
+test_hosts (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test /etc/hosts file. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,273 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_disable
+test_cloud_init_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Verify disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,313 - tests.cloud_tests - DEBUG - verifying test data for modules/final_message
+test_final_message_string (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure final handles regular strings. ... ok
+test_final_message_subs (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Test variable substitution in final message. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:12,355 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_key
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test key list updated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,398 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_servers
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test config server entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:12,441 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_chrony
+test_chrony_entries (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Test chrony config entries ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,480 - tests.cloud_tests - DEBUG - verifying test data for modules/write_files
+test_b64 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test b64 encoded file reads as ascii. ... ok
+test_binary (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test binary file reads as executable. ... ok
+test_gzip (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test gzip file shows up as a shell script. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Unexpected warnings should not be found in the log. ... ok
+test_text (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test text shows up as ASCII text. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,520 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test ubuntu user in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,562 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test ntp installed ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,605 - tests.cloud_tests - DEBUG - verifying test data for modules/timezone
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Unexpected warnings should not be found in the log. ... ok
+test_timezone (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Test date prints correct timezone. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,649 - tests.cloud_tests - DEBUG - verifying test data for modules/keys_to_console
+test_excluded_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test excluded keys missing. ... ok
+test_expected_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test expected keys exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,695 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_enable
+test_debug_enable (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Test debug messages in cloud-init log. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,736 - tests.cloud_tests - DEBUG - verifying test data for modules/seed_random_data
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Unexpected warnings should not be found in the log. ... ok
+test_random_seed_data (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Test random data passed in exists. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,781 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 11:22:12,827 - tests.cloud_tests - DEBUG - verifying test data for modules/user_groups
+test_group_cloud_users (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloud users group exists. ... ok
+test_group_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu group exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Unexpected warnings should not be found in the log. ... ok
+test_user_barfoo (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test barfoo user exists. ... ok
+test_user_cloudy (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloudy user exists. ... ok
+test_user_foobar (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test foobar user exists. ... ok
+test_user_root_in_secret (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test root user is in 'secret' group. ... ok
+test_user_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu user exists. ... ok
+
+----------------------------------------------------------------------
+Ran 12 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:12,869 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_disable
+test_debug_disable (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Test verbose output missing from logs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,909 - tests.cloud_tests - DEBUG - verifying test data for modules/byobu
+test_byobu_installed (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu installed. ... ok
+test_byobu_launch_exists (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu-launch exists. ... ok
+test_byobu_profile_enabled (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu profile.d file exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:12,950 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_proxy
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Unexpected warnings should not be found in the log. ... ok
+test_proxy_config (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Test proxy options added to apt config. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,014 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_ppa
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Unexpected warnings should not be found in the log. ... ok
+test_ppa (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test specific ppa added. ... ok
+test_ppa_key (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test ppa key added. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,055 - tests.cloud_tests - DEBUG - verifying test data for modules/package_update_upgrade_install
+test_apt_history (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test apt history for update command. ... ok
+test_cloud_init_output (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test cloud-init-output for install & upgrade stuff. ... ok
+test_installed_sl (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test sl got installed. ... ok
+test_installed_tree (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test tree got installed. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:13,097 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_timesyncd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Unexpected warnings should not be found in the log. ... ok
+test_timesyncd_entries (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Test timesyncd config entries ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,138 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_dir
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_lxc (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,177 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_disable
+test_disable_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Test pipelining disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,218 - tests.cloud_tests - DEBUG - verifying test data for modules/runcmd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Unexpected warnings should not be found in the log. ... ok
+test_run_cmd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Test run command worked. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,259 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Test hostname command shows correct output. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,300 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_conf
+test_apt_conf_assumeyes (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config assumes true. ... ok
+test_apt_conf_fixbroken (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config fixes broken. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,339 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_disable_suites
+test_empty_sourcelist (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Test source list is empty. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,379 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list_string
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 11:22:13,423 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_expire
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test user frozen in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,466 - tests.cloud_tests - DEBUG - verifying test data for modules/ca_certs
+test_cert_installed (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test line from our cert exists. ... ok
+test_certs_updated (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test certs have been updated in /etc/ssl/certs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:22:13,507 - tests.cloud_tests - DEBUG - verifying test data for main/command_output_simple
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Unexpected warnings should not be found in the log. ... ok
+test_output_file (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that the output file is not empty and has all stages. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:22:13,552 - tests.cloud_tests - INFO - test: platform='nocloud-kvm', os='bionic' passed all tests
+2019-09-09 11:22:13,552 - tests.cloud_tests - DEBUG - 
+---- Verify summarized results:
+
+Platform: nocloud-kvm
+  Distro: bionic
+    test modules passed:44 tests failed:0
+2019-09-09 11:22:13,552 - tests.cloud_tests - INFO - leaving data in /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-kvm/cloud-init/results
+___________________________________ summary ____________________________________
+  citest: commands succeeded
+  congratulations :)
++ RET=0
++ find . -name id_rsa* -delete
++ exit 0
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS
+=== End series b ===
+=== Begin series x ===
+Started by remote host 10.247.8.15
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm
+[cloud-init-integration-proposed-x-kvm] $ /bin/sh -xe /tmp/jenkins1040451546270423953.sh
++ release=xenial
++ release_ver=16.04
++ platform=nocloud-kvm
++ set -e
++ sudo rm -Rf cloud-init
++ git clone https://git.launchpad.net/cloud-init
+Cloning into 'cloud-init'...
++ cd cloud-init
++ git tag --list
++ grep 16.04
++ tail -1
++ tag=ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
++ echo Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
+Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
++ git checkout ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
+Note: checking out 'ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at 2d95da3a releasing cloud-init version 19.2-24-ge7881d5c-0ubuntu1~16.04.1
++ mirror=http://archive.ubuntu.com/ubuntu/
++ hostname
++ [ -z  -a torkoal = torkoal ]
++ export TMPDIR=/var/lib/jenkins/tmp/
++ set +e
++ no_proxy=launchpad.net https_proxy=http://squid.internal:3128 tox -e citest -- run --os-name=xenial --platform=nocloud-kvm --repo='deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main' --preserve-data --data-dir=./results --verbose
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/setup.py
+citest create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/.tox/citest
+citest installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/integration-requirements.txt
+citest inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/.tox/dist/cloud-init-19.2.zip
+citest installed: asn1crypto==0.24.0,attrs==19.1.0,bcrypt==3.1.7,boto3==1.5.9,botocore==1.8.50,certifi==2019.6.16,cffi==1.12.3,chardet==3.0.4,cloud-init==19.2,configobj==5.0.6,cryptography==2.4.2,docutils==0.15.2,idna==2.8,Jinja2==2.10.1,jmespath==0.9.4,jsonpatch==1.24,jsonpointer==2.0,jsonschema==3.0.2,linecache2==1.0.0,MarkupSafe==1.1.1,oauthlib==3.1.0,paramiko==2.4.2,pbr==5.4.3,pkg-resources==0.0.0,pyasn1==0.4.7,pycparser==2.19,pylxd==2.2.7,PyNaCl==1.3.0,pyrsistent==0.15.4,python-dateutil==2.8.0,python-simplestreams==0.1.0,PyYAML==5.1.2,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,s3transfer==0.1.13,six==1.12.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.3,ws4py==0.5.1
+citest runtests: PYTHONHASHSEED='1800094723'
+citest runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=xenial --platform=nocloud-kvm --repo=deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main --preserve-data --data-dir=./results --verbose
+2019-09-09 10:33:25,696 - tests.cloud_tests - DEBUG - running with args: Namespace(data_dir='/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results', deb=None, feature_override={}, os_name=['xenial'], platform=['nocloud-kvm'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo='deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main', result=None, rpm=None, script=None, subcmd='run', test_config=['/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1511485.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1611074.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1628337.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/add_apt_repositories.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/alter_completion_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/configure_instance_trusted_ca_certificates.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/configure_instances_ssh_keys.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/including_user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/install_arbitrary_packages.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/install_run_chef_recipes.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_apt_upgrade.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_commands.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_commands_first_boot.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/setup_run_puppet.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/examples/writing_out_arbitrary_files.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/main/command_output_simple.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_conf.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_disable_suites.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_primary.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_proxy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_security.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_key.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_keyserver.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_os.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/bootcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/byobu.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ca_certs.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/debug_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/debug_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/final_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/keys_to_console.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/landscape.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/locale.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/lxd_bridge.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/lxd_dir.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_chrony.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_pools.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_servers.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_timesyncd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/package_update_upgrade_install.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/runcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/seed_random_command.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/seed_random_data.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_hostname.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_hostname_fqdn.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_expire.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_list_string.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/snap.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/snappy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_import_id.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_generate.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_provided.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/timezone.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/tests/cloud_tests/testcases/modules/write_files.yaml'], upgrade=True, upgrade_full=False, verbose=True)
+2019-09-09 10:33:25,696 - tests.cloud_tests - DEBUG - using tmpdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results
+2019-09-09 10:33:25,704 - tests.cloud_tests - DEBUG - platform config: {'enabled': True, 'get_image_timeout': 300, 'create_instance_timeout': 60, 'private_key': 'cloud_init_rsa', 'public_key': 'cloud_init_rsa.pub', 'cache_mode': 'cache=none,aio=native', 'data_dir': '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results'}
+2019-09-09 10:33:25,704 - tests.cloud_tests - INFO - setting up platform: nocloud-kvm
+2019-09-09 10:33:26,066 - tests.cloud_tests - DEBUG - os config: {'enabled': True, 'boot_timeout': 120, 'boot_clean_script': '#!/bin/bash\nrm -rf /var/log/cloud-init.log /var/log/cloud-init-output.log \\\n    /var/lib/cloud/ /run/cloud-init/ /var/log/syslog\n', 'system_ready_script': "# permit running or degraded state as both indicate complete boot\n[ $(systemctl is-system-running) = 'running' -o\n  $(systemctl is-system-running) = 'degraded' ]\n", 'cloud_init_ready_script': "[ -f '/run/cloud-init/result.json' ]\n", 'feature_groups': ['base', 'debian_base', 'ubuntu_specific'], 'features': {'apt': True, 'byobu': True, 'landscape': True, 'lxd': True, 'ppa': True, 'rpm': None, 'snap': True, 'hostname': True, 'apt_src_cont': True, 'apt_hist_fmt': True, 'daylight_time': True, 'apt_up_out': True, 'engb_locale': True, 'locale_gen': True, 'no_ntpdate': True, 'no_file_fmt_e': True, 'ppa_file_name': True, 'sshd': True, 'ssh_key_fmt': True, 'syslog': True, 'ubuntu_ntp': True, 'ubuntu_repos': True, 'ubuntu_user': True, 'lsb_release': True, 'sudo': True}, 'mirror_url': 'https://cloud-images.ubuntu.com/daily', 'mirror_dir': '/srv/citest/images', 'keyring': '/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg', 'version': 16.04, 'setup_overrides': None, 'override_templates': False, 'release': 'xenial', 'os': 'ubuntu', 'arch': 'amd64'}
+2019-09-09 10:33:26,066 - tests.cloud_tests - INFO - acquiring image for os: xenial
+2019-09-09 10:33:33,404 - tests.cloud_tests - DEBUG - updating args for setup with: None
+2019-09-09 10:33:34,073 - tests.cloud_tests - INFO - setting up ubuntu-xenial (build_name=server serial=20190903)
+2019-09-09 10:33:34,073 - tests.cloud_tests - DEBUG - enable repo: "deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main" in target
+2019-09-09 10:33:34,073 - tests.cloud_tests - DEBUG - executing "enable repo: "deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main" in target"
+2019-09-09 10:33:42,912 - tests.cloud_tests - DEBUG - upgrading cloud-init
+2019-09-09 10:33:42,912 - tests.cloud_tests - DEBUG - executing "upgrading cloud-init"
+2019-09-09 10:33:49,683 - tests.cloud_tests - DEBUG - creating snapshot for xenial
+2019-09-09 10:33:49,863 - tests.cloud_tests - INFO - collecting test data for os: xenial
+2019-09-09 10:33:49,868 - tests.cloud_tests - WARNING - test config bugs/lp1511485 is not enabled, skipping
+2019-09-09 10:33:49,872 - tests.cloud_tests - WARNING - test config bugs/lp1611074 is not enabled, skipping
+2019-09-09 10:33:49,910 - tests.cloud_tests - INFO - collecting test data for test: bugs/lp1628337
+2019-09-09 10:33:50,941 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:34:06,015 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:34:25,038 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:34:25,039 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:34:25,103 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,105 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:34:25,105 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:34:25,166 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,168 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:34:25,168 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:34:25,232 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,234 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:34:25,234 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:34:25,296 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,298 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:34:25,298 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:34:25,361 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,362 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:34:25,363 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:34:25,429 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,430 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:34:25,430 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:34:25,514 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,515 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:34:25,515 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:34:25,586 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,588 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:34:25,588 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:34:25,701 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:25,858 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25348 to end
+2019-09-09 10:34:31,202 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-bugs-lp1628337-fj4hgxgsjshd39o0qot6olm to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/bugs/lp1628337/console.log
+2019-09-09 10:34:31,210 - tests.cloud_tests - WARNING - test config examples/add_apt_repositories is not enabled, skipping
+2019-09-09 10:34:31,214 - tests.cloud_tests - WARNING - test config examples/alter_completion_message is not enabled, skipping
+2019-09-09 10:34:31,221 - tests.cloud_tests - WARNING - test config examples/configure_instance_trusted_ca_certificates is not enabled, skipping
+2019-09-09 10:34:31,229 - tests.cloud_tests - WARNING - test config examples/configure_instances_ssh_keys is not enabled, skipping
+2019-09-09 10:34:31,235 - tests.cloud_tests - WARNING - test config examples/including_user_groups is not enabled, skipping
+2019-09-09 10:34:31,240 - tests.cloud_tests - WARNING - test config examples/install_arbitrary_packages is not enabled, skipping
+2019-09-09 10:34:31,251 - tests.cloud_tests - WARNING - test config examples/install_run_chef_recipes is not enabled, skipping
+2019-09-09 10:34:31,255 - tests.cloud_tests - WARNING - test config examples/run_apt_upgrade is not enabled, skipping
+2019-09-09 10:34:31,260 - tests.cloud_tests - WARNING - test config examples/run_commands is not enabled, skipping
+2019-09-09 10:34:31,265 - tests.cloud_tests - WARNING - test config examples/run_commands_first_boot is not enabled, skipping
+2019-09-09 10:34:31,271 - tests.cloud_tests - WARNING - test config examples/setup_run_puppet is not enabled, skipping
+2019-09-09 10:34:31,277 - tests.cloud_tests - WARNING - test config examples/writing_out_arbitrary_files is not enabled, skipping
+2019-09-09 10:34:31,327 - tests.cloud_tests - INFO - collecting test data for test: main/command_output_simple
+2019-09-09 10:34:32,361 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:34:47,386 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:34:50,779 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:34:50,780 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:34:50,848 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:50,850 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:34:50,850 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:34:50,939 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:50,940 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:34:50,940 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:34:51,001 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,002 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:34:51,002 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:34:51,066 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,067 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:34:51,067 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:34:51,126 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,127 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:34:51,127 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:34:51,186 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,188 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:34:51,188 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:34:51,267 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,268 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:34:51,268 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:34:51,331 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,332 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:34:51,332 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:34:51,429 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,430 - tests.cloud_tests - DEBUG - running collect script: cloud-init-test-output
+2019-09-09 10:34:51,430 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-test-output"
+2019-09-09 10:34:51,496 - tests.cloud_tests - DEBUG - collect script cloud-init-test-output exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:34:51,587 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 4169 to end
+2019-09-09 10:34:53,489 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-main-command-output-simple-zzy0msft1ge to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/main/command_output_simple/console.log
+2019-09-09 10:34:53,529 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_conf
+2019-09-09 10:34:54,565 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:35:09,607 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:35:12,966 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:35:12,966 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:35:13,028 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,030 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:35:13,030 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:35:13,087 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,088 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:35:13,089 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:35:13,144 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,145 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:35:13,145 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:35:13,199 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,200 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:35:13,201 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:35:13,255 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,256 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:35:13,257 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:35:13,311 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,313 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:35:13,313 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:35:13,377 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,378 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:35:13,378 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:35:13,436 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,437 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:35:13,437 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:35:13,528 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,529 - tests.cloud_tests - DEBUG - running collect script: 94cloud-init-config
+2019-09-09 10:35:13,529 - tests.cloud_tests - DEBUG - executing "collect: 94cloud-init-config"
+2019-09-09 10:35:13,584 - tests.cloud_tests - DEBUG - collect script 94cloud-init-config exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:13,733 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 10156 to end
+2019-09-09 10:35:15,321 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-conf-dc28jmigtsg to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_conf/console.log
+2019-09-09 10:35:15,359 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_disable_suites
+2019-09-09 10:35:16,387 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:35:31,412 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:35:34,801 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:35:34,802 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:35:34,864 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:34,865 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:35:34,865 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:35:34,921 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:34,922 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:35:34,923 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:35:34,981 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:34,982 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:35:34,983 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:35:35,041 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,042 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:35:35,042 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:35:35,102 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,103 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:35:35,103 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:35:35,162 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,163 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:35:35,163 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:35:35,232 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,233 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:35:35,233 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:35:35,290 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,291 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:35:35,292 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:35:35,386 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,388 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:35:35,388 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:35:35,447 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:35,532 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 13494 to end
+2019-09-09 10:35:37,317 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-disable--emt9ofs to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_disable_suites/console.log
+2019-09-09 10:35:37,356 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_primary
+2019-09-09 10:35:38,384 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:35:53,409 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:35:59,062 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:35:59,062 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:35:59,129 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,130 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:35:59,131 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:35:59,192 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,194 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:35:59,194 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:35:59,251 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,253 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:35:59,253 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:35:59,311 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,312 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:35:59,312 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:35:59,370 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,372 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:35:59,372 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:35:59,433 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,435 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:35:59,435 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:35:59,507 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,509 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:35:59,509 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:35:59,567 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,569 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:35:59,569 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:35:59,667 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,668 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:35:59,668 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:35:59,731 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:35:59,820 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14536 to end
+2019-09-09 10:36:01,849 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-primary-2nw4pfey to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_primary/console.log
+2019-09-09 10:36:01,887 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_proxy
+2019-09-09 10:36:02,915 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:36:17,942 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:36:21,366 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:36:21,366 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:36:21,431 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,433 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:36:21,433 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:36:21,494 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,495 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:36:21,495 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:36:21,557 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,559 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:36:21,559 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:36:21,621 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,622 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:36:21,623 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:36:21,684 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,685 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:36:21,685 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:36:21,741 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,742 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:36:21,743 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:36:21,813 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,814 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:36:21,815 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:36:21,873 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,875 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:36:21,875 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:36:21,973 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:21,975 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-aptproxy
+2019-09-09 10:36:21,975 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-aptproxy"
+2019-09-09 10:36:22,035 - tests.cloud_tests - DEBUG - collect script 90cloud-init-aptproxy exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:22,124 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14692 to end
+2019-09-09 10:36:23,861 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-proxy-tc9xfw2fpd to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_proxy/console.log
+2019-09-09 10:36:23,902 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_security
+2019-09-09 10:36:24,934 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:36:39,959 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:36:42,964 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:36:52,854 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:36:52,854 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:36:52,924 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:52,926 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:36:52,926 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:36:52,990 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:52,992 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:36:52,992 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:36:53,053 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,055 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:36:53,055 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:36:53,117 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,118 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:36:53,119 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:36:53,186 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,188 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:36:53,188 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:36:53,249 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,251 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:36:53,251 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:36:53,336 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,337 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:36:53,338 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:36:53,401 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,402 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:36:53,402 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:36:53,500 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,502 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:36:53,502 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:36:53,565 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:36:53,657 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14767 to end
+2019-09-09 10:36:55,685 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-security-u0mq143 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_security/console.log
+2019-09-09 10:36:55,726 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_key
+2019-09-09 10:36:56,753 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:37:11,778 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:37:25,753 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:37:25,753 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:37:25,784 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:25,786 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:37:25,786 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:37:25,846 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:25,848 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:37:25,848 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:37:25,913 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:25,914 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:37:25,914 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:37:25,978 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:25,980 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:37:25,980 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:37:26,043 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,044 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:37:26,044 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:37:26,107 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,108 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:37:26,108 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:37:26,189 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,190 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:37:26,190 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:37:26,254 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,256 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:37:26,256 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:37:26,367 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,368 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:37:26,369 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:37:26,434 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,436 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:37:26,436 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:37:26,614 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:37:26,730 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14870 to end
+2019-09-09 10:37:28,849 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--jorzlo6 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_sources_key/console.log
+2019-09-09 10:37:28,890 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_keyserver
+2019-09-09 10:37:29,924 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:37:44,948 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:38:03,477 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:38:03,478 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:38:03,503 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,504 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:38:03,504 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:38:03,561 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,562 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:38:03,562 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:38:03,622 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,623 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:38:03,623 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:38:03,683 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,684 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:38:03,684 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:38:03,742 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,743 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:38:03,743 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:38:03,802 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,803 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:38:03,803 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:38:03,872 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,873 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:38:03,873 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:38:03,934 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:03,935 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:38:03,935 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:38:04,032 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:04,033 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:38:04,033 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:38:04,090 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:04,091 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:38:04,091 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:38:04,219 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:04,286 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 15133 to end
+2019-09-09 10:38:06,029 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--oc8w2z6 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_sources_keyserver/console.log
+2019-09-09 10:38:06,069 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_list
+2019-09-09 10:38:07,095 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:38:22,119 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:38:25,560 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:38:25,560 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:38:25,622 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,624 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:38:25,624 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:38:25,685 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,686 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:38:25,686 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:38:25,744 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,746 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:38:25,746 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:38:25,804 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,806 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:38:25,806 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:38:25,860 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,861 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:38:25,861 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:38:25,919 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,921 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:38:25,921 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:38:25,992 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:25,994 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:38:25,994 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:38:26,053 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:26,054 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:38:26,054 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:38:26,150 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:26,151 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:38:26,151 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:38:26,208 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:26,374 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 15323 to end
+2019-09-09 10:38:28,029 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--fh5otzh to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_sources_list/console.log
+2019-09-09 10:38:28,068 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_ppa
+2019-09-09 10:38:29,095 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:38:35,795 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:38:48,635 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:38:48,635 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:38:48,656 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:48,658 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:38:48,658 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:38:48,719 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:48,720 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:38:48,720 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:38:48,779 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:48,780 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:38:48,780 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:38:48,839 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:48,840 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:38:48,840 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:38:48,899 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:48,900 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:38:48,901 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:38:48,961 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:48,962 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:38:48,962 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:38:49,040 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:49,042 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:38:49,042 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:38:49,102 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:49,104 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:38:49,104 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:38:49,218 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:49,220 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:38:49,220 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:38:49,284 - tests.cloud_tests - DEBUG - collect script sources.list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:49,285 - tests.cloud_tests - DEBUG - running collect script: apt-key
+2019-09-09 10:38:49,285 - tests.cloud_tests - DEBUG - executing "collect: apt-key"
+2019-09-09 10:38:49,443 - tests.cloud_tests - DEBUG - collect script apt-key exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:49,445 - tests.cloud_tests - DEBUG - running collect script: sources_full
+2019-09-09 10:38:49,445 - tests.cloud_tests - DEBUG - executing "collect: sources_full"
+2019-09-09 10:38:49,468 - tests.cloud_tests - DEBUG - collect script sources_full exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:38:49,713 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16318 to end
+2019-09-09 10:38:51,437 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--l0huyts to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_configure_sources_ppa/console.log
+2019-09-09 10:38:51,513 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_disable
+2019-09-09 10:38:52,544 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:38:59,307 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:39:06,989 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:39:06,990 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:39:07,052 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,053 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:39:07,054 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:39:07,114 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,115 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:39:07,115 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:39:07,173 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,175 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:39:07,175 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:39:07,235 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,236 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:39:07,236 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:39:07,295 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,296 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:39:07,296 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:39:07,353 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,355 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:39:07,355 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:39:07,427 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,429 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:39:07,429 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:39:07,486 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,488 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:39:07,488 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:39:07,585 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,586 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining
+2019-09-09 10:39:07,586 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining"
+2019-09-09 10:39:07,646 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:07,758 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16496 to end
+2019-09-09 10:39:09,693 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-pipelining-disable-htljbai to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_pipelining_disable/console.log
+2019-09-09 10:39:09,733 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_os
+2019-09-09 10:39:10,761 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:39:25,789 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:39:32,832 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:39:32,832 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:39:32,853 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:32,855 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:39:32,855 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:39:32,916 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:32,918 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:39:32,918 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:39:32,980 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:32,981 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:39:32,982 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:39:33,044 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:33,045 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:39:33,045 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:39:33,104 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:33,105 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:39:33,105 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:39:33,164 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:33,166 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:39:33,166 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:39:33,237 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:33,238 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:39:33,239 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:39:33,298 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:33,299 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:39:33,299 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:39:33,406 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:33,407 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining_not_written
+2019-09-09 10:39:33,408 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining_not_written"
+2019-09-09 10:39:33,467 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining_not_written exited 'b"sudo: unable to resolve host ubuntu\nls: cannot access '/etc/apt/apt.conf.d/90cloud-init-pipelining': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:39:33,545 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16617 to end
+2019-09-09 10:39:35,521 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-pipelining-os-g8gkzu408x2t to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/apt_pipelining_os/console.log
+2019-09-09 10:39:35,562 - tests.cloud_tests - INFO - collecting test data for test: modules/bootcmd
+2019-09-09 10:39:36,595 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:39:43,304 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:39:49,732 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:39:49,732 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:39:49,793 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:49,795 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:39:49,795 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:39:49,853 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:49,855 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:39:49,855 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:39:49,914 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:49,915 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:39:49,915 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:39:49,973 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:49,975 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:39:49,975 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:39:50,034 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:50,036 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:39:50,036 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:39:50,094 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:50,095 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:39:50,095 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:39:50,167 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:50,168 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:39:50,168 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:39:50,225 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:50,227 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:39:50,227 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:39:50,336 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:50,337 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:39:50,338 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:39:50,397 - tests.cloud_tests - DEBUG - collect script hosts exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:39:50,553 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16764 to end
+2019-09-09 10:39:52,153 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-bootcmd-63umfux1aiarf1zahb8m18 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/bootcmd/console.log
+2019-09-09 10:39:52,193 - tests.cloud_tests - INFO - collecting test data for test: modules/byobu
+2019-09-09 10:39:53,222 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:40:08,247 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:40:11,607 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:40:11,607 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:40:11,675 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:11,676 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:40:11,676 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:40:11,733 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:11,734 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:40:11,735 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:40:11,796 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:11,797 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:40:11,798 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:40:11,859 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:11,860 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:40:11,860 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:40:11,918 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:11,919 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:40:11,919 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:40:11,981 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:11,983 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:40:11,983 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:40:12,059 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:12,060 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:40:12,061 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:40:12,122 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:12,123 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:40:12,124 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:40:12,233 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:12,235 - tests.cloud_tests - DEBUG - running collect script: byobu_profile_enabled
+2019-09-09 10:40:12,235 - tests.cloud_tests - DEBUG - executing "collect: byobu_profile_enabled"
+2019-09-09 10:40:12,295 - tests.cloud_tests - DEBUG - collect script byobu_profile_enabled exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:12,296 - tests.cloud_tests - DEBUG - running collect script: byobu_launch_exists
+2019-09-09 10:40:12,296 - tests.cloud_tests - DEBUG - executing "collect: byobu_launch_exists"
+2019-09-09 10:40:12,355 - tests.cloud_tests - DEBUG - collect script byobu_launch_exists exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:12,455 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 17729 to end
+2019-09-09 10:40:14,141 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-byobu-mmt0fspzrto69x3qtgl8u6xb to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/byobu/console.log
+2019-09-09 10:40:14,182 - tests.cloud_tests - INFO - collecting test data for test: modules/ca_certs
+2019-09-09 10:40:15,228 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:40:30,253 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:40:33,626 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:40:33,626 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:40:33,689 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:33,691 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:40:33,691 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:40:33,749 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:33,750 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:40:33,750 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:40:33,809 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:33,810 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:40:33,810 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:40:33,869 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:33,871 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:40:33,871 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:40:33,929 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:33,931 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:40:33,931 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:40:33,997 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:33,998 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:40:33,998 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:40:34,079 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:34,080 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:40:34,080 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:40:34,143 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:34,145 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:40:34,145 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:40:34,250 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:34,252 - tests.cloud_tests - DEBUG - running collect script: cert_links
+2019-09-09 10:40:34,252 - tests.cloud_tests - DEBUG - executing "collect: cert_links"
+2019-09-09 10:40:34,315 - tests.cloud_tests - DEBUG - collect script cert_links exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:34,316 - tests.cloud_tests - DEBUG - running collect script: cert
+2019-09-09 10:40:34,316 - tests.cloud_tests - DEBUG - executing "collect: cert"
+2019-09-09 10:40:34,378 - tests.cloud_tests - DEBUG - collect script cert exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:34,466 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 17895 to end
+2019-09-09 10:40:36,613 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ca-certs-hm8ke82lu4jqattyh3ni9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ca_certs/console.log
+2019-09-09 10:40:36,654 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_disable
+2019-09-09 10:40:37,687 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:40:52,711 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:40:56,060 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:40:56,060 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:40:56,122 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,123 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:40:56,123 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:40:56,181 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,183 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:40:56,183 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:40:56,241 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,243 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:40:56,243 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:40:56,301 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,302 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:40:56,302 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:40:56,361 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,362 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:40:56,362 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:40:56,421 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,422 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:40:56,423 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:40:56,491 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,492 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:40:56,492 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:40:56,549 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,550 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:40:56,550 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:40:56,646 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:40:56,820 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18026 to end
+2019-09-09 10:40:58,429 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-debug-disable-ewi09b860pddoni1 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/debug_disable/console.log
+2019-09-09 10:40:58,466 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_enable
+2019-09-09 10:40:59,493 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:41:06,167 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:41:11,535 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:41:11,535 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:41:11,595 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,597 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:41:11,597 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:41:11,653 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,654 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:41:11,654 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:41:11,713 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,714 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:41:11,714 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:41:11,773 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,774 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:41:11,774 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:41:11,835 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,836 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:41:11,836 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:41:11,895 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,897 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:41:11,897 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:41:11,964 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:11,965 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:41:11,965 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:41:12,023 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:12,025 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:41:12,025 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:41:12,132 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:12,226 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18218 to end
+2019-09-09 10:41:14,025 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-debug-enable-9ln3pgpuydey0s2rh to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/debug_enable/console.log
+2019-09-09 10:41:14,070 - tests.cloud_tests - INFO - collecting test data for test: modules/final_message
+2019-09-09 10:41:15,101 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:41:30,125 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:41:33,495 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:41:33,495 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:41:33,562 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,563 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:41:33,563 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:41:33,626 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,627 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:41:33,627 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:41:33,686 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,687 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:41:33,687 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:41:33,745 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,747 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:41:33,747 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:41:33,810 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,812 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:41:33,812 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:41:33,870 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,871 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:41:33,871 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:41:33,940 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:33,942 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:41:33,942 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:41:34,006 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:34,007 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:41:34,008 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:41:34,115 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:34,193 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18495 to end
+2019-09-09 10:41:35,929 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-final-message-loedj8b6jmh85wow to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/final_message/console.log
+2019-09-09 10:41:35,970 - tests.cloud_tests - INFO - collecting test data for test: modules/keys_to_console
+2019-09-09 10:41:37,003 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:41:52,028 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:41:55,455 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:41:55,455 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:41:55,516 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,518 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:41:55,518 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:41:55,584 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,585 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:41:55,585 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:41:55,647 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,648 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:41:55,648 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:41:55,711 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,712 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:41:55,712 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:41:55,775 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,776 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:41:55,776 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:41:55,840 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,841 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:41:55,841 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:41:55,920 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,921 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:41:55,921 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:41:55,980 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:55,982 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:41:55,982 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:41:56,101 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:56,102 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:41:56,102 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:41:56,168 - tests.cloud_tests - DEBUG - collect script syslog exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:41:56,283 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19396 to end
+2019-09-09 10:41:58,205 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-keys-to-console-2zxjunlsp5zagf to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/keys_to_console/console.log
+2019-09-09 10:41:58,211 - tests.cloud_tests - WARNING - test config modules/landscape is not enabled, skipping
+2019-09-09 10:41:58,250 - tests.cloud_tests - INFO - collecting test data for test: modules/locale
+2019-09-09 10:41:59,282 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:42:14,306 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:42:19,949 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:42:19,949 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:42:20,015 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,017 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:42:20,017 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:42:20,075 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,076 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:42:20,076 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:42:20,138 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,140 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:42:20,140 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:42:20,197 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,198 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:42:20,199 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:42:20,258 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,259 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:42:20,259 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:42:20,318 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,320 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:42:20,320 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:42:20,390 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,392 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:42:20,392 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:42:20,451 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,452 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:42:20,453 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:42:20,575 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,576 - tests.cloud_tests - DEBUG - running collect script: locale_default
+2019-09-09 10:42:20,576 - tests.cloud_tests - DEBUG - executing "collect: locale_default"
+2019-09-09 10:42:20,633 - tests.cloud_tests - DEBUG - collect script locale_default exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,635 - tests.cloud_tests - DEBUG - running collect script: locale_a
+2019-09-09 10:42:20,635 - tests.cloud_tests - DEBUG - executing "collect: locale_a"
+2019-09-09 10:42:20,694 - tests.cloud_tests - DEBUG - collect script locale_a exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,695 - tests.cloud_tests - DEBUG - running collect script: locale_gen
+2019-09-09 10:42:20,695 - tests.cloud_tests - DEBUG - executing "collect: locale_gen"
+2019-09-09 10:42:20,756 - tests.cloud_tests - DEBUG - collect script locale_gen exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:20,973 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19484 to end
+2019-09-09 10:42:22,653 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-locale-f6t1xygso1cqukhcyd5rd10 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/locale/console.log
+2019-09-09 10:42:22,694 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_bridge
+2019-09-09 10:42:23,731 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:42:30,101 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:42:40,538 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:42:40,538 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:42:40,598 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,599 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:42:40,600 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:42:40,659 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,660 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:42:40,660 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:42:40,718 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,719 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:42:40,719 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:42:40,777 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,778 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:42:40,779 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:42:40,836 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,838 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:42:40,838 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:42:40,896 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,898 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:42:40,898 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:42:40,967 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:40,969 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:42:40,969 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:42:41,024 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:41,026 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:42:41,026 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:42:41,124 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:41,125 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 10:42:41,125 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 10:42:41,181 - tests.cloud_tests - DEBUG - collect script lxc exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:41,182 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 10:42:41,182 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 10:42:41,242 - tests.cloud_tests - DEBUG - collect script lxd exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:42:41,243 - tests.cloud_tests - DEBUG - running collect script: lxc-bridge
+2019-09-09 10:42:41,243 - tests.cloud_tests - DEBUG - executing "collect: lxc-bridge"
+2019-09-09 10:42:41,306 - tests.cloud_tests - DEBUG - collect script lxc-bridge exited 'b'sudo: unable to resolve host ubuntu\nDevice "lxdbr0" does not exist.\n'' and had stderr: 0
+2019-09-09 10:42:41,396 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19683 to end
+2019-09-09 10:42:43,193 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-lxd-bridge-ryue3ol2s2t6zu3wwcm to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/lxd_bridge/console.log
+2019-09-09 10:42:43,233 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_dir
+2019-09-09 10:42:46,240 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:43:01,264 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:43:04,650 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:43:04,650 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:43:04,717 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:04,719 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:43:04,719 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:43:04,778 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:04,780 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:43:04,780 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:43:04,838 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:04,839 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:43:04,839 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:43:04,898 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:04,900 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:43:04,900 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:43:04,958 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:04,960 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:43:04,960 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:43:05,020 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:05,022 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:43:05,022 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:43:05,091 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:05,093 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:43:05,093 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:43:05,153 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:05,154 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:43:05,154 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:43:05,253 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:05,254 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 10:43:05,254 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 10:43:05,314 - tests.cloud_tests - DEBUG - collect script lxc exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:05,316 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 10:43:05,316 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 10:43:05,379 - tests.cloud_tests - DEBUG - collect script lxd exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:05,471 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19800 to end
+2019-09-09 10:43:07,149 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-lxd-dir-o4oyaqpxiors3la27zos4q to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/lxd_dir/console.log
+2019-09-09 10:43:07,186 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp
+2019-09-09 10:43:08,212 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:43:23,236 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:43:39,907 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:43:39,907 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:43:39,967 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:39,968 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:43:39,968 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:43:40,024 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,025 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:43:40,026 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:43:40,084 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,085 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:43:40,085 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:43:40,140 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,141 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:43:40,141 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:43:40,196 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,197 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:43:40,197 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:43:40,254 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,255 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:43:40,255 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:43:40,324 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,325 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:43:40,325 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:43:40,379 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,380 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:43:40,381 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:43:40,475 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,477 - tests.cloud_tests - DEBUG - running collect script: ntp_installed
+2019-09-09 10:43:40,477 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed"
+2019-09-09 10:43:40,536 - tests.cloud_tests - DEBUG - collect script ntp_installed exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,537 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_empty
+2019-09-09 10:43:40,537 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_empty"
+2019-09-09 10:43:40,593 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_empty exited 'b"sudo: unable to resolve host ubuntu\nls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:43:40,594 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pool_list
+2019-09-09 10:43:40,594 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pool_list"
+2019-09-09 10:43:40,653 - tests.cloud_tests - DEBUG - collect script ntp_conf_pool_list exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:43:40,731 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 20897 to end
+2019-09-09 10:43:42,625 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-1i4zem0txbbs1hkyrs6dp5w444 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ntp/console.log
+2019-09-09 10:43:42,666 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_chrony
+2019-09-09 10:43:43,695 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:43:58,719 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:44:14,616 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:44:14,616 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:44:14,676 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:14,678 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:44:14,678 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:44:14,736 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:14,737 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:44:14,737 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:44:14,793 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:14,794 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:44:14,794 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:44:14,854 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:14,855 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:44:14,855 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:44:14,914 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:14,915 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:44:14,915 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:44:14,974 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:14,975 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:44:14,975 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:44:15,044 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:15,045 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:44:15,046 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:44:15,111 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:15,112 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:44:15,112 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:44:15,212 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:15,213 - tests.cloud_tests - DEBUG - running collect script: chrony_conf
+2019-09-09 10:44:15,214 - tests.cloud_tests - DEBUG - executing "collect: chrony_conf"
+2019-09-09 10:44:15,278 - tests.cloud_tests - DEBUG - collect script chrony_conf exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:15,500 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 21102 to end
+2019-09-09 10:44:17,185 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-chrony-08ng6lh9ebzq9nv4rww to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ntp_chrony/console.log
+2019-09-09 10:44:17,224 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_pools
+2019-09-09 10:44:18,251 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:44:33,275 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:44:40,015 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:44:40,015 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:44:40,037 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,038 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:44:40,039 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:44:40,100 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,101 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:44:40,102 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:44:40,162 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,163 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:44:40,164 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:44:40,222 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,223 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:44:40,223 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:44:40,282 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,283 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:44:40,283 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:44:40,346 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,348 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:44:40,348 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:44:40,426 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,428 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:44:40,428 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:44:40,487 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,489 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:44:40,489 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:44:40,584 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,585 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_pools
+2019-09-09 10:44:40,586 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_pools"
+2019-09-09 10:44:40,653 - tests.cloud_tests - DEBUG - collect script ntp_installed_pools exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,655 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_pools
+2019-09-09 10:44:40,655 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_pools"
+2019-09-09 10:44:40,721 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_pools exited 'b"sudo: unable to resolve host ubuntu\nls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:44:40,722 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pools
+2019-09-09 10:44:40,722 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pools"
+2019-09-09 10:44:40,787 - tests.cloud_tests - DEBUG - collect script ntp_conf_pools exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:40,789 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 10:44:40,789 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 10:44:40,860 - tests.cloud_tests - DEBUG - collect script ntpq_servers exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:44:41,114 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22267 to end
+2019-09-09 10:44:43,365 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-pools-hxnxxlabkkdywarefg3q to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ntp_pools/console.log
+2019-09-09 10:44:43,406 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_servers
+2019-09-09 10:44:44,439 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:44:59,464 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:45:11,573 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:45:11,573 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:45:11,642 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:11,644 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:45:11,644 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:45:11,706 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:11,708 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:45:11,708 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:45:11,770 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:11,772 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:45:11,772 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:45:11,834 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:11,835 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:45:11,835 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:45:11,897 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:11,899 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:45:11,899 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:45:11,957 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:11,959 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:45:11,959 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:45:12,027 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:12,029 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:45:12,029 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:45:12,085 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:12,087 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:45:12,087 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:45:12,183 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:12,185 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_servers
+2019-09-09 10:45:12,185 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_servers"
+2019-09-09 10:45:12,243 - tests.cloud_tests - DEBUG - collect script ntp_installed_servers exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:12,244 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_servers
+2019-09-09 10:45:12,244 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_servers"
+2019-09-09 10:45:12,302 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_servers exited 'b'sudo: unable to resolve host ubuntu\ncat: /etc/ntp.conf.dist: No such file or directory\n'' and had stderr: 0
+2019-09-09 10:45:12,303 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_servers
+2019-09-09 10:45:12,303 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_servers"
+2019-09-09 10:45:12,362 - tests.cloud_tests - DEBUG - collect script ntp_conf_servers exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:12,363 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 10:45:12,363 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 10:45:12,428 - tests.cloud_tests - DEBUG - collect script ntpq_servers exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:12,723 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22358 to end
+2019-09-09 10:45:14,693 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-servers-0edc6qx07myizgdl13 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ntp_servers/console.log
+2019-09-09 10:45:14,738 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_timesyncd
+2019-09-09 10:45:15,770 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:45:30,795 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:45:34,195 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:45:34,195 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:45:34,259 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,260 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:45:34,261 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:45:34,319 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,320 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:45:34,321 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:45:34,382 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,384 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:45:34,384 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:45:34,450 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,452 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:45:34,452 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:45:34,515 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,516 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:45:34,516 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:45:34,574 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,576 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:45:34,576 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:45:34,727 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,728 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:45:34,728 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:45:34,790 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,792 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:45:34,792 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:45:34,903 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:34,904 - tests.cloud_tests - DEBUG - running collect script: timesyncd_conf
+2019-09-09 10:45:34,904 - tests.cloud_tests - DEBUG - executing "collect: timesyncd_conf"
+2019-09-09 10:45:34,963 - tests.cloud_tests - DEBUG - collect script timesyncd_conf exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:45:35,059 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22662 to end
+2019-09-09 10:45:37,109 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-timesyncd-0uz07e9t31rf06yt to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ntp_timesyncd/console.log
+2019-09-09 10:45:37,150 - tests.cloud_tests - INFO - collecting test data for test: modules/package_update_upgrade_install
+2019-09-09 10:45:38,180 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:45:53,204 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:46:14,749 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:46:14,749 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:46:14,812 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:14,814 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:46:14,814 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:46:14,874 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:14,875 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:46:14,875 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:46:14,934 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:14,935 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:46:14,936 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:46:14,998 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:14,999 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:46:15,000 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:46:15,058 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,060 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:46:15,060 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:46:15,118 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,120 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:46:15,120 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:46:15,188 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,190 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:46:15,190 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:46:15,250 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,251 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:46:15,252 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:46:15,347 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,349 - tests.cloud_tests - DEBUG - running collect script: apt_history_cmdline
+2019-09-09 10:46:15,349 - tests.cloud_tests - DEBUG - executing "collect: apt_history_cmdline"
+2019-09-09 10:46:15,407 - tests.cloud_tests - DEBUG - collect script apt_history_cmdline exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,409 - tests.cloud_tests - DEBUG - running collect script: dpkg_show
+2019-09-09 10:46:15,409 - tests.cloud_tests - DEBUG - executing "collect: dpkg_show"
+2019-09-09 10:46:15,479 - tests.cloud_tests - DEBUG - collect script dpkg_show exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:15,624 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23413 to end
+2019-09-09 10:46:17,541 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-package-update-upgrade-5e7mwwp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/package_update_upgrade_install/console.log
+2019-09-09 10:46:17,581 - tests.cloud_tests - INFO - collecting test data for test: modules/runcmd
+2019-09-09 10:46:18,624 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:46:33,649 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:46:41,192 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:46:41,192 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:46:41,213 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,215 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:46:41,215 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:46:41,272 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,274 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:46:41,274 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:46:41,333 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,334 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:46:41,334 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:46:41,396 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,397 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:46:41,397 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:46:41,456 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,457 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:46:41,458 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:46:41,526 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,527 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:46:41,527 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:46:41,604 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,605 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:46:41,605 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:46:41,664 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,666 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:46:41,666 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:46:41,772 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,773 - tests.cloud_tests - DEBUG - running collect script: run_cmd
+2019-09-09 10:46:41,773 - tests.cloud_tests - DEBUG - executing "collect: run_cmd"
+2019-09-09 10:46:41,835 - tests.cloud_tests - DEBUG - collect script run_cmd exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:46:41,928 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23621 to end
+2019-09-09 10:46:43,969 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-runcmd-yo7duyzsx2nrvsvubaxaf2h to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/runcmd/console.log
+2019-09-09 10:46:43,975 - tests.cloud_tests - WARNING - test config modules/seed_random_command is not enabled, skipping
+2019-09-09 10:46:44,012 - tests.cloud_tests - INFO - collecting test data for test: modules/seed_random_data
+2019-09-09 10:46:45,040 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:47:00,067 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:47:03,442 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:47:03,442 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:47:03,504 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,506 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:47:03,506 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:47:03,561 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,562 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:47:03,563 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:47:03,625 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,626 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:47:03,626 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:47:03,689 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,690 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:47:03,690 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:47:03,755 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,756 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:47:03,756 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:47:03,818 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,819 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:47:03,820 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:47:03,897 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,898 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:47:03,898 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:47:03,961 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:03,962 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:47:03,962 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:47:04,074 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:04,075 - tests.cloud_tests - DEBUG - running collect script: seed_data
+2019-09-09 10:47:04,075 - tests.cloud_tests - DEBUG - executing "collect: seed_data"
+2019-09-09 10:47:04,135 - tests.cloud_tests - DEBUG - collect script seed_data exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:47:04,230 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23761 to end
+2019-09-09 10:47:05,909 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-seed-random-data-rvuxmmlp4pgv8 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/seed_random_data/console.log
+2019-09-09 10:47:05,947 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname
+2019-09-09 10:47:06,976 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:47:22,001 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:47:28,989 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:47:28,989 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:47:29,011 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,012 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:47:29,012 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:47:29,069 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,070 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:47:29,070 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:47:29,128 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,129 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:47:29,129 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:47:29,188 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,189 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:47:29,190 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:47:29,244 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,245 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:47:29,245 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:47:29,304 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,305 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:47:29,305 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:47:29,374 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,375 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:47:29,375 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:47:29,432 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,433 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:47:29,433 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:47:29,522 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,523 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:47:29,523 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:47:29,581 - tests.cloud_tests - DEBUG - collect script hosts exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,582 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 10:47:29,582 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 10:47:29,641 - tests.cloud_tests - DEBUG - collect script hostname exited 'b'sudo: unable to resolve host cloudinit2\n'' and had stderr: 0
+2019-09-09 10:47:29,642 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 10:47:29,642 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 10:47:29,702 - tests.cloud_tests - DEBUG - collect script fqdn exited 'b'sudo: unable to resolve host cloudinit2\nhostname: Name or service not known\n'' and had stderr: 1
+2019-09-09 10:47:29,780 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23926 to end
+2019-09-09 10:47:31,633 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-hostname-vw91rbg5vxrhwegl3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/set_hostname/console.log
+2019-09-09 10:47:31,672 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname_fqdn
+2019-09-09 10:47:32,702 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:47:47,726 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:47:51,103 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:47:51,103 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:47:51,201 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:47:51,201 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:47:51,290 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:47:51,290 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:47:51,386 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:47:51,386 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:47:51,478 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:47:51,478 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:47:51,575 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:47:51,576 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:47:51,667 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:47:51,667 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:47:51,777 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:47:51,778 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:47:51,866 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:47:51,867 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:47:52,007 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:47:52,007 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:47:52,101 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 10:47:52,101 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 10:47:52,195 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 10:47:52,195 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 10:47:52,533 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 24107 to end
+2019-09-09 10:47:54,169 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-hostname-fqdn-o8yr53ps4hsk to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/set_hostname_fqdn/console.log
+2019-09-09 10:47:54,244 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password
+2019-09-09 10:47:55,273 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:48:10,298 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:48:13,652 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:48:13,652 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:48:13,715 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:13,717 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:48:13,717 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:48:13,775 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:13,776 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:48:13,776 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:48:13,834 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:13,835 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:48:13,835 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:48:13,900 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:13,901 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:48:13,902 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:48:13,962 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:13,963 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:48:13,964 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:48:14,025 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:14,027 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:48:14,027 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:48:14,106 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:14,107 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:48:14,107 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:48:14,169 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:14,170 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:48:14,170 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:48:14,281 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:14,282 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:48:14,282 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:48:14,533 - tests.cloud_tests - DEBUG - collect script shadow exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:14,535 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:48:14,535 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:48:14,604 - tests.cloud_tests - DEBUG - collect script sshd_config exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:15,037 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25031 to end
+2019-09-09 10:48:16,717 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-h43e908mb9ves5suz to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/set_password/console.log
+2019-09-09 10:48:16,757 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_expire
+2019-09-09 10:48:17,786 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:48:32,812 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:48:36,202 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:48:36,202 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:48:36,266 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,268 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:48:36,268 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:48:36,326 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,327 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:48:36,327 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:48:36,386 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,387 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:48:36,388 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:48:36,446 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,447 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:48:36,448 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:48:36,515 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,516 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:48:36,517 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:48:36,580 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,582 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:48:36,582 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:48:36,656 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,658 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:48:36,658 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:48:36,718 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,720 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:48:36,720 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:48:36,822 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,824 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:48:36,824 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:48:36,883 - tests.cloud_tests - DEBUG - collect script shadow exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:36,884 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:48:36,884 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:48:36,943 - tests.cloud_tests - DEBUG - collect script sshd_config exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:37,034 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25175 to end
+2019-09-09 10:48:38,741 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-expire-ro8t7fu78y to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/set_password_expire/console.log
+2019-09-09 10:48:38,783 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list
+2019-09-09 10:48:39,817 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:48:54,842 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:48:58,187 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:48:58,188 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:48:58,258 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,260 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:48:58,260 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:48:58,321 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,323 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:48:58,323 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:48:58,382 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,383 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:48:58,383 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:48:58,443 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,444 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:48:58,444 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:48:58,501 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,502 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:48:58,502 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:48:58,565 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,566 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:48:58,566 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:48:58,635 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,636 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:48:58,636 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:48:58,693 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,694 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:48:58,694 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:48:58,791 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,792 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:48:58,792 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:48:58,850 - tests.cloud_tests - DEBUG - collect script shadow exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:58,851 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:48:58,851 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:48:58,910 - tests.cloud_tests - DEBUG - collect script sshd_config exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:48:59,063 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25381 to end
+2019-09-09 10:49:00,653 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-list-owwn8b7l7kud to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/set_password_list/console.log
+2019-09-09 10:49:00,692 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list_string
+2019-09-09 10:49:01,721 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:49:08,442 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:49:17,249 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:49:17,249 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:49:17,271 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,273 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:49:17,273 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:49:17,330 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,331 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:49:17,331 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:49:17,389 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,390 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:49:17,390 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:49:17,449 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,450 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:49:17,450 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:49:17,510 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,511 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:49:17,511 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:49:17,568 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,569 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:49:17,570 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:49:17,640 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,641 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:49:17,641 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:49:17,696 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,697 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:49:17,698 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:49:17,795 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,796 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:49:17,796 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:49:17,853 - tests.cloud_tests - DEBUG - collect script shadow exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:17,855 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:49:17,855 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:49:17,916 - tests.cloud_tests - DEBUG - collect script sshd_config exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:18,018 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25596 to end
+2019-09-09 10:49:20,085 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-list-stri-321g87k to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/set_password_list_string/console.log
+2019-09-09 10:49:20,092 - tests.cloud_tests - WARNING - test config modules/snap is not enabled, skipping
+2019-09-09 10:49:20,096 - tests.cloud_tests - WARNING - test config modules/snappy is not enabled, skipping
+2019-09-09 10:49:20,136 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_disable
+2019-09-09 10:49:21,167 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:49:36,191 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:49:39,564 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:49:39,565 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:49:39,629 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:39,630 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:49:39,630 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:49:39,696 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:39,698 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:49:39,698 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:49:39,766 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:39,767 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:49:39,767 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:49:39,828 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:39,829 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:49:39,829 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:49:39,885 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:39,886 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:49:39,886 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:49:39,950 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:39,952 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:49:39,952 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:49:40,032 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:40,034 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:49:40,034 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:49:40,092 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:40,093 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:49:40,093 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:49:40,199 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:40,200 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:49:40,200 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:49:40,266 - tests.cloud_tests - DEBUG - collect script syslog exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:49:40,369 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25698 to end
+2019-09-09 10:49:42,045 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-6t7xr9h to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ssh_auth_key_fingerprints_disable/console.log
+2019-09-09 10:49:42,085 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_enable
+2019-09-09 10:49:43,112 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:49:58,136 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:50:01,565 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:50:01,565 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:50:01,629 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:01,630 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:50:01,631 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:50:01,700 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:01,701 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:50:01,701 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:50:01,757 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:01,759 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:50:01,759 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:50:01,821 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:01,823 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:50:01,823 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:50:01,890 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:01,891 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:50:01,891 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:50:01,953 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:01,955 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:50:01,955 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:50:02,031 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:02,033 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:50:02,033 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:50:02,095 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:02,096 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:50:02,097 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:50:02,215 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:02,216 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:50:02,216 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:50:02,280 - tests.cloud_tests - DEBUG - collect script syslog exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:02,364 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 26693 to end
+2019-09-09 10:50:04,177 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-kt1ugym to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ssh_auth_key_fingerprints_enable/console.log
+2019-09-09 10:50:04,217 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_import_id
+2019-09-09 10:50:05,257 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:50:20,281 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:50:25,842 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:50:25,843 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:50:25,903 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:25,904 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:50:25,904 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:50:25,961 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:25,963 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:50:25,963 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:50:26,021 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,022 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:50:26,022 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:50:26,081 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,082 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:50:26,082 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:50:26,141 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,142 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:50:26,142 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:50:26,201 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,203 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:50:26,203 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:50:26,272 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,273 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:50:26,274 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:50:26,334 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,335 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:50:26,336 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:50:26,434 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,436 - tests.cloud_tests - DEBUG - running collect script: auth_keys_ubuntu
+2019-09-09 10:50:26,436 - tests.cloud_tests - DEBUG - executing "collect: auth_keys_ubuntu"
+2019-09-09 10:50:26,496 - tests.cloud_tests - DEBUG - collect script auth_keys_ubuntu exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:26,574 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 27562 to end
+2019-09-09 10:50:28,557 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-import-id-dbfm3klgy5wfb9jx to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ssh_import_id/console.log
+2019-09-09 10:50:28,597 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_keys_generate
+2019-09-09 10:50:29,624 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:50:44,648 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:50:48,041 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:50:48,041 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:50:48,112 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,114 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:50:48,114 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:50:48,173 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,174 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:50:48,174 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:50:48,240 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,241 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:50:48,241 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:50:48,304 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,306 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:50:48,306 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:50:48,370 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,372 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:50:48,372 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:50:48,433 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,434 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:50:48,434 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:50:48,516 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,517 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:50:48,518 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:50:48,576 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,577 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:50:48,578 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:50:48,680 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,681 - tests.cloud_tests - DEBUG - running collect script: dsa_public
+2019-09-09 10:50:48,682 - tests.cloud_tests - DEBUG - executing "collect: dsa_public"
+2019-09-09 10:50:48,745 - tests.cloud_tests - DEBUG - collect script dsa_public exited 'b'sudo: unable to resolve host ubuntu\ncat: /etc/ssh/ssh_host_dsa_key.pub: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:50:48,747 - tests.cloud_tests - DEBUG - running collect script: dsa_private
+2019-09-09 10:50:48,747 - tests.cloud_tests - DEBUG - executing "collect: dsa_private"
+2019-09-09 10:50:48,805 - tests.cloud_tests - DEBUG - collect script dsa_private exited 'b'sudo: unable to resolve host ubuntu\ncat: /etc/ssh/ssh_host_dsa_key: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:50:48,806 - tests.cloud_tests - DEBUG - running collect script: rsa_public
+2019-09-09 10:50:48,806 - tests.cloud_tests - DEBUG - executing "collect: rsa_public"
+2019-09-09 10:50:48,865 - tests.cloud_tests - DEBUG - collect script rsa_public exited 'b'sudo: unable to resolve host ubuntu\ncat: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:50:48,867 - tests.cloud_tests - DEBUG - running collect script: rsa_private
+2019-09-09 10:50:48,867 - tests.cloud_tests - DEBUG - executing "collect: rsa_private"
+2019-09-09 10:50:48,930 - tests.cloud_tests - DEBUG - collect script rsa_private exited 'b'sudo: unable to resolve host ubuntu\ncat: /etc/ssh/ssh_host_rsa_key: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:50:48,931 - tests.cloud_tests - DEBUG - running collect script: ecdsa_public
+2019-09-09 10:50:48,931 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_public"
+2019-09-09 10:50:48,989 - tests.cloud_tests - DEBUG - collect script ecdsa_public exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:48,990 - tests.cloud_tests - DEBUG - running collect script: ecdsa_private
+2019-09-09 10:50:48,990 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_private"
+2019-09-09 10:50:49,051 - tests.cloud_tests - DEBUG - collect script ecdsa_private exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:49,052 - tests.cloud_tests - DEBUG - running collect script: ed25519_public
+2019-09-09 10:50:49,052 - tests.cloud_tests - DEBUG - executing "collect: ed25519_public"
+2019-09-09 10:50:49,109 - tests.cloud_tests - DEBUG - collect script ed25519_public exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:49,110 - tests.cloud_tests - DEBUG - running collect script: ed25519_private
+2019-09-09 10:50:49,111 - tests.cloud_tests - DEBUG - executing "collect: ed25519_private"
+2019-09-09 10:50:49,170 - tests.cloud_tests - DEBUG - collect script ed25519_private exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:50:49,781 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 32022 to end
+2019-09-09 10:50:52,873 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-keys-generate-ycji6n0i3jfb to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/ssh_keys_generate/console.log
+2019-09-09 10:50:52,885 - tests.cloud_tests - WARNING - test config modules/ssh_keys_provided is not enabled, skipping
+2019-09-09 10:50:52,926 - tests.cloud_tests - INFO - collecting test data for test: modules/timezone
+2019-09-09 10:50:53,957 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:51:08,990 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:51:12,377 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:51:12,378 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:51:12,446 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,447 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:51:12,447 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:51:12,505 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,506 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:51:12,506 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:51:12,567 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,569 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:51:12,569 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:51:12,625 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,626 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:51:12,626 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:51:12,687 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,689 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:51:12,689 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:51:12,745 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,746 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:51:12,746 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:51:12,816 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,817 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:51:12,817 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:51:12,878 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,879 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:51:12,879 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:51:12,990 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:12,991 - tests.cloud_tests - DEBUG - running collect script: timezone
+2019-09-09 10:51:12,991 - tests.cloud_tests - DEBUG - executing "collect: timezone"
+2019-09-09 10:51:13,050 - tests.cloud_tests - DEBUG - collect script timezone exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:13,137 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 4598 to end
+2019-09-09 10:51:14,909 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-timezone-97jx183y0ogb8bjplpt7l to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/timezone/console.log
+2019-09-09 10:51:14,952 - tests.cloud_tests - INFO - collecting test data for test: modules/user_groups
+2019-09-09 10:51:15,985 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:51:31,013 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:51:34,392 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:51:34,393 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:51:34,455 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,457 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:51:34,458 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:51:34,512 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,514 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:51:34,514 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:51:34,573 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,574 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:51:34,574 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:51:34,632 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,634 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:51:34,634 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:51:34,694 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,696 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:51:34,696 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:51:34,756 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,758 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:51:34,758 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:51:34,833 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,834 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:51:34,834 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:51:34,893 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,894 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:51:34,894 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:51:34,993 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:34,994 - tests.cloud_tests - DEBUG - running collect script: group_ubuntu
+2019-09-09 10:51:34,994 - tests.cloud_tests - DEBUG - executing "collect: group_ubuntu"
+2019-09-09 10:51:35,058 - tests.cloud_tests - DEBUG - collect script group_ubuntu exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,059 - tests.cloud_tests - DEBUG - running collect script: group_cloud_users
+2019-09-09 10:51:35,059 - tests.cloud_tests - DEBUG - executing "collect: group_cloud_users"
+2019-09-09 10:51:35,124 - tests.cloud_tests - DEBUG - collect script group_cloud_users exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,125 - tests.cloud_tests - DEBUG - running collect script: user_ubuntu
+2019-09-09 10:51:35,125 - tests.cloud_tests - DEBUG - executing "collect: user_ubuntu"
+2019-09-09 10:51:35,180 - tests.cloud_tests - DEBUG - collect script user_ubuntu exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,182 - tests.cloud_tests - DEBUG - running collect script: user_foobar
+2019-09-09 10:51:35,182 - tests.cloud_tests - DEBUG - executing "collect: user_foobar"
+2019-09-09 10:51:35,242 - tests.cloud_tests - DEBUG - collect script user_foobar exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,243 - tests.cloud_tests - DEBUG - running collect script: user_barfoo
+2019-09-09 10:51:35,243 - tests.cloud_tests - DEBUG - executing "collect: user_barfoo"
+2019-09-09 10:51:35,315 - tests.cloud_tests - DEBUG - collect script user_barfoo exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,316 - tests.cloud_tests - DEBUG - running collect script: user_cloudy
+2019-09-09 10:51:35,317 - tests.cloud_tests - DEBUG - executing "collect: user_cloudy"
+2019-09-09 10:51:35,375 - tests.cloud_tests - DEBUG - collect script user_cloudy exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,376 - tests.cloud_tests - DEBUG - running collect script: root_groups
+2019-09-09 10:51:35,376 - tests.cloud_tests - DEBUG - executing "collect: root_groups"
+2019-09-09 10:51:35,444 - tests.cloud_tests - DEBUG - collect script root_groups exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:35,528 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 8410 to end
+2019-09-09 10:51:37,165 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-user-groups-nwhp20d2z2hlf8wah7 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/user_groups/console.log
+2019-09-09 10:51:37,205 - tests.cloud_tests - INFO - collecting test data for test: modules/write_files
+2019-09-09 10:51:38,232 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:51:44,966 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:51:51,446 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:51:51,446 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:51:51,510 - tests.cloud_tests - DEBUG - collect script cloud-init.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,511 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:51:51,512 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:51:51,570 - tests.cloud_tests - DEBUG - collect script cloud-init-output.log exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,571 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:51:51,571 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:51:51,631 - tests.cloud_tests - DEBUG - collect script instance-id exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,632 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:51:51,632 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:51:51,690 - tests.cloud_tests - DEBUG - collect script instance-data.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,691 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:51:51,691 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:51:51,750 - tests.cloud_tests - DEBUG - collect script result.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,751 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:51:51,751 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:51:51,812 - tests.cloud_tests - DEBUG - collect script status.json exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,814 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:51:51,814 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:51:51,886 - tests.cloud_tests - DEBUG - collect script package-versions exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,887 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:51:51,887 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:51:51,945 - tests.cloud_tests - DEBUG - collect script build.info exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:51,946 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:51:51,946 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:51:52,042 - tests.cloud_tests - DEBUG - collect script system.journal.gz exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:52,043 - tests.cloud_tests - DEBUG - running collect script: file_b64
+2019-09-09 10:51:52,043 - tests.cloud_tests - DEBUG - executing "collect: file_b64"
+2019-09-09 10:51:52,120 - tests.cloud_tests - DEBUG - collect script file_b64 exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:52,121 - tests.cloud_tests - DEBUG - running collect script: file_text
+2019-09-09 10:51:52,121 - tests.cloud_tests - DEBUG - executing "collect: file_text"
+2019-09-09 10:51:52,182 - tests.cloud_tests - DEBUG - collect script file_text exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:52,183 - tests.cloud_tests - DEBUG - running collect script: file_binary
+2019-09-09 10:51:52,183 - tests.cloud_tests - DEBUG - executing "collect: file_binary"
+2019-09-09 10:51:52,243 - tests.cloud_tests - DEBUG - collect script file_binary exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:52,244 - tests.cloud_tests - DEBUG - running collect script: file_gzip
+2019-09-09 10:51:52,244 - tests.cloud_tests - DEBUG - executing "collect: file_gzip"
+2019-09-09 10:51:52,306 - tests.cloud_tests - DEBUG - collect script file_gzip exited 'b'sudo: unable to resolve host ubuntu\n'' and had stderr: 0
+2019-09-09 10:51:52,398 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 11583 to end
+2019-09-09 10:51:54,165 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-write-files-ax6oz5t1vq8z505jo3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results/nocloud-kvm/xenial/modules/write_files/console.log
+2019-09-09 10:51:54,186 - tests.cloud_tests - DEBUG - collect stages: {'name': 'collect data', 'time': 1108.4895153045654, 'errors': [], 'stages': [{'name': 'collect for platform: nocloud-kvm', 'time': 1108.1657145023346, 'errors': [], 'stages': [{'name': 'set up and collect data for os: xenial', 'time': 1100.7660593986511, 'errors': [], 'stages': [{'name': 'set up for ubuntu-xenial', 'time': 15.609371662139893, 'errors': [], 'stages': [{'name': 'setup func for --repo, enable repo', 'time': 8.838242769241333, 'errors': [], 'success': True}, {'name': 'setup func for --upgrade, upgrade cloud-init', 'time': 6.771092176437378, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect test data for xenial', 'time': 1084.3027176856995, 'errors': [], 'stages': [{}, {}, {'name': 'collect for test: bugs/lp1628337', 'time': 35.78475904464722, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.11980366706848, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06727790832519531, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06228208541870117, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0659785270690918, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06425142288208008, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0644681453704834, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0676887035369873, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08466124534606934, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.07288002967834473, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11533331871032715, 'errors': [], 'success': True}], 'success': True}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {'name': 'collect for test: main/command_output_simple', 'time': 20.15877652168274, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.440645694732666, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0710153579711914, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08989453315734863, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06172466278076172, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06534719467163086, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0600123405456543, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.060832977294921875, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08012843132019043, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06368279457092285, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09804797172546387, 'errors': [], 'success': True}, {'name': 'script cloud-init-test-output', 'time': 0.06729006767272949, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_conf', 'time': 20.04731774330139, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.427494525909424, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06396007537841797, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05873394012451172, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.056211233139038086, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05578255653381348, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05593395233154297, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05620884895324707, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06555342674255371, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05877375602722168, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09212565422058105, 'errors': [], 'success': True}, {'name': 'script 94cloud-init-config', 'time': 0.056416988372802734, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_disable_suites', 'time': 20.08142328262329, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.43455147743225, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06403183937072754, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05707836151123047, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05999422073364258, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05977988243103027, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06068587303161621, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05964970588684082, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07018756866455078, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0586392879486084, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.0962824821472168, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.06043362617492676, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_primary', 'time': 22.368848085403442, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 21.697887182235718, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06848931312561035, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06315302848815918, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05905413627624512, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05921292304992676, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05959677696228027, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0629727840423584, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0740044116973877, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06032228469848633, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09933924674987793, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.06461739540100098, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_proxy', 'time': 20.141422510147095, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.470393180847168, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06757569313049316, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.061903953552246094, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06353902816772461, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0637662410736084, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06279873847961426, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.057149648666381836, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07197260856628418, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06040048599243164, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09986305236816406, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-aptproxy', 'time': 0.06188631057739258, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_security', 'time': 29.65526533126831, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 28.942532062530518, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.07199215888977051, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06601333618164062, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06298160552978516, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06374239921569824, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06924271583557129, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06323480606079102, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08647370338439941, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06491279602050781, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09950613975524902, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.06446290016174316, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_key', 'time': 30.881693124771118, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.018770933151245, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.03328084945678711, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06194162368774414, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06611347198486328, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06565666198730469, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06404709815979004, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06404590606689453, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08234596252441406, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06528711318969727, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11279153823852539, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.06752634048461914, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.17969059944152832, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_keyserver', 'time': 35.32145547866821, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 34.5784387588501, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.026919841766357422, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05800294876098633, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06080937385559082, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06058216094970703, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.059276580810546875, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05996060371398926, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06969976425170898, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06251716613769531, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09756112098693848, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.058414459228515625, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.1291189193725586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_list', 'time': 20.133614540100098, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.483201503753662, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0641930103302002, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06223273277282715, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.059429168701171875, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05994057655334473, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.055335283279418945, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05963253974914551, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0734250545501709, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.060079097747802734, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09705972671508789, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.05894732475280762, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_ppa', 'time': 21.393362760543823, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 20.558613777160645, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.023394107818603516, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06236696243286133, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05992889404296875, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05996561050415039, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.060204267501831055, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.061213016510009766, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08005166053771973, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06221437454223633, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11590456962585449, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.0651404857635498, 'errors': [], 'success': True}, {'name': 'script apt-key', 'time': 0.15979647636413574, 'errors': [], 'success': True}, {'name': 'script sources_full', 'time': 0.02440810203552246, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_disable', 'time': 16.124043941497803, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.466419696807861, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06428718566894531, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.061301231384277344, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.059842824935913086, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.061473846435546875, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05989885330200195, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05876326560974121, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07384467124938965, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05893254280090332, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09824132919311523, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining', 'time': 0.06088137626647949, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_os', 'time': 23.727086067199707, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 23.091432094573975, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.022608041763305664, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06278872489929199, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06384968757629395, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06323075294494629, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.060253143310546875, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06055593490600586, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07293558120727539, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06075429916381836, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10821914672851562, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining_not_written', 'time': 0.060341835021972656, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/bootcmd', 'time': 14.82482123374939, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.158628940582275, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06346607208251953, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.059305667877197266, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06067967414855957, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.059266090393066406, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06089019775390625, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05973052978515625, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0726017951965332, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05868220329284668, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11081814765930176, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.06058049201965332, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/byobu', 'time': 20.154555320739746, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.405184984207153, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06980347633361816, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05804777145385742, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06296801567077637, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06273174285888672, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.058570146560668945, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06391787528991699, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07777547836303711, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06303596496582031, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11120104789733887, 'errors': [], 'success': True}, {'name': 'script byobu_profile_enabled', 'time': 0.06158280372619629, 'errors': [], 'success': True}, {'name': 'script byobu_launch_exists', 'time': 0.05957460403442383, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ca_certs', 'time': 20.17037010192871, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.41732931137085, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06477952003479004, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05936789512634277, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06030559539794922, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06060147285461426, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05971074104309082, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0673360824584961, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08222413063049316, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06434869766235352, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10707259178161621, 'errors': [], 'success': True}, {'name': 'script cert_links', 'time': 0.06420350074768066, 'errors': [], 'success': True}, {'name': 'script cert', 'time': 0.06294608116149902, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_disable', 'time': 19.984367847442627, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.39680814743042, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06363463401794434, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05945014953613281, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05974698066711426, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05937910079956055, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05991101264953613, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06060075759887695, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06940889358520508, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05818629264831543, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.0971364974975586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_enable', 'time': 13.659998655319214, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 13.060528993606567, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06222343444824219, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.056966304779052734, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06029367446899414, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.060198068618774414, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.061991214752197266, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.060405731201171875, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06823539733886719, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05970144271850586, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10934066772460938, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/final_message', 'time': 20.039199590682983, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.41682004928589, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06886458396911621, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06372952461242676, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06005668640136719, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05954313278198242, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06502795219421387, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.059363603591918945, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07083964347839355, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06540656089782715, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10941314697265625, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/keys_to_console', 'time': 20.191280364990234, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.47689652442932, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06281518936157227, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06678056716918945, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06335282325744629, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06414198875427246, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06408572196960449, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06479859352111816, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0801689624786377, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06049656867980957, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.12025976181030273, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.06734681129455566, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/locale', 'time': 22.497782707214355, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 21.68932819366455, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06792807579040527, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.059395790100097656, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06370711326599121, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.058753252029418945, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06085515022277832, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.060434579849243164, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0719904899597168, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06065702438354492, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.12389111518859863, 'errors': [], 'success': True}, {'name': 'script locale_default', 'time': 0.058277130126953125, 'errors': [], 'success': True}, {'name': 'script locale_a', 'time': 0.06065821647644043, 'errors': [], 'success': True}, {'name': 'script locale_gen', 'time': 0.06172037124633789, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_bridge', 'time': 18.604062795639038, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 17.834306001663208, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06171131134033203, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.060262441635131836, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05927777290344238, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.059447288513183594, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.059227705001831055, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06017041206359863, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07087564468383789, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.057005882263183594, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.0993204116821289, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.05720710754394531, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.060964107513427734, 'errors': [], 'success': True}, {'name': 'script lxc-bridge', 'time': 0.06409454345703125, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_dir', 'time': 20.161070585250854, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.429960012435913, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0692291259765625, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06061148643493652, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05974888801574707, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.060268402099609375, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06027722358703613, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06161379814147949, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07115316390991211, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.061620473861694336, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.099639892578125, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.0616915225982666, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.06506633758544922, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp', 'time': 33.46090221405029, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 32.71273374557495, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06165003776550293, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05723905563354492, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05989646911621094, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0556330680847168, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05613827705383301, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05814409255981445, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0698404312133789, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.055229902267456055, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09615540504455566, 'errors': [], 'success': True}, {'name': 'script ntp_installed', 'time': 0.060417890548706055, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_empty', 'time': 0.057297706604003906, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pool_list', 'time': 0.06038069725036621, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_chrony', 'time': 32.60589385032654, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.9415602684021, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06208062171936035, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05949521064758301, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0565035343170166, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06120133399963379, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.060190677642822266, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05974602699279785, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07051348686218262, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06657767295837402, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10143017768859863, 'errors': [], 'success': True}, {'name': 'script chrony_conf', 'time': 0.06645512580871582, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_pools', 'time': 23.62969660758972, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 22.782405138015747, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0237884521484375, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06297755241394043, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0619816780090332, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05947113037109375, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06039619445800781, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06431269645690918, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08029294013977051, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.061040639877319336, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09643173217773438, 'errors': [], 'success': True}, {'name': 'script ntp_installed_pools', 'time': 0.06926918029785156, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_pools', 'time': 0.06741809844970703, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pools', 'time': 0.06660342216491699, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.07312583923339844, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_servers', 'time': 29.01449155807495, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 28.158279418945312, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.07044100761413574, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06434106826782227, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06361961364746094, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06368446350097656, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06349968910217285, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.060010671615600586, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06990218162536621, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05793404579162598, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09833359718322754, 'errors': [], 'success': True}, {'name': 'script ntp_installed_servers', 'time': 0.05899310111999512, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_servers', 'time': 0.059271812438964844, 'errors': [], 'success': True}, {'name': 'script ntp_conf_servers', 'time': 0.059912919998168945, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.06607365608215332, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_timesyncd', 'time': 20.217003345489502, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.447768688201904, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06543445587158203, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.059981346130371094, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06344056129455566, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06818342208862305, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06421923637390137, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05953860282897949, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15233302116394043, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0634160041809082, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1125936508178711, 'errors': [], 'success': True}, {'name': 'script timesyncd_conf', 'time': 0.05992436408996582, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/package_update_upgrade_install', 'time': 38.32227110862732, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 37.59002089500427, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06539297103881836, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.061231374740600586, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06019473075866699, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06395483016967773, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.060175418853759766, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.05994534492492676, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0701453685760498, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06154632568359375, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09716320037841797, 'errors': [], 'success': True}, {'name': 'script apt_history_cmdline', 'time': 0.060303449630737305, 'errors': [], 'success': True}, {'name': 'script dpkg_show', 'time': 0.07198476791381836, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/runcmd', 'time': 24.234543561935425, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 23.589521408081055, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.023012399673461914, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05895709991455078, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06016945838928223, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06290078163146973, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.060864925384521484, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06979179382324219, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07780885696411133, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.060388803482055664, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10780072212219238, 'errors': [], 'success': True}, {'name': 'script run_cmd', 'time': 0.06319069862365723, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/seed_random_data', 'time': 20.116339445114136, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.421910047531128, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06338858604431152, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05684399604797363, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06329751014709473, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0643155574798584, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06603527069091797, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06340265274047852, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0785531997680664, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06398558616638184, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11292433738708496, 'errors': [], 'success': True}, {'name': 'script seed_data', 'time': 0.06152844429016113, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname', 'time': 23.748058319091797, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 23.033648014068604, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.022909164428710938, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.058138132095336914, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05905008316040039, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06009316444396973, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.055831193923950195, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.060028791427612305, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06997179985046387, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05784916877746582, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.08978104591369629, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.058725595474243164, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.060341835021972656, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.061548709869384766, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname_fqdn', 'time': 20.726306915283203, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.422439098358154, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.09764266014099121, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08949017524719238, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0959312915802002, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09210348129272461, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09699416160583496, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0919654369354248, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.11013364791870117, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08893895149230957, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.14061260223388672, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.09389424324035645, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.09427714347839355, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.2117140293121338, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password', 'time': 20.35290002822876, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.39933967590332, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06486749649047852, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05941128730773926, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.059119224548339844, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06614565849304199, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06191229820251465, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06328916549682617, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08032917976379395, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0633232593536377, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1117401123046875, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.252410888671875, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.07084846496582031, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_expire', 'time': 20.179298639297485, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.437156915664673, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06583213806152344, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05942583084106445, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06018829345703125, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.060013532638549805, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06897711753845215, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06528878211975098, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0761251449584961, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.061840057373046875, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10421991348266602, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.06025815010070801, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.05976557731628418, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list', 'time': 20.118256092071533, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.394250869750977, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.07286429405212402, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.062422990798950195, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06037712097167969, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06114983558654785, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.057762861251831055, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06438183784484863, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.06982231140136719, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05799078941345215, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09760069847106934, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.059301137924194336, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.060182809829711914, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list_string', 'time': 17.216979026794434, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 16.54892086982727, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.023755550384521484, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05813241004943848, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05939221382141113, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05957174301147461, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06084895133972168, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.058704376220703125, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07123303413391113, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05667591094970703, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09875607490539551, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.058588266372680664, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.06220841407775879, 'errors': [], 'success': True}], 'success': True}, {}, {}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_disable', 'time': 20.122451543807983, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.419628143310547, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0654909610748291, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.06754827499389648, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06909823417663574, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0626678466796875, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.05651211738586426, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06620621681213379, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.08141899108886719, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05946516990661621, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10724568367004395, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.06701445579528809, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_enable', 'time': 20.188822031021118, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.471672534942627, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06579732894897461, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0706472396850586, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.057706356048583984, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06369447708129883, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06870317459106445, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06339192390441895, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07789921760559082, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0638885498046875, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1197977066040039, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.06544661521911621, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_import_id', 'time': 22.27131962776184, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 21.616506814956665, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.061892032623291016, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0583341121673584, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.05954289436340332, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.060082435607910156, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.059496164321899414, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06079816818237305, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0707082748413086, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06198740005493164, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10036754608154297, 'errors': [], 'success': True}, {'name': 'script auth_keys_ubuntu', 'time': 0.0614316463470459, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_keys_generate', 'time': 20.566123723983765, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.435757160186768, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.07297611236572266, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.060361623764038086, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06688380241394043, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.06480526924133301, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0656585693359375, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06252431869506836, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0832815170288086, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05993819236755371, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10405778884887695, 'errors': [], 'success': True}, {'name': 'script dsa_public', 'time': 0.0651087760925293, 'errors': [], 'success': True}, {'name': 'script dsa_private', 'time': 0.05944705009460449, 'errors': [], 'success': True}, {'name': 'script rsa_public', 'time': 0.06080985069274902, 'errors': [], 'success': True}, {'name': 'script rsa_private', 'time': 0.06409859657287598, 'errors': [], 'success': True}, {'name': 'script ecdsa_public', 'time': 0.059076786041259766, 'errors': [], 'success': True}, {'name': 'script ecdsa_private', 'time': 0.06228995323181152, 'errors': [], 'success': True}, {'name': 'script ed25519_public', 'time': 0.05799055099487305, 'errors': [], 'success': True}, {'name': 'script ed25519_private', 'time': 0.060853004455566406, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/timezone', 'time': 20.115708351135254, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.44207215309143, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06977295875549316, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05920147895812988, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06225013732910156, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.057431936264038086, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06273746490478516, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.057448387145996094, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0706322193145752, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.06220269203186035, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.11176848411560059, 'errors': [], 'success': True}, {'name': 'script timezone', 'time': 0.0599970817565918, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/user_groups', 'time': 20.482227087020874, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.429706811904907, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06495380401611328, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.05663418769836426, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06013941764831543, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0598297119140625, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06175851821899414, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06190037727355957, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07620024681091309, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05992865562438965, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.10050463676452637, 'errors': [], 'success': True}, {'name': 'script group_ubuntu', 'time': 0.06464338302612305, 'errors': [], 'success': True}, {'name': 'script group_cloud_users', 'time': 0.06612038612365723, 'errors': [], 'success': True}, {'name': 'script user_ubuntu', 'time': 0.056478023529052734, 'errors': [], 'success': True}, {'name': 'script user_foobar', 'time': 0.06108403205871582, 'errors': [], 'success': True}, {'name': 'script user_barfoo', 'time': 0.07362604141235352, 'errors': [], 'success': True}, {'name': 'script user_cloudy', 'time': 0.0598454475402832, 'errors': [], 'success': True}, {'name': 'script root_groups', 'time': 0.06858134269714355, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/write_files', 'time': 15.094127178192139, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.233384132385254, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06520390510559082, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.059528350830078125, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.06078219413757324, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.05912947654724121, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.06006979942321777, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.06276249885559082, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.07333493232727051, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.05914783477783203, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.09669923782348633, 'errors': [], 'success': True}, {'name': 'script file_b64', 'time': 0.07828879356384277, 'errors': [], 'success': True}, {'name': 'script file_text', 'time': 0.06189227104187012, 'errors': [], 'success': True}, {'name': 'script file_binary', 'time': 0.06082606315612793, 'errors': [], 'success': True}, {'name': 'script file_gzip', 'time': 0.06288552284240723, 'errors': [], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}
+2019-09-09 10:51:54,190 - tests.cloud_tests - DEBUG - found test data: {'nocloud-kvm': {'xenial': ['bugs/lp1628337', 'modules/apt_configure_sources_list', 'modules/locale', 'modules/apt_configure_primary', 'modules/lxd_bridge', 'modules/apt_configure_security', 'modules/apt_pipelining_os', 'modules/ssh_import_id', 'modules/ntp_pools', 'modules/ssh_keys_generate', 'modules/ssh_auth_key_fingerprints_enable', 'modules/apt_configure_sources_keyserver', 'modules/bootcmd', 'modules/set_hostname_fqdn', 'modules/ssh_auth_key_fingerprints_disable', 'modules/final_message', 'modules/apt_configure_sources_key', 'modules/ntp_servers', 'modules/ntp_chrony', 'modules/write_files', 'modules/set_password', 'modules/ntp', 'modules/timezone', 'modules/keys_to_console', 'modules/debug_enable', 'modules/seed_random_data', 'modules/set_password_list', 'modules/user_groups', 'modules/debug_disable', 'modules/byobu', 'modules/apt_configure_proxy', 'modules/apt_configure_sources_ppa', 'modules/package_update_upgrade_install', 'modules/ntp_timesyncd', 'modules/lxd_dir', 'modules/apt_pipelining_disable', 'modules/runcmd', 'modules/set_hostname', 'modules/apt_configure_conf', 'modules/apt_configure_disable_suites', 'modules/set_password_list_string', 'modules/set_password_expire', 'modules/ca_certs', 'main/command_output_simple']}}
+
+2019-09-09 10:51:54,190 - tests.cloud_tests - INFO - test: platform='nocloud-kvm', os='xenial' verifying test data
+2019-09-09 10:51:54,190 - tests.cloud_tests - DEBUG - verifying test data for bugs/lp1628337
+test_fetch_indices (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify no apt errors. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify can find ntp and install it. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:54,234 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Unexpected warnings should not be found in the log. ... ok
+test_sources_list (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Test sources.list includes sources. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:54,277 - tests.cloud_tests - DEBUG - verifying test data for modules/locale
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_locale (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale is set properly. ... ok
+test_locale_a (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale -a has both options. ... ok
+test_locale_gen (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test local.gen file has all entries. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,320 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_primary
+test_gatech_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test GaTech entries exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Unexpected warnings should not be found in the log. ... ok
+test_ubuntu_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test no default Ubuntu entries exist. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,360 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_bridge
+test_bridge (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test bridge config. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_lxc (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,403 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_security
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Unexpected warnings should not be found in the log. ... ok
+test_security_mirror (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Test security lines added and uncommented in source.list. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,445 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_os
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Unexpected warnings should not be found in the log. ... ok
+test_os_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+test 'os' settings does not write apt config file. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,491 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_import_id
+test_authorized_keys (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Test that ssh keys were imported. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,529 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_pools
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test dist config file is empty ... ok
+test_ntp_entires (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 10:51:54,572 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_keys_generate
+test_dsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa private key not generated. ... ok
+test_dsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa public key not generated. ... ok
+test_ecdsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ecdsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ed25519_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_ed25519_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Unexpected warnings should not be found in the log. ... ok
+test_rsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+test_rsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+
+----------------------------------------------------------------------
+Ran 13 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:54,613 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_enable
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Unexpected warnings should not be found in the log. ... ok
+test_syslog (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Verify output of syslog. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:54,652 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_keyserver
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test specific key added. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,693 - tests.cloud_tests - DEBUG - verifying test data for modules/bootcmd
+test_bootcmd_host (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Test boot cmd worked. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,733 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname_fqdn
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname output. ... ok
+test_hostname_fqdn (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname fqdn output. ... ok
+test_hosts (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test /etc/hosts file. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,774 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_disable
+test_cloud_init_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Verify disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,812 - tests.cloud_tests - DEBUG - verifying test data for modules/final_message
+test_final_message_string (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure final handles regular strings. ... ok
+test_final_message_subs (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Test variable substitution in final message. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:54,853 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_key
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test key list updated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,895 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_servers
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test config server entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 10:51:54,938 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_chrony
+test_chrony_entries (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Test chrony config entries ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:54,978 - tests.cloud_tests - DEBUG - verifying test data for modules/write_files
+test_b64 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test b64 encoded file reads as ascii. ... ok
+test_binary (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test binary file reads as executable. ... ok
+test_gzip (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test gzip file shows up as a shell script. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Unexpected warnings should not be found in the log. ... ok
+test_text (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test text shows up as ASCII text. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,018 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test ubuntu user in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,057 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test ntp installed ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:55,099 - tests.cloud_tests - DEBUG - verifying test data for modules/timezone
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Unexpected warnings should not be found in the log. ... ok
+test_timezone (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Test date prints correct timezone. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,138 - tests.cloud_tests - DEBUG - verifying test data for modules/keys_to_console
+test_excluded_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test excluded keys missing. ... ok
+test_expected_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test expected keys exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,178 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_enable
+test_debug_enable (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Test debug messages in cloud-init log. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,220 - tests.cloud_tests - DEBUG - verifying test data for modules/seed_random_data
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Unexpected warnings should not be found in the log. ... ok
+test_random_seed_data (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Test random data passed in exists. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,260 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 10:51:55,303 - tests.cloud_tests - DEBUG - verifying test data for modules/user_groups
+test_group_cloud_users (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloud users group exists. ... ok
+test_group_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu group exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Unexpected warnings should not be found in the log. ... ok
+test_user_barfoo (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test barfoo user exists. ... ok
+test_user_cloudy (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloudy user exists. ... ok
+test_user_foobar (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test foobar user exists. ... ok
+test_user_root_in_secret (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test root user is in 'secret' group. ... ok
+test_user_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu user exists. ... ok
+
+----------------------------------------------------------------------
+Ran 12 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:55,343 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_disable
+test_debug_disable (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Test verbose output missing from logs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,383 - tests.cloud_tests - DEBUG - verifying test data for modules/byobu
+test_byobu_installed (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu installed. ... ok
+test_byobu_launch_exists (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu-launch exists. ... ok
+test_byobu_profile_enabled (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu profile.d file exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,424 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_proxy
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Unexpected warnings should not be found in the log. ... ok
+test_proxy_config (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Test proxy options added to apt config. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,514 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_ppa
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Unexpected warnings should not be found in the log. ... ok
+test_ppa (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test specific ppa added. ... ok
+test_ppa_key (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test ppa key added. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,597 - tests.cloud_tests - DEBUG - verifying test data for modules/package_update_upgrade_install
+test_apt_history (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test apt history for update command. ... ok
+test_cloud_init_output (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test cloud-init-output for install & upgrade stuff. ... ok
+test_installed_sl (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test sl got installed. ... ok
+test_installed_tree (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test tree got installed. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:55,675 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_timesyncd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Unexpected warnings should not be found in the log. ... ok
+test_timesyncd_entries (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Test timesyncd config entries ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,749 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_dir
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_lxc (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,822 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_disable
+test_disable_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Test pipelining disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,900 - tests.cloud_tests - DEBUG - verifying test data for modules/runcmd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Unexpected warnings should not be found in the log. ... ok
+test_run_cmd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Test run command worked. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:55,966 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Test hostname command shows correct output. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:56,045 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_conf
+test_apt_conf_assumeyes (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config assumes true. ... ok
+test_apt_conf_fixbroken (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config fixes broken. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:56,118 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_disable_suites
+test_empty_sourcelist (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Test source list is empty. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:56,156 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list_string
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 10:51:56,194 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_expire
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test user frozen in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:56,238 - tests.cloud_tests - DEBUG - verifying test data for modules/ca_certs
+test_cert_installed (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test line from our cert exists. ... ok
+test_certs_updated (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test certs have been updated in /etc/ssl/certs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:51:56,279 - tests.cloud_tests - DEBUG - verifying test data for main/command_output_simple
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Unexpected warnings should not be found in the log. ... ok
+test_output_file (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that the output file is not empty and has all stages. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:51:56,319 - tests.cloud_tests - INFO - test: platform='nocloud-kvm', os='xenial' passed all tests
+2019-09-09 10:51:56,319 - tests.cloud_tests - DEBUG - 
+---- Verify summarized results:
+
+Platform: nocloud-kvm
+  Distro: xenial
+    test modules passed:44 tests failed:0
+2019-09-09 10:51:56,319 - tests.cloud_tests - INFO - leaving data in /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-kvm/cloud-init/results
+___________________________________ summary ____________________________________
+  citest: commands succeeded
+  congratulations :)
++ RET=0
++ find . -name id_rsa* -delete
++ exit 0
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS
+=== End series x ===
+=== Begin series d ===
+Started by remote host 10.247.8.15
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm
+[cloud-init-integration-proposed-d-kvm] $ /bin/sh -xe /tmp/jenkins10486458557534962147.sh
++ release=disco
++ release_ver=19.04
++ platform=nocloud-kvm
++ set -e
++ sudo rm -Rf cloud-init
++ git clone https://git.launchpad.net/cloud-init
+Cloning into 'cloud-init'...
++ cd cloud-init
++ git tag --list
++ grep 19.04
++ tail -1
++ tag=ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
++ echo Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
+Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
++ git checkout ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
+Note: checking out 'ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at f0141fe0 releasing cloud-init version 19.2-24-ge7881d5c-0ubuntu1~19.04.1
++ mirror=http://archive.ubuntu.com/ubuntu/
++ hostname
++ [ -z  -a torkoal = torkoal ]
++ export TMPDIR=/var/lib/jenkins/tmp/
++ set +e
++ no_proxy=launchpad.net https_proxy=http://squid.internal:3128 tox -e citest -- run --os-name=disco --platform=nocloud-kvm --repo='deb http://archive.ubuntu.com/ubuntu/ disco-proposed main' --preserve-data --data-dir=./results --verbose
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/setup.py
+citest create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/.tox/citest
+citest installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/integration-requirements.txt
+citest inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/.tox/dist/cloud-init-19.2.zip
+citest installed: asn1crypto==0.24.0,attrs==19.1.0,bcrypt==3.1.7,boto3==1.5.9,botocore==1.8.50,certifi==2019.6.16,cffi==1.12.3,chardet==3.0.4,cloud-init==19.2,configobj==5.0.6,cryptography==2.4.2,docutils==0.15.2,idna==2.8,Jinja2==2.10.1,jmespath==0.9.4,jsonpatch==1.24,jsonpointer==2.0,jsonschema==3.0.2,linecache2==1.0.0,MarkupSafe==1.1.1,oauthlib==3.1.0,paramiko==2.4.2,pbr==5.4.3,pkg-resources==0.0.0,pyasn1==0.4.7,pycparser==2.19,pylxd==2.2.7,PyNaCl==1.3.0,pyrsistent==0.15.4,python-dateutil==2.8.0,python-simplestreams==0.1.0,PyYAML==5.1.2,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,s3transfer==0.1.13,six==1.12.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.3,ws4py==0.5.1
+citest runtests: PYTHONHASHSEED='913910815'
+citest runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=disco --platform=nocloud-kvm --repo=deb http://archive.ubuntu.com/ubuntu/ disco-proposed main --preserve-data --data-dir=./results --verbose
+2019-09-09 10:16:02,640 - tests.cloud_tests - DEBUG - running with args: Namespace(data_dir='/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results', deb=None, feature_override={}, os_name=['disco'], platform=['nocloud-kvm'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo='deb http://archive.ubuntu.com/ubuntu/ disco-proposed main', result=None, rpm=None, script=None, subcmd='run', test_config=['/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1511485.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1611074.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/bugs/lp1628337.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/add_apt_repositories.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/alter_completion_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/configure_instance_trusted_ca_certificates.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/configure_instances_ssh_keys.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/including_user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/install_arbitrary_packages.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/install_run_chef_recipes.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_apt_upgrade.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_commands.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/run_commands_first_boot.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/setup_run_puppet.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/examples/writing_out_arbitrary_files.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/main/command_output_simple.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_conf.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_disable_suites.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_primary.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_proxy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_security.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_key.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_keyserver.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_os.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/bootcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/byobu.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ca_certs.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/debug_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/debug_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/final_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/keys_to_console.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/landscape.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/locale.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/lxd_bridge.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/lxd_dir.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_chrony.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_pools.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_servers.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ntp_timesyncd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/package_update_upgrade_install.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/runcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/seed_random_command.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/seed_random_data.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_hostname.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_hostname_fqdn.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_expire.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/set_password_list_string.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/snap.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/snappy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_import_id.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_generate.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_provided.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/timezone.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/tests/cloud_tests/testcases/modules/write_files.yaml'], upgrade=True, upgrade_full=False, verbose=True)
+2019-09-09 10:16:02,640 - tests.cloud_tests - DEBUG - using tmpdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results
+2019-09-09 10:16:02,649 - tests.cloud_tests - DEBUG - platform config: {'enabled': True, 'get_image_timeout': 300, 'create_instance_timeout': 60, 'private_key': 'cloud_init_rsa', 'public_key': 'cloud_init_rsa.pub', 'cache_mode': 'cache=none,aio=native', 'data_dir': '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results'}
+2019-09-09 10:16:02,649 - tests.cloud_tests - INFO - setting up platform: nocloud-kvm
+2019-09-09 10:16:03,414 - tests.cloud_tests - DEBUG - os config: {'enabled': True, 'boot_timeout': 120, 'boot_clean_script': '#!/bin/bash\nrm -rf /var/log/cloud-init.log /var/log/cloud-init-output.log \\\n    /var/lib/cloud/ /run/cloud-init/ /var/log/syslog\n', 'system_ready_script': "# permit running or degraded state as both indicate complete boot\n[ $(systemctl is-system-running) = 'running' -o\n  $(systemctl is-system-running) = 'degraded' ]\n", 'cloud_init_ready_script': "[ -f '/run/cloud-init/result.json' ]\n", 'feature_groups': ['base', 'debian_base', 'ubuntu_specific'], 'features': {'apt': True, 'byobu': True, 'landscape': True, 'lxd': True, 'ppa': True, 'rpm': None, 'snap': True, 'hostname': True, 'apt_src_cont': True, 'apt_hist_fmt': True, 'daylight_time': True, 'apt_up_out': True, 'engb_locale': True, 'locale_gen': True, 'no_ntpdate': True, 'no_file_fmt_e': True, 'ppa_file_name': True, 'sshd': True, 'ssh_key_fmt': True, 'syslog': True, 'ubuntu_ntp': True, 'ubuntu_repos': True, 'ubuntu_user': True, 'lsb_release': True, 'sudo': True}, 'mirror_url': 'https://cloud-images.ubuntu.com/daily', 'mirror_dir': '/srv/citest/images', 'keyring': '/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg', 'version': 19.04, 'setup_overrides': None, 'override_templates': False, 'release': 'disco', 'os': 'ubuntu', 'arch': 'amd64'}
+2019-09-09 10:16:03,414 - tests.cloud_tests - INFO - acquiring image for os: disco
+2019-09-09 10:16:10,608 - tests.cloud_tests - DEBUG - updating args for setup with: None
+2019-09-09 10:16:11,496 - tests.cloud_tests - INFO - setting up ubuntu-disco (build_name=server serial=20190904)
+2019-09-09 10:16:11,497 - tests.cloud_tests - DEBUG - enable repo: "deb http://archive.ubuntu.com/ubuntu/ disco-proposed main" in target
+2019-09-09 10:16:11,497 - tests.cloud_tests - DEBUG - executing "enable repo: "deb http://archive.ubuntu.com/ubuntu/ disco-proposed main" in target"
+2019-09-09 10:16:20,952 - tests.cloud_tests - DEBUG - upgrading cloud-init
+2019-09-09 10:16:20,952 - tests.cloud_tests - DEBUG - executing "upgrading cloud-init"
+2019-09-09 10:16:27,719 - tests.cloud_tests - DEBUG - creating snapshot for disco
+2019-09-09 10:16:27,907 - tests.cloud_tests - INFO - collecting test data for os: disco
+2019-09-09 10:16:27,912 - tests.cloud_tests - WARNING - test config bugs/lp1511485 is not enabled, skipping
+2019-09-09 10:16:27,916 - tests.cloud_tests - WARNING - test config bugs/lp1611074 is not enabled, skipping
+2019-09-09 10:16:27,958 - tests.cloud_tests - INFO - collecting test data for test: bugs/lp1628337
+2019-09-09 10:16:29,009 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:16:44,089 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:17:01,822 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:17:01,823 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:17:01,878 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:17:01,878 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:17:01,970 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:17:01,971 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:17:02,063 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:17:02,063 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:17:02,157 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:17:02,158 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:17:02,258 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:17:02,259 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:17:02,355 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:17:02,355 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:17:02,456 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:17:02,456 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:17:02,551 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:17:02,551 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:17:02,841 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 4139 to end
+2019-09-09 10:17:08,073 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-bugs-lp1628337-8zp9yoxspdc9ln4u87b65pew to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/bugs/lp1628337/console.log
+2019-09-09 10:17:08,079 - tests.cloud_tests - WARNING - test config examples/add_apt_repositories is not enabled, skipping
+2019-09-09 10:17:08,083 - tests.cloud_tests - WARNING - test config examples/alter_completion_message is not enabled, skipping
+2019-09-09 10:17:08,093 - tests.cloud_tests - WARNING - test config examples/configure_instance_trusted_ca_certificates is not enabled, skipping
+2019-09-09 10:17:08,107 - tests.cloud_tests - WARNING - test config examples/configure_instances_ssh_keys is not enabled, skipping
+2019-09-09 10:17:08,113 - tests.cloud_tests - WARNING - test config examples/including_user_groups is not enabled, skipping
+2019-09-09 10:17:08,117 - tests.cloud_tests - WARNING - test config examples/install_arbitrary_packages is not enabled, skipping
+2019-09-09 10:17:08,125 - tests.cloud_tests - WARNING - test config examples/install_run_chef_recipes is not enabled, skipping
+2019-09-09 10:17:08,130 - tests.cloud_tests - WARNING - test config examples/run_apt_upgrade is not enabled, skipping
+2019-09-09 10:17:08,134 - tests.cloud_tests - WARNING - test config examples/run_commands is not enabled, skipping
+2019-09-09 10:17:08,139 - tests.cloud_tests - WARNING - test config examples/run_commands_first_boot is not enabled, skipping
+2019-09-09 10:17:08,145 - tests.cloud_tests - WARNING - test config examples/setup_run_puppet is not enabled, skipping
+2019-09-09 10:17:08,150 - tests.cloud_tests - WARNING - test config examples/writing_out_arbitrary_files is not enabled, skipping
+2019-09-09 10:17:08,188 - tests.cloud_tests - INFO - collecting test data for test: main/command_output_simple
+2019-09-09 10:17:09,734 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:17:24,759 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:17:40,137 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:17:40,137 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:17:40,194 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:17:40,194 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:17:40,287 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:17:40,287 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:17:40,379 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:17:40,379 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:17:40,471 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:17:40,471 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:17:40,563 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:17:40,563 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:17:40,655 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:17:40,655 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:17:40,754 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:17:40,755 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:17:40,847 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:17:40,847 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:17:41,027 - tests.cloud_tests - DEBUG - running collect script: cloud-init-test-output
+2019-09-09 10:17:41,027 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-test-output"
+2019-09-09 10:17:41,220 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 11205 to end
+2019-09-09 10:17:46,490 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-main-command-output-simple-z9yzo1ur4qms to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/main/command_output_simple/console.log
+2019-09-09 10:17:46,536 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_conf
+2019-09-09 10:17:47,561 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:18:02,585 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:18:30,032 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:18:30,033 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:18:30,090 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:18:30,090 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:18:30,183 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:18:30,183 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:18:30,274 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:18:30,275 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:18:30,366 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:18:30,367 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:18:30,458 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:18:30,459 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:18:30,551 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:18:30,551 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:18:30,651 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:18:30,651 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:18:30,742 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:18:30,743 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:18:30,918 - tests.cloud_tests - DEBUG - running collect script: 94cloud-init-config
+2019-09-09 10:18:30,918 - tests.cloud_tests - DEBUG - executing "collect: 94cloud-init-config"
+2019-09-09 10:18:31,114 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18708 to end
+2019-09-09 10:18:36,513 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-conf-p0ke098v1wsl to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_conf/console.log
+2019-09-09 10:18:36,569 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_disable_suites
+2019-09-09 10:18:37,602 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:18:52,627 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:19:18,695 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:19:18,695 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:19:18,756 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:19:18,756 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:19:18,847 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:19:18,847 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:19:18,939 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:19:18,939 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:19:19,035 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:19:19,035 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:19:19,127 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:19:19,127 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:19:19,219 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:19:19,219 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:19:19,320 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:19:19,321 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:19:19,412 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:19:19,412 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:19:19,594 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:19:19,595 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:19:19,795 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 27976 to end
+2019-09-09 10:19:25,613 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-disable--5jfkhvig to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_disable_suites/console.log
+2019-09-09 10:19:25,656 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_primary
+2019-09-09 10:19:27,384 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:19:42,409 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:19:56,200 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:19:56,200 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:19:56,257 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:19:56,257 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:19:56,347 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:19:56,347 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:19:56,438 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:19:56,439 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:19:56,543 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:19:56,543 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:19:56,637 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:19:56,637 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:19:56,731 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:19:56,732 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:19:56,838 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:19:56,838 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:19:56,935 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:19:56,935 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:19:57,116 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:19:57,117 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:19:57,378 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 3875 to end
+2019-09-09 10:20:02,909 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-primary-t1m1xz2cq to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_primary/console.log
+2019-09-09 10:20:02,949 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_proxy
+2019-09-09 10:20:03,977 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:20:19,003 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:20:34,619 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:20:34,620 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:20:34,681 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:20:34,681 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:20:34,784 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:20:34,784 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:20:34,879 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:20:34,879 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:20:34,981 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:20:34,981 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:20:35,079 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:20:35,079 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:20:35,172 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:20:35,172 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:20:35,271 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:20:35,271 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:20:35,363 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:20:35,363 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:20:35,545 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-aptproxy
+2019-09-09 10:20:35,546 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-aptproxy"
+2019-09-09 10:20:35,735 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 10822 to end
+2019-09-09 10:20:41,001 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-proxy-l4px6eec5ni to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_proxy/console.log
+2019-09-09 10:20:41,040 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_security
+2019-09-09 10:20:42,075 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:20:57,099 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:21:14,403 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:21:14,404 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:21:14,457 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:21:14,457 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:21:14,547 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:21:14,547 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:21:14,639 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:21:14,639 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:21:14,730 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:21:14,730 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:21:14,823 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:21:14,823 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:21:14,915 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:21:14,915 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:21:15,019 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:21:15,019 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:21:15,119 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:21:15,120 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:21:15,350 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:21:15,350 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:21:15,577 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18249 to end
+2019-09-09 10:21:20,821 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-security-xlrmo5z1 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_security/console.log
+2019-09-09 10:21:20,864 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_key
+2019-09-09 10:21:21,898 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:21:36,924 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:22:00,814 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:22:00,814 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:22:00,880 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:22:00,880 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:22:00,977 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:22:00,977 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:22:01,066 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:22:01,067 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:22:01,160 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:22:01,160 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:22:01,251 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:22:01,252 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:22:01,344 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:22:01,344 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:22:01,445 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:22:01,445 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:22:01,535 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:22:01,535 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:22:01,725 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:22:01,726 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:22:01,818 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:22:01,818 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:22:02,018 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:22:02,278 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 28284 to end
+2019-09-09 10:22:07,529 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--8t8tl3yu to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_sources_key/console.log
+2019-09-09 10:22:07,580 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_keyserver
+2019-09-09 10:22:08,611 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:22:23,636 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:22:46,640 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:22:46,641 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:22:46,697 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:22:46,697 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:22:46,786 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:22:46,787 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:22:46,878 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:22:46,878 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:22:46,970 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:22:46,970 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:22:47,062 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:22:47,062 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:22:47,154 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:22:47,154 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:22:47,256 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:22:47,256 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:22:47,346 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:22:47,347 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:22:47,517 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:22:47,518 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:22:47,612 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:22:47,612 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:22:47,828 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:22:48,226 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 7352 to end
+2019-09-09 10:22:53,277 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--x6k6vwjm to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_sources_keyserver/console.log
+2019-09-09 10:22:53,361 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_list
+2019-09-09 10:22:54,392 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:23:09,417 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:23:21,848 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:23:21,848 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:23:21,909 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:23:21,909 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:23:22,000 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:23:22,000 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:23:22,090 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:23:22,090 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:23:22,183 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:23:22,183 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:23:22,274 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:23:22,274 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:23:22,367 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:23:22,367 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:23:22,467 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:23:22,468 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:23:22,559 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:23:22,559 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:23:22,730 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:23:22,730 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:23:22,918 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19844 to end
+2019-09-09 10:23:28,261 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--xhghsgp5 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_sources_list/console.log
+2019-09-09 10:23:28,313 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_ppa
+2019-09-09 10:23:29,351 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:23:44,376 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:24:10,425 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:24:10,425 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:24:10,484 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:24:10,484 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:24:10,576 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:24:10,577 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:24:10,668 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:24:10,668 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:24:10,759 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:24:10,760 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:24:10,852 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:24:10,852 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:24:10,948 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:24:10,948 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:24:11,054 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:24:11,054 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:24:11,144 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:24:11,144 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:24:11,325 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:24:11,325 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:24:11,418 - tests.cloud_tests - DEBUG - running collect script: apt-key
+2019-09-09 10:24:11,418 - tests.cloud_tests - DEBUG - executing "collect: apt-key"
+2019-09-09 10:24:11,621 - tests.cloud_tests - DEBUG - collect script apt-key exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:24:11,623 - tests.cloud_tests - DEBUG - running collect script: sources_full
+2019-09-09 10:24:11,623 - tests.cloud_tests - DEBUG - executing "collect: sources_full"
+2019-09-09 10:24:11,795 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 30418 to end
+2019-09-09 10:24:17,121 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--su52d3x9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_configure_sources_ppa/console.log
+2019-09-09 10:24:17,160 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_disable
+2019-09-09 10:24:18,187 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:24:33,218 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:24:36,434 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:24:39,439 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:24:42,441 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 10:24:45,444 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:25:31,395 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:25:31,396 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:25:31,452 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:25:31,452 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:25:31,543 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:25:31,543 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:25:31,636 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:25:31,636 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:25:31,731 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:25:31,731 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:25:31,823 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:25:31,823 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:25:31,919 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:25:31,919 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:25:32,020 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:25:32,020 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:25:32,115 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:25:32,115 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:25:32,299 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining
+2019-09-09 10:25:32,299 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining"
+2019-09-09 10:25:32,522 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 11606 to end
+2019-09-09 10:25:38,005 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-pipelining-disable-8mbmtaej to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_pipelining_disable/console.log
+2019-09-09 10:25:38,045 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_os
+2019-09-09 10:25:39,161 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:25:54,190 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:26:03,831 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:26:07,015 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:26:10,017 - tests.cloud_tests - WARNING - failed to connect via SSH
+2019-09-09 10:26:13,020 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:26:28,822 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:26:28,823 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:26:28,880 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:26:28,880 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:26:28,972 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:26:28,972 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:26:29,063 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:26:29,063 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:26:29,157 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:26:29,157 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:26:29,251 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:26:29,251 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:26:29,343 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:26:29,343 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:26:29,445 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:26:29,445 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:26:29,540 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:26:29,540 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:26:29,780 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining_not_written
+2019-09-09 10:26:29,780 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining_not_written"
+2019-09-09 10:26:29,877 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining_not_written exited 'b"ls: cannot access '/etc/apt/apt.conf.d/90cloud-init-pipelining': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:26:29,979 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 4171 to end
+2019-09-09 10:26:35,281 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-pipelining-os-dhq8qi57usws9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/apt_pipelining_os/console.log
+2019-09-09 10:26:35,316 - tests.cloud_tests - INFO - collecting test data for test: modules/bootcmd
+2019-09-09 10:26:36,357 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:26:51,382 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:27:23,100 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:27:23,100 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:27:23,157 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:27:23,157 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:27:23,250 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:27:23,251 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:27:23,343 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:27:23,343 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:27:23,434 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:27:23,435 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:27:23,527 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:27:23,527 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:27:23,618 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:27:23,618 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:27:23,720 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:27:23,720 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:27:23,810 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:27:23,811 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:27:23,992 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:27:23,992 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:27:24,237 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 21886 to end
+2019-09-09 10:27:29,605 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-bootcmd-cb5kimmvjn9bqa8ppqu5gly to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/bootcmd/console.log
+2019-09-09 10:27:29,689 - tests.cloud_tests - INFO - collecting test data for test: modules/byobu
+2019-09-09 10:27:30,743 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:27:45,774 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:28:11,759 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:28:11,760 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:28:11,812 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:28:11,813 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:28:11,902 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:28:11,902 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:28:11,994 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:28:11,994 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:28:12,086 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:28:12,086 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:28:12,178 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:28:12,178 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:28:12,270 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:28:12,270 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:28:12,370 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:28:12,371 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:28:12,462 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:28:12,463 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:28:12,641 - tests.cloud_tests - DEBUG - running collect script: byobu_profile_enabled
+2019-09-09 10:28:12,641 - tests.cloud_tests - DEBUG - executing "collect: byobu_profile_enabled"
+2019-09-09 10:28:12,734 - tests.cloud_tests - DEBUG - running collect script: byobu_launch_exists
+2019-09-09 10:28:12,735 - tests.cloud_tests - DEBUG - executing "collect: byobu_launch_exists"
+2019-09-09 10:28:13,085 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 6690 to end
+2019-09-09 10:28:18,261 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-byobu-y2rhd88a0xv8xwcy7px4uzsei to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/byobu/console.log
+2019-09-09 10:28:18,331 - tests.cloud_tests - INFO - collecting test data for test: modules/ca_certs
+2019-09-09 10:28:19,367 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:28:34,395 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:28:49,788 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:28:49,789 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:28:49,846 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:28:49,846 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:28:49,940 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:28:49,941 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:28:50,031 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:28:50,031 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:28:50,123 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:28:50,124 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:28:50,215 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:28:50,215 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:28:50,308 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:28:50,308 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:28:50,408 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:28:50,408 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:28:50,499 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:28:50,499 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:28:50,681 - tests.cloud_tests - DEBUG - running collect script: cert_links
+2019-09-09 10:28:50,681 - tests.cloud_tests - DEBUG - executing "collect: cert_links"
+2019-09-09 10:28:50,776 - tests.cloud_tests - DEBUG - running collect script: cert
+2019-09-09 10:28:50,776 - tests.cloud_tests - DEBUG - executing "collect: cert"
+2019-09-09 10:28:51,016 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22008 to end
+2019-09-09 10:28:56,333 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ca-certs-0rmdksfbjurpmyvk2wql1m to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ca_certs/console.log
+2019-09-09 10:28:56,375 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_disable
+2019-09-09 10:28:57,405 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:29:12,430 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:29:31,182 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:29:31,182 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:29:31,247 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:29:31,247 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:29:31,351 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:29:31,351 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:29:31,447 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:29:31,447 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:29:31,538 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:29:31,539 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:29:31,631 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:29:31,631 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:29:31,723 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:29:31,723 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:29:31,831 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:29:31,832 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:29:31,923 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:29:31,924 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:29:32,297 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 632 to end
+2019-09-09 10:29:37,465 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-debug-disable-32x75gs0pwx2dw562 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/debug_disable/console.log
+2019-09-09 10:29:37,504 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_enable
+2019-09-09 10:29:38,531 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:29:53,555 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:30:11,405 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:30:11,405 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:30:11,463 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:30:11,463 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:30:11,555 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:30:11,555 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:30:11,652 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:30:11,652 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:30:11,743 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:30:11,743 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:30:11,836 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:30:11,836 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:30:11,928 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:30:11,928 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:30:12,033 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:30:12,033 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:30:12,124 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:30:12,124 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:30:12,415 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 10402 to end
+2019-09-09 10:30:17,769 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-debug-enable-qw2ohrt7w8uwvldcfj to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/debug_enable/console.log
+2019-09-09 10:30:17,811 - tests.cloud_tests - INFO - collecting test data for test: modules/final_message
+2019-09-09 10:30:18,861 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:30:33,892 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:30:48,320 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:30:48,320 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:30:48,377 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:30:48,377 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:30:48,467 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:30:48,467 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:30:48,559 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:30:48,559 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:30:48,651 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:30:48,651 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:30:48,743 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:30:48,743 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:30:48,835 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:30:48,835 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:30:48,935 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:30:48,935 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:30:49,027 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:30:49,027 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:30:49,293 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22502 to end
+2019-09-09 10:30:54,581 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-final-message-ic5gn07cvoiz7q46d to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/final_message/console.log
+2019-09-09 10:30:54,619 - tests.cloud_tests - INFO - collecting test data for test: modules/keys_to_console
+2019-09-09 10:30:55,649 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:31:10,675 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:31:29,189 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:31:29,189 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:31:29,244 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:31:29,244 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:31:29,339 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:31:29,339 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:31:29,440 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:31:29,440 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:31:29,537 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:31:29,537 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:31:29,650 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:31:29,650 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:31:29,745 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:31:29,745 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:31:29,848 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:31:29,848 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:31:29,940 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:31:29,940 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:31:30,118 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:31:30,119 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:31:30,445 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 453 to end
+2019-09-09 10:31:35,601 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-keys-to-console-61wtcxogye1w84r to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/keys_to_console/console.log
+2019-09-09 10:31:35,607 - tests.cloud_tests - WARNING - test config modules/landscape is not enabled, skipping
+2019-09-09 10:31:35,648 - tests.cloud_tests - INFO - collecting test data for test: modules/locale
+2019-09-09 10:31:36,681 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:31:51,709 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:32:12,182 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:32:12,182 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:32:12,241 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:32:12,242 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:32:12,332 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:32:12,332 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:32:12,427 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:32:12,427 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:32:12,519 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:32:12,519 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:32:12,623 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:32:12,623 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:32:12,726 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:32:12,727 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:32:12,833 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:32:12,833 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:32:12,932 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:32:12,932 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:32:13,118 - tests.cloud_tests - DEBUG - running collect script: locale_default
+2019-09-09 10:32:13,118 - tests.cloud_tests - DEBUG - executing "collect: locale_default"
+2019-09-09 10:32:13,214 - tests.cloud_tests - DEBUG - running collect script: locale_a
+2019-09-09 10:32:13,214 - tests.cloud_tests - DEBUG - executing "collect: locale_a"
+2019-09-09 10:32:13,308 - tests.cloud_tests - DEBUG - running collect script: locale_gen
+2019-09-09 10:32:13,308 - tests.cloud_tests - DEBUG - executing "collect: locale_gen"
+2019-09-09 10:32:13,537 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 15191 to end
+2019-09-09 10:32:18,945 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-locale-8e9yrjvtrzcj46cwig2ms4by to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/locale/console.log
+2019-09-09 10:32:18,984 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_bridge
+2019-09-09 10:32:20,011 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:32:35,044 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:32:38,048 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:33:01,815 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:33:01,816 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:33:01,874 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:33:01,874 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:33:01,967 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:33:01,967 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:33:02,063 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:33:02,063 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:33:02,159 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:33:02,159 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:33:02,251 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:33:02,251 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:33:02,351 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:33:02,351 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:33:02,456 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:33:02,456 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:33:02,555 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:33:02,557 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:33:02,741 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 10:33:02,741 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 10:33:02,834 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 10:33:02,834 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 10:33:02,929 - tests.cloud_tests - DEBUG - running collect script: lxc-bridge
+2019-09-09 10:33:02,929 - tests.cloud_tests - DEBUG - executing "collect: lxc-bridge"
+2019-09-09 10:33:03,142 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 29513 to end
+2019-09-09 10:33:08,549 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-lxd-bridge-w4jo8mbw73hz4erl04kw to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/lxd_bridge/console.log
+2019-09-09 10:33:08,604 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_dir
+2019-09-09 10:33:09,635 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:33:24,666 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:33:49,927 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:33:49,927 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:33:49,981 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:33:49,982 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:33:50,072 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:33:50,072 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:33:50,164 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:33:50,164 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:33:50,259 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:33:50,259 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:33:50,351 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:33:50,351 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:33:50,444 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:33:50,445 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:33:50,549 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:33:50,549 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:33:50,640 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:33:50,640 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:33:50,820 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 10:33:50,821 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 10:33:50,921 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 10:33:50,921 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 10:33:51,103 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 12954 to end
+2019-09-09 10:33:56,597 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-lxd-dir-iorm2nqhiu9aqdsp243ewhd to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/lxd_dir/console.log
+2019-09-09 10:33:56,638 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp
+2019-09-09 10:33:57,669 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:34:12,696 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:34:54,082 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:34:54,082 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:34:54,141 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:34:54,142 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:34:54,244 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:34:54,244 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:34:54,340 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:34:54,340 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:34:54,439 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:34:54,439 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:34:54,531 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:34:54,531 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:34:54,624 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:34:54,624 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:34:54,728 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:34:54,728 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:34:54,819 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:34:54,819 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:34:55,014 - tests.cloud_tests - DEBUG - running collect script: ntp_installed
+2019-09-09 10:34:55,014 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed"
+2019-09-09 10:34:55,117 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_empty
+2019-09-09 10:34:55,117 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_empty"
+2019-09-09 10:34:55,215 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_empty exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:34:55,216 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pool_list
+2019-09-09 10:34:55,216 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pool_list"
+2019-09-09 10:34:55,568 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 26828 to end
+2019-09-09 10:35:00,962 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-34x64yior8t8lwv9rs4ffkeyg7n to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ntp/console.log
+2019-09-09 10:35:01,031 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_chrony
+2019-09-09 10:35:02,061 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:35:17,085 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:35:46,877 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:35:46,877 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:35:46,934 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:35:46,935 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:35:47,028 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:35:47,028 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:35:47,119 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:35:47,119 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:35:47,211 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:35:47,211 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:35:47,303 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:35:47,303 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:35:47,396 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:35:47,396 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:35:47,496 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:35:47,496 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:35:47,587 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:35:47,587 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:35:47,766 - tests.cloud_tests - DEBUG - running collect script: chrony_conf
+2019-09-09 10:35:47,767 - tests.cloud_tests - DEBUG - executing "collect: chrony_conf"
+2019-09-09 10:35:47,943 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 12320 to end
+2019-09-09 10:35:54,073 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-chrony-flcrnrq35z95rzczfh7i to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ntp_chrony/console.log
+2019-09-09 10:35:54,116 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_pools
+2019-09-09 10:35:55,348 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:36:10,372 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:36:56,818 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:36:56,818 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:36:56,876 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:36:56,876 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:36:56,968 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:36:56,968 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:36:57,060 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:36:57,060 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:36:57,152 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:36:57,152 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:36:57,244 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:36:57,244 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:36:57,336 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:36:57,336 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:36:57,441 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:36:57,441 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:36:57,532 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:36:57,532 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:36:57,721 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_pools
+2019-09-09 10:36:57,721 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_pools"
+2019-09-09 10:36:57,815 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_pools
+2019-09-09 10:36:57,815 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_pools"
+2019-09-09 10:36:57,910 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_pools exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:36:57,911 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pools
+2019-09-09 10:36:57,911 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pools"
+2019-09-09 10:36:58,005 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 10:36:58,006 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 10:36:58,314 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14614 to end
+2019-09-09 10:37:03,837 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-pools-o1rwngptsvjwa0gxuzz0w to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ntp_pools/console.log
+2019-09-09 10:37:03,881 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_servers
+2019-09-09 10:37:04,910 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:37:19,935 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:37:22,938 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:37:56,154 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:37:56,154 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:37:56,209 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:37:56,209 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:37:56,299 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:37:56,300 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:37:56,391 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:37:56,391 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:37:56,483 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:37:56,483 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:37:56,575 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:37:56,575 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:37:56,667 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:37:56,667 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:37:56,767 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:37:56,768 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:37:56,859 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:37:56,859 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:37:57,045 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_servers
+2019-09-09 10:37:57,045 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_servers"
+2019-09-09 10:37:57,136 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_servers
+2019-09-09 10:37:57,136 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_servers"
+2019-09-09 10:37:57,228 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_servers exited 'b'cat: /etc/ntp.conf.dist: No such file or directory\n'' and had stderr: 0
+2019-09-09 10:37:57,229 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_servers
+2019-09-09 10:37:57,229 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_servers"
+2019-09-09 10:37:57,321 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 10:37:57,321 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 10:37:57,538 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 14939 to end
+2019-09-09 10:38:02,877 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-servers-1iar5li283s1timgna9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ntp_servers/console.log
+2019-09-09 10:38:02,919 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_timesyncd
+2019-09-09 10:38:03,965 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:38:18,989 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:38:34,291 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:38:34,292 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:38:34,348 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:38:34,348 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:38:34,439 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:38:34,439 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:38:34,530 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:38:34,530 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:38:34,622 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:38:34,623 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:38:34,714 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:38:34,715 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:38:34,807 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:38:34,807 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:38:34,907 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:38:34,907 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:38:34,999 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:38:34,999 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:38:35,174 - tests.cloud_tests - DEBUG - running collect script: timesyncd_conf
+2019-09-09 10:38:35,174 - tests.cloud_tests - DEBUG - executing "collect: timesyncd_conf"
+2019-09-09 10:38:35,348 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 15260 to end
+2019-09-09 10:38:40,713 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-timesyncd-inhq0ypuk98o46equ to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ntp_timesyncd/console.log
+2019-09-09 10:38:40,755 - tests.cloud_tests - INFO - collecting test data for test: modules/package_update_upgrade_install
+2019-09-09 10:38:41,786 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:38:56,811 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:39:27,682 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:39:27,682 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:39:27,736 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:39:27,737 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:39:27,827 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:39:27,827 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:39:27,923 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:39:27,923 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:39:28,015 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:39:28,015 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:39:28,111 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:39:28,111 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:39:28,203 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:39:28,203 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:39:28,305 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:39:28,305 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:39:28,395 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:39:28,395 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:39:28,570 - tests.cloud_tests - DEBUG - running collect script: apt_history_cmdline
+2019-09-09 10:39:28,570 - tests.cloud_tests - DEBUG - executing "collect: apt_history_cmdline"
+2019-09-09 10:39:28,665 - tests.cloud_tests - DEBUG - running collect script: dpkg_show
+2019-09-09 10:39:28,665 - tests.cloud_tests - DEBUG - executing "collect: dpkg_show"
+2019-09-09 10:39:29,216 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16399 to end
+2019-09-09 10:39:34,301 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-package-update-upgrade-eko4o1re to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/package_update_upgrade_install/console.log
+2019-09-09 10:39:34,341 - tests.cloud_tests - INFO - collecting test data for test: modules/runcmd
+2019-09-09 10:39:35,370 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:39:50,394 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:40:08,860 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:40:08,860 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:40:08,917 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:40:08,917 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:40:09,007 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:40:09,007 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:40:09,098 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:40:09,099 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:40:09,190 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:40:09,190 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:40:09,283 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:40:09,283 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:40:09,375 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:40:09,375 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:40:09,475 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:40:09,475 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:40:09,567 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:40:09,567 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:40:09,741 - tests.cloud_tests - DEBUG - running collect script: run_cmd
+2019-09-09 10:40:09,741 - tests.cloud_tests - DEBUG - executing "collect: run_cmd"
+2019-09-09 10:40:09,941 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 16714 to end
+2019-09-09 10:40:15,285 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-runcmd-kn7bj6hy3cvv2ay6vmn0emi2 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/runcmd/console.log
+2019-09-09 10:40:15,291 - tests.cloud_tests - WARNING - test config modules/seed_random_command is not enabled, skipping
+2019-09-09 10:40:15,329 - tests.cloud_tests - INFO - collecting test data for test: modules/seed_random_data
+2019-09-09 10:40:16,358 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:40:31,383 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:40:50,952 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:40:50,953 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:40:51,010 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:40:51,010 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:40:51,103 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:40:51,103 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:40:51,195 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:40:51,195 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:40:51,287 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:40:51,287 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:40:51,379 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:40:51,379 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:40:51,471 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:40:51,471 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:40:51,576 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:40:51,577 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:40:51,667 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:40:51,667 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:40:51,846 - tests.cloud_tests - DEBUG - running collect script: seed_data
+2019-09-09 10:40:51,846 - tests.cloud_tests - DEBUG - executing "collect: seed_data"
+2019-09-09 10:40:52,029 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 17945 to end
+2019-09-09 10:40:57,417 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-seed-random-data-4o9r21qgb2d7ua to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/seed_random_data/console.log
+2019-09-09 10:40:57,456 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname
+2019-09-09 10:40:58,483 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:41:13,508 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:41:28,728 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:41:28,728 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:41:28,784 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:41:28,784 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:41:28,874 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:41:28,875 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:41:28,966 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:41:28,966 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:41:29,059 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:41:29,059 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:41:29,150 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:41:29,150 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:41:29,242 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:41:29,242 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:41:29,342 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:41:29,342 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:41:29,434 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:41:29,434 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:41:29,610 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:41:29,610 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:41:29,704 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 10:41:29,704 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 10:41:29,795 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 10:41:29,795 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 10:41:30,007 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 18169 to end
+2019-09-09 10:41:35,561 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-hostname-hegy1c818e6ixvvp59 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/set_hostname/console.log
+2019-09-09 10:41:35,639 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname_fqdn
+2019-09-09 10:41:36,672 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:41:51,697 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:42:10,666 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:42:10,667 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:42:10,723 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:42:10,723 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:42:10,815 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:42:10,815 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:42:10,907 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:42:10,907 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:42:10,999 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:42:11,000 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:42:11,091 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:42:11,092 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:42:11,183 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:42:11,183 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:42:11,284 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:42:11,284 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:42:11,375 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:42:11,375 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:42:11,553 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:42:11,553 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:42:11,647 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 10:42:11,647 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 10:42:11,743 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 10:42:11,744 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 10:42:11,976 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19348 to end
+2019-09-09 10:42:17,317 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-hostname-fqdn-7up02pihbcy04 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/set_hostname_fqdn/console.log
+2019-09-09 10:42:17,382 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password
+2019-09-09 10:42:18,416 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:42:33,441 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:42:50,267 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:42:50,268 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:42:50,321 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:42:50,322 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:42:50,411 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:42:50,411 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:42:50,503 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:42:50,503 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:42:50,595 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:42:50,596 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:42:50,687 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:42:50,687 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:42:50,779 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:42:50,779 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:42:50,880 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:42:50,880 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:42:50,971 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:42:50,971 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:42:51,152 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:42:51,152 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:42:51,246 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:42:51,246 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:42:51,482 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 19578 to end
+2019-09-09 10:42:56,733 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-0jeiztml025v3xx8in to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/set_password/console.log
+2019-09-09 10:42:56,787 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_expire
+2019-09-09 10:42:57,815 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:43:12,840 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:43:26,428 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:43:26,428 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:43:26,481 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:43:26,482 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:43:26,571 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:43:26,571 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:43:26,663 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:43:26,663 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:43:26,755 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:43:26,755 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:43:26,847 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:43:26,847 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:43:26,939 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:43:26,939 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:43:27,043 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:43:27,044 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:43:27,135 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:43:27,136 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:43:27,319 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:43:27,319 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:43:27,414 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:43:27,415 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:43:27,658 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 20148 to end
+2019-09-09 10:43:32,981 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-expire-wxlzbdc3psk to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/set_password_expire/console.log
+2019-09-09 10:43:33,022 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list
+2019-09-09 10:43:34,057 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:43:49,081 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:44:08,562 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:44:08,562 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:44:08,617 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:44:08,617 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:44:08,707 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:44:08,707 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:44:08,799 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:44:08,799 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:44:08,891 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:44:08,891 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:44:08,983 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:44:08,983 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:44:09,075 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:44:09,075 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:44:09,176 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:44:09,177 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:44:09,267 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:44:09,267 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:44:09,446 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:44:09,446 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:44:09,542 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:44:09,542 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:44:09,742 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 21040 to end
+2019-09-09 10:44:15,037 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-list-ffjg0tglebovi to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/set_password_list/console.log
+2019-09-09 10:44:15,078 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list_string
+2019-09-09 10:44:16,108 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:44:31,133 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:44:53,788 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:44:53,789 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:44:53,845 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:44:53,845 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:44:53,935 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:44:53,935 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:44:54,027 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:44:54,027 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:44:54,119 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:44:54,119 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:44:54,211 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:44:54,211 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:44:54,303 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:44:54,303 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:44:54,403 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:44:54,403 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:44:54,495 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:44:54,495 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:44:54,673 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 10:44:54,674 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 10:44:54,771 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 10:44:54,771 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 10:44:54,988 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22209 to end
+2019-09-09 10:45:00,401 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-list-stri-6jupq0q4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/set_password_list_string/console.log
+2019-09-09 10:45:00,407 - tests.cloud_tests - WARNING - test config modules/snap is not enabled, skipping
+2019-09-09 10:45:00,411 - tests.cloud_tests - WARNING - test config modules/snappy is not enabled, skipping
+2019-09-09 10:45:00,449 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_disable
+2019-09-09 10:45:01,476 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:45:16,501 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:45:45,920 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:45:45,920 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:45:45,997 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:45:45,997 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:45:46,087 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:45:46,087 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:45:46,183 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:45:46,184 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:45:46,276 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:45:46,276 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:45:46,368 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:45:46,368 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:45:46,460 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:45:46,460 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:45:46,565 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:45:46,565 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:45:46,657 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:45:46,657 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:45:46,850 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:45:46,851 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:45:47,092 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 22450 to end
+2019-09-09 10:45:52,481 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-zc45yrad to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ssh_auth_key_fingerprints_disable/console.log
+2019-09-09 10:45:52,522 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_enable
+2019-09-09 10:45:53,564 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:46:08,587 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:46:18,031 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:46:43,082 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:46:43,082 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:46:43,139 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:46:43,139 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:46:43,231 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:46:43,231 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:46:43,324 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:46:43,324 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:46:43,415 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:46:43,415 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:46:43,507 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:46:43,507 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:46:43,599 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:46:43,599 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:46:43,707 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:46:43,707 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:46:43,799 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:46:43,800 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:46:43,974 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:46:43,974 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:46:44,201 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23541 to end
+2019-09-09 10:46:49,669 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-6co838cq to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ssh_auth_key_fingerprints_enable/console.log
+2019-09-09 10:46:49,708 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_import_id
+2019-09-09 10:46:50,736 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:47:05,761 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:47:31,158 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:47:31,158 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:47:31,217 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:47:31,218 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:47:31,307 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:47:31,308 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:47:31,399 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:47:31,400 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:47:31,492 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:47:31,492 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:47:31,587 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:47:31,587 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:47:31,680 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:47:31,681 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:47:31,782 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:47:31,783 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:47:31,877 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:47:31,878 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:47:32,054 - tests.cloud_tests - DEBUG - running collect script: auth_keys_ubuntu
+2019-09-09 10:47:32,055 - tests.cloud_tests - DEBUG - executing "collect: auth_keys_ubuntu"
+2019-09-09 10:47:32,250 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 23810 to end
+2019-09-09 10:47:37,597 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-import-id-gp5lkpch4hit1fu31 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ssh_import_id/console.log
+2019-09-09 10:47:37,639 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_keys_generate
+2019-09-09 10:47:38,669 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:47:53,693 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:48:09,218 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:48:09,218 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:48:09,275 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:48:09,275 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:48:09,367 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:48:09,367 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:48:09,459 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:48:09,460 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:48:09,551 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:48:09,551 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:48:09,643 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:48:09,643 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:48:09,735 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:48:09,735 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:48:09,836 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:48:09,836 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:48:09,927 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:48:09,927 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:48:10,101 - tests.cloud_tests - DEBUG - running collect script: dsa_public
+2019-09-09 10:48:10,101 - tests.cloud_tests - DEBUG - executing "collect: dsa_public"
+2019-09-09 10:48:10,193 - tests.cloud_tests - DEBUG - collect script dsa_public exited 'b'cat: /etc/ssh/ssh_host_dsa_key.pub: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:48:10,194 - tests.cloud_tests - DEBUG - running collect script: dsa_private
+2019-09-09 10:48:10,194 - tests.cloud_tests - DEBUG - executing "collect: dsa_private"
+2019-09-09 10:48:10,287 - tests.cloud_tests - DEBUG - collect script dsa_private exited 'b'cat: /etc/ssh/ssh_host_dsa_key: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:48:10,288 - tests.cloud_tests - DEBUG - running collect script: rsa_public
+2019-09-09 10:48:10,289 - tests.cloud_tests - DEBUG - executing "collect: rsa_public"
+2019-09-09 10:48:10,383 - tests.cloud_tests - DEBUG - collect script rsa_public exited 'b'cat: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:48:10,384 - tests.cloud_tests - DEBUG - running collect script: rsa_private
+2019-09-09 10:48:10,384 - tests.cloud_tests - DEBUG - executing "collect: rsa_private"
+2019-09-09 10:48:10,475 - tests.cloud_tests - DEBUG - collect script rsa_private exited 'b'cat: /etc/ssh/ssh_host_rsa_key: No such file or directory\n'' and had stderr: 1
+2019-09-09 10:48:10,476 - tests.cloud_tests - DEBUG - running collect script: ecdsa_public
+2019-09-09 10:48:10,477 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_public"
+2019-09-09 10:48:10,568 - tests.cloud_tests - DEBUG - running collect script: ecdsa_private
+2019-09-09 10:48:10,568 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_private"
+2019-09-09 10:48:10,660 - tests.cloud_tests - DEBUG - running collect script: ed25519_public
+2019-09-09 10:48:10,660 - tests.cloud_tests - DEBUG - executing "collect: ed25519_public"
+2019-09-09 10:48:10,752 - tests.cloud_tests - DEBUG - running collect script: ed25519_private
+2019-09-09 10:48:10,752 - tests.cloud_tests - DEBUG - executing "collect: ed25519_private"
+2019-09-09 10:48:10,939 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 24160 to end
+2019-09-09 10:48:16,273 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-keys-generate-s6fuxfdjdchxz to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/ssh_keys_generate/console.log
+2019-09-09 10:48:16,284 - tests.cloud_tests - WARNING - test config modules/ssh_keys_provided is not enabled, skipping
+2019-09-09 10:48:16,322 - tests.cloud_tests - INFO - collecting test data for test: modules/timezone
+2019-09-09 10:48:17,367 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:48:32,391 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:48:46,967 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:48:46,967 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:48:47,026 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:48:47,027 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:48:47,119 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:48:47,120 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:48:47,212 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:48:47,212 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:48:47,304 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:48:47,304 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:48:47,396 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:48:47,396 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:48:47,488 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:48:47,488 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:48:47,593 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:48:47,593 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:48:47,684 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:48:47,684 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:48:47,868 - tests.cloud_tests - DEBUG - running collect script: timezone
+2019-09-09 10:48:47,869 - tests.cloud_tests - DEBUG - executing "collect: timezone"
+2019-09-09 10:48:48,073 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25126 to end
+2019-09-09 10:48:53,533 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-timezone-3igdd9cyfr3zu0o4tk4cr4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/timezone/console.log
+2019-09-09 10:48:53,578 - tests.cloud_tests - INFO - collecting test data for test: modules/user_groups
+2019-09-09 10:48:54,607 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:49:09,632 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:49:30,729 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:49:30,729 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:49:30,787 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:49:30,788 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:49:30,880 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:49:30,880 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:49:30,974 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:49:30,974 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:49:31,076 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:49:31,076 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:49:31,168 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:49:31,168 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:49:31,260 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:49:31,260 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:49:31,364 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:49:31,365 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:49:31,455 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:49:31,455 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:49:31,636 - tests.cloud_tests - DEBUG - running collect script: group_ubuntu
+2019-09-09 10:49:31,636 - tests.cloud_tests - DEBUG - executing "collect: group_ubuntu"
+2019-09-09 10:49:31,730 - tests.cloud_tests - DEBUG - running collect script: group_cloud_users
+2019-09-09 10:49:31,730 - tests.cloud_tests - DEBUG - executing "collect: group_cloud_users"
+2019-09-09 10:49:31,824 - tests.cloud_tests - DEBUG - running collect script: user_ubuntu
+2019-09-09 10:49:31,825 - tests.cloud_tests - DEBUG - executing "collect: user_ubuntu"
+2019-09-09 10:49:31,916 - tests.cloud_tests - DEBUG - running collect script: user_foobar
+2019-09-09 10:49:31,916 - tests.cloud_tests - DEBUG - executing "collect: user_foobar"
+2019-09-09 10:49:32,008 - tests.cloud_tests - DEBUG - running collect script: user_barfoo
+2019-09-09 10:49:32,008 - tests.cloud_tests - DEBUG - executing "collect: user_barfoo"
+2019-09-09 10:49:32,100 - tests.cloud_tests - DEBUG - running collect script: user_cloudy
+2019-09-09 10:49:32,100 - tests.cloud_tests - DEBUG - executing "collect: user_cloudy"
+2019-09-09 10:49:32,192 - tests.cloud_tests - DEBUG - running collect script: root_groups
+2019-09-09 10:49:32,192 - tests.cloud_tests - DEBUG - executing "collect: root_groups"
+2019-09-09 10:49:32,384 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 25525 to end
+2019-09-09 10:49:37,701 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-user-groups-3b2i5f03hhbhb3pztr4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/user_groups/console.log
+2019-09-09 10:49:37,745 - tests.cloud_tests - INFO - collecting test data for test: modules/write_files
+2019-09-09 10:49:38,783 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:49:53,808 - tests.cloud_tests - DEBUG - Retrying ssh connection on connect failure
+2019-09-09 10:50:16,656 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:50:16,657 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:50:16,714 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:50:16,714 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:50:16,806 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:50:16,806 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:50:16,895 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:50:16,895 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:50:16,989 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:50:16,989 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:50:17,081 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:50:17,081 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:50:17,177 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:50:17,177 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:50:17,277 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:50:17,278 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:50:17,368 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:50:17,368 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:50:17,551 - tests.cloud_tests - DEBUG - running collect script: file_b64
+2019-09-09 10:50:17,552 - tests.cloud_tests - DEBUG - executing "collect: file_b64"
+2019-09-09 10:50:17,668 - tests.cloud_tests - DEBUG - running collect script: file_text
+2019-09-09 10:50:17,669 - tests.cloud_tests - DEBUG - executing "collect: file_text"
+2019-09-09 10:50:17,769 - tests.cloud_tests - DEBUG - running collect script: file_binary
+2019-09-09 10:50:17,770 - tests.cloud_tests - DEBUG - executing "collect: file_binary"
+2019-09-09 10:50:17,860 - tests.cloud_tests - DEBUG - running collect script: file_gzip
+2019-09-09 10:50:17,861 - tests.cloud_tests - DEBUG - executing "collect: file_gzip"
+2019-09-09 10:50:18,087 - tests.cloud_tests - DEBUG - Executed shutdown. waiting on pid 26617 to end
+2019-09-09 10:50:23,373 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-write-files-yqxznzw8j2bmuyv1xu0 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results/nocloud-kvm/disco/modules/write_files/console.log
+2019-09-09 10:50:23,384 - tests.cloud_tests - DEBUG - collect stages: {'name': 'collect data', 'time': 2060.7437314987183, 'errors': [], 'stages': [{'name': 'collect for platform: nocloud-kvm', 'time': 2060.0069930553436, 'errors': [], 'stages': [{'name': 'set up and collect data for os: disco', 'time': 2052.7703001499176, 'errors': [], 'stages': [{'name': 'set up for ubuntu-disco', 'time': 16.22187829017639, 'errors': [], 'stages': [{'name': 'setup func for --repo, enable repo', 'time': 9.45517349243164, 'errors': [], 'success': True}, {'name': 'setup func for --upgrade, upgrade cloud-init', 'time': 6.766659498214722, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect test data for disco', 'time': 2035.4665622711182, 'errors': [], 'stages': [{}, {}, {'name': 'collect for test: bugs/lp1628337', 'time': 34.77429795265198, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 33.855061531066895, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05594611167907715, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09238624572753906, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09239792823791504, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09460973739624023, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1009058952331543, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09632158279418945, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1010282039642334, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09493708610534668, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.19059062004089355, 'errors': [], 'success': True}], 'success': True}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {'name': 'collect for test: main/command_output_simple', 'time': 32.406720876693726, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.422729969024658, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05718708038330078, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09269452095031738, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09197735786437988, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09235262870788574, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09151554107666016, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09257698059082031, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.0991363525390625, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0921933650970459, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18067455291748047, 'errors': [], 'success': True}, {'name': 'script cloud-init-test-output', 'time': 0.09353780746459961, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_conf', 'time': 44.4696159362793, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 43.48847818374634, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05782270431518555, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09276199340820312, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0914299488067627, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0920257568359375, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09200024604797363, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0923609733581543, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.09977436065673828, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09184789657592773, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17560935020446777, 'errors': [], 'success': True}, {'name': 'script 94cloud-init-config', 'time': 0.09538507461547852, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_disable_suites', 'time': 43.11473822593689, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 42.11687350273132, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06089162826538086, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09137177467346191, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09215593338012695, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09606790542602539, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09140706062316895, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09206509590148926, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10169434547424316, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0916147232055664, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18233418464660645, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09810662269592285, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_primary', 'time': 30.864510536193848, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.8505699634552, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05674314498901367, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0901947021484375, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09134745597839355, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1043863296508789, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09378957748413086, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09467053413391113, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1069333553314209, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0963890552520752, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18164658546447754, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09768986701965332, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_proxy', 'time': 32.681031465530396, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.66251015663147, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0614161491394043, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.10314106941223145, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09486079216003418, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.10183429718017578, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0983130931854248, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09261512756347656, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.09962868690490723, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09198641777038574, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18207001686096191, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-aptproxy', 'time': 0.09250664710998535, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_security', 'time': 34.390788078308105, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 33.34662222862244, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0534815788269043, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08995223045349121, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09170913696289062, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09152817726135254, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09302330017089844, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09129571914672852, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10428118705749512, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.10058903694152832, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.23051857948303223, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09765768051147461, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_key', 'time': 41.144465923309326, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 39.939170360565186, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06608986854553223, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09714102745056152, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.08944010734558105, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09319686889648438, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09163594245910645, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09220051765441895, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10129404067993164, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09010028839111328, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1903386116027832, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.0925440788269043, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.2011125087738037, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_keyserver', 'time': 40.241721868515015, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 39.05260729789734, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.056162357330322266, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08985757827758789, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09184741973876953, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09176135063171387, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09159088134765625, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09225320816040039, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10203981399536133, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0904083251953125, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17103981971740723, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09423041343688965, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.21779108047485352, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_list', 'time': 29.451560735702515, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 28.477417707443237, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0610959529876709, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09069967269897461, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.08989524841308594, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09276199340820312, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09159278869628906, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09268498420715332, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1005711555480957, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09117341041564941, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17106962203979492, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09247660636901855, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_ppa', 'time': 43.35108685493469, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 42.10027503967285, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05955958366394043, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09226608276367188, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09155559539794922, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09142565727233887, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09261345863342285, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09556221961975098, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10588979721069336, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09002518653869629, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18110990524291992, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.09345173835754395, 'errors': [], 'success': True}, {'name': 'script apt-key', 'time': 0.20453119277954102, 'errors': [], 'success': True}, {'name': 'script sources_full', 'time': 0.052649497985839844, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_disable', 'time': 75.22907900810242, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 74.22727704048157, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0563204288482666, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09126615524291992, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09287762641906738, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0949399471282959, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0919337272644043, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09646797180175781, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1009070873260498, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09473681449890137, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18409299850463867, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining', 'time': 0.09812450408935547, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_os', 'time': 51.78307032585144, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 50.726529121398926, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.057878971099853516, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09148859977722168, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0915079116821289, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09399652481079102, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0940089225769043, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09189009666442871, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10184359550476074, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0950617790222168, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24004578590393066, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining_not_written', 'time': 0.09865260124206543, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/bootcmd', 'time': 48.76154065132141, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 47.776015520095825, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.056716203689575195, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09380745887756348, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09227681159973145, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09169840812683105, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09280753135681152, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09116339683532715, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10136175155639648, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09064674377441406, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18185853958129883, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.09307122230529785, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/byobu', 'time': 43.12246036529541, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 42.050297498703, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05290794372558594, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08991432189941406, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09168672561645508, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09186434745788574, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09201478958129883, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09210371971130371, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10044622421264648, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09189343452453613, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17867565155029297, 'errors': [], 'success': True}, {'name': 'script byobu_profile_enabled', 'time': 0.09330487251281738, 'errors': [], 'success': True}, {'name': 'script byobu_launch_exists', 'time': 0.09721064567565918, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ca_certs', 'time': 32.526575565338135, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.446226119995117, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05766916275024414, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09409904479980469, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09076142311096191, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09252071380615234, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09112739562988281, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09313583374023438, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10028314590454102, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09102034568786621, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1818850040435791, 'errors': [], 'success': True}, {'name': 'script cert_links', 'time': 0.09521126747131348, 'errors': [], 'success': True}, {'name': 'script cert', 'time': 0.0924835205078125, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_disable', 'time': 35.72176218032837, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 34.79839825630188, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.06475424766540527, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.10436892509460449, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09560537338256836, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0918581485748291, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09265518188476562, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09192514419555664, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10823488235473633, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09212136268615723, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18171477317810059, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_enable', 'time': 34.78713798522949, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 33.89280319213867, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05816912651062012, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09216856956481934, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09679245948791504, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09096884727478027, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09311461448669434, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09174728393554688, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1055750846862793, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09065532684326172, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17500901222229004, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/final_message', 'time': 31.378098487854004, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.496108770370483, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.057115793228149414, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08992409706115723, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09215283393859863, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09210348129272461, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09171009063720703, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09202384948730469, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10024666786193848, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09145784378051758, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1751573085784912, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/keys_to_console', 'time': 35.59097218513489, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 34.5608868598938, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05544471740722656, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09441089630126953, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.10159540176391602, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09686732292175293, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.11299991607666016, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0944972038269043, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10350918769836426, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09195542335510254, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17824268341064453, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.10040855407714844, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/locale', 'time': 37.747750759124756, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 36.52198004722595, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05935215950012207, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09023523330688477, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09514784812927246, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09204816818237305, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.10381221771240234, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.10360121726989746, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10690855979919434, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09847521781921387, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18598556518554688, 'errors': [], 'success': True}, {'name': 'script locale_default', 'time': 0.09633445739746094, 'errors': [], 'success': True}, {'name': 'script locale_a', 'time': 0.09396553039550781, 'errors': [], 'success': True}, {'name': 'script locale_gen', 'time': 0.09972810745239258, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_bridge', 'time': 44.03554153442383, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 42.82238411903381, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.058561086654663086, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09286785125732422, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09588456153869629, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09605050086975098, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09244441986083984, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09988760948181152, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10504007339477539, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09942030906677246, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18545174598693848, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.09287500381469727, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.09531426429748535, 'errors': [], 'success': True}, {'name': 'script lxc-bridge', 'time': 0.09918451309204102, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_dir', 'time': 42.39930987358093, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 41.31379008293152, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.054639577865600586, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09066200256347656, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.0915827751159668, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09542560577392578, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09176301956176758, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09332966804504395, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10490870475769043, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09094977378845215, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18027520179748535, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.10034680366516113, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.09145689010620117, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp', 'time': 58.66678476333618, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 57.435195446014404, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05983853340148926, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.10259532928466797, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09595513343811035, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09864568710327148, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09253644943237305, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09261441230773926, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10447239875793457, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09044098854064941, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.19519758224487305, 'errors': [], 'success': True}, {'name': 'script ntp_installed', 'time': 0.10249209403991699, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_empty', 'time': 0.09948229789733887, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pool_list', 'time': 0.09714865684509277, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_chrony', 'time': 46.82133340835571, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 45.83731746673584, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0573725700378418, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0936734676361084, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09070158004760742, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09216618537902832, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09191226959228516, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09297990798950195, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.09978747367858887, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09090399742126465, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17987370491027832, 'errors': [], 'success': True}, {'name': 'script chrony_conf', 'time': 0.0945291519165039, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_pools', 'time': 63.798832178115845, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 62.5047607421875, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05779743194580078, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09207987785339355, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09174823760986328, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09203910827636719, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09209108352661133, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09176230430603027, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10488510131835938, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09110331535339355, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18892168998718262, 'errors': [], 'success': True}, {'name': 'script ntp_installed_pools', 'time': 0.09432125091552734, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_pools', 'time': 0.0959780216217041, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pools', 'time': 0.09439802169799805, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.10676360130310059, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_servers', 'time': 53.53565335273743, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 52.26408362388611, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05482769012451172, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09079885482788086, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09131622314453125, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09210515022277832, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09220004081726074, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09174036979675293, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10050225257873535, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09136128425598145, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1858365535736084, 'errors': [], 'success': True}, {'name': 'script ntp_installed_servers', 'time': 0.09163999557495117, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_servers', 'time': 0.0929572582244873, 'errors': [], 'success': True}, {'name': 'script ntp_conf_servers', 'time': 0.09177350997924805, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.10433053970336914, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_timesyncd', 'time': 32.32084941864014, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.345622539520264, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05668973922729492, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09064388275146484, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09154820442199707, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09212088584899902, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09205865859985352, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09207320213317871, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10050010681152344, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09158635139465332, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17543840408325195, 'errors': [], 'success': True}, {'name': 'script timesyncd_conf', 'time': 0.09244298934936523, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/package_update_upgrade_install', 'time': 48.00063633918762, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 46.91848039627075, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05464029312133789, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09031558036804199, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09598302841186523, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09203457832336426, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09575343132019043, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09211516380310059, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10210347175598145, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.08988547325134277, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1754322052001953, 'errors': [], 'success': True}, {'name': 'script apt_history_cmdline', 'time': 0.09453368186950684, 'errors': [], 'success': True}, {'name': 'script dpkg_show', 'time': 0.09920668601989746, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/runcmd', 'time': 35.48479080200195, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 34.51135849952698, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.056543588638305664, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08982515335083008, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09187793731689453, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09180188179016113, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09254932403564453, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09192728996276855, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10054445266723633, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09143567085266113, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17437124252319336, 'errors': [], 'success': True}, {'name': 'script run_cmd', 'time': 0.09243941307067871, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/seed_random_data', 'time': 36.60366702079773, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.61509299278259, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0572662353515625, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09296345710754395, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09185028076171875, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09223246574401855, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09199881553649902, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09222173690795898, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10547637939453125, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09046792984008789, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17911005020141602, 'errors': [], 'success': True}, {'name': 'script seed_data', 'time': 0.09485816955566406, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname', 'time': 32.423991441726685, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.26471972465515, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.055963993072509766, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09027433395385742, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09183454513549805, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09257221221923828, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09111237525939941, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09181070327758789, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.09997439384460449, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09193992614746094, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17647957801818848, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.0937201976776123, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.09062695503234863, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.09279036521911621, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname_fqdn', 'time': 36.192171812057495, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.01775789260864, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.056543827056884766, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09184050559997559, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09231042861938477, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09212970733642578, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09210562705993652, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09150505065917969, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10109925270080566, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0909724235534668, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17814970016479492, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.09325623512268066, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.09691262245178223, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.09740090370178223, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password', 'time': 33.94808030128479, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 32.875088930130005, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05408358573913574, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08964085578918457, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09186339378356934, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09230947494506836, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.091949462890625, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09202432632446289, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10065460205078125, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0909879207611084, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18073606491088867, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.09434795379638672, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.09423589706420898, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_expire', 'time': 30.713816165924072, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 29.632837772369385, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05372309684753418, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08927702903747559, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09211325645446777, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09181618690490723, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09260129928588867, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09190249443054199, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10414958000183105, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09202814102172852, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18320369720458984, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.09581899642944336, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.0941615104675293, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list', 'time': 36.605796098709106, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 35.53144121170044, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05513620376586914, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08992791175842285, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09211897850036621, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09195685386657715, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0918588638305664, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09166598320007324, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10180521011352539, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09053993225097656, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17874598503112793, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.09651923179626465, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.0939183235168457, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list_string', 'time': 39.77671003341675, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 38.70088267326355, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05679059028625488, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08974552154541016, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09179449081420898, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.0920414924621582, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09162092208862305, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09252691268920898, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10013628005981445, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09162473678588867, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17840361595153809, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.09797239303588867, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.09301018714904785, 'errors': [], 'success': True}], 'success': True}, {}, {}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_disable', 'time': 46.493059158325195, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 45.46262168884277, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.07766103744506836, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.08995509147644043, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09616684913635254, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09259843826293945, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09231328964233398, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09134864807128906, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10534191131591797, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09153938293457031, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.19391918182373047, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.09941267967224121, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_enable', 'time': 51.53757333755493, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 50.544997692108154, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05722451210021973, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09192657470703125, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09239625930786133, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09159994125366211, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09196615219116211, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09213423728942871, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10729312896728516, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0927884578704834, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17452335357666016, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.10057377815246582, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_import_id', 'time': 42.43548035621643, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 41.44095420837402, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.0597844123840332, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.0899820327758789, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09199357032775879, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09222030639648438, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09516668319702148, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09351730346679688, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10190343856811523, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0950312614440918, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17696309089660645, 'errors': [], 'success': True}, {'name': 'script auth_keys_ubuntu', 'time': 0.09780764579772949, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_keys_generate', 'time': 33.19594979286194, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 31.569183826446533, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05756831169128418, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09208464622497559, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09221458435058594, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09161639213562012, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09186148643493652, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09227991104125977, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10054421424865723, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09136080741882324, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.17347502708435059, 'errors': [], 'success': True}, {'name': 'script dsa_public', 'time': 0.0934453010559082, 'errors': [], 'success': True}, {'name': 'script dsa_private', 'time': 0.09427928924560547, 'errors': [], 'success': True}, {'name': 'script rsa_public', 'time': 0.0957801342010498, 'errors': [], 'success': True}, {'name': 'script rsa_private', 'time': 0.09223818778991699, 'errors': [], 'success': True}, {'name': 'script ecdsa_public', 'time': 0.09170699119567871, 'errors': [], 'success': True}, {'name': 'script ecdsa_private', 'time': 0.09154558181762695, 'errors': [], 'success': True}, {'name': 'script ed25519_public', 'time': 0.09245800971984863, 'errors': [], 'success': True}, {'name': 'script ed25519_private', 'time': 0.09204912185668945, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/timezone', 'time': 31.63147759437561, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 30.63650345802307, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05927753448486328, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09305596351623535, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09272432327270508, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09200096130371094, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09144878387451172, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09236383438110352, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10515856742858887, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0908670425415039, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18438482284545898, 'errors': [], 'success': True}, {'name': 'script timezone', 'time': 0.09350180625915527, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/user_groups', 'time': 38.69937300682068, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 37.14237856864929, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.05846452713012695, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09220147132873535, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.09462714195251465, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1012887954711914, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.09276843070983887, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.09125328063964844, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10490989685058594, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.09056901931762695, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.18096375465393066, 'errors': [], 'success': True}, {'name': 'script group_ubuntu', 'time': 0.09368038177490234, 'errors': [], 'success': True}, {'name': 'script group_cloud_users', 'time': 0.09456515312194824, 'errors': [], 'success': True}, {'name': 'script user_ubuntu', 'time': 0.09149336814880371, 'errors': [], 'success': True}, {'name': 'script user_foobar', 'time': 0.09212589263916016, 'errors': [], 'success': True}, {'name': 'script user_barfoo', 'time': 0.09164190292358398, 'errors': [], 'success': True}, {'name': 'script user_cloudy', 'time': 0.09214401245117188, 'errors': [], 'success': True}, {'name': 'script root_groups', 'time': 0.0940847396850586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/write_files', 'time': 40.191028356552124, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 38.89335298538208, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.057372331619262695, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.09190511703491211, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.08963418006896973, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.09339690208435059, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.0919346809387207, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.0962224006652832, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.10062527656555176, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.0904545783996582, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.1835329532623291, 'errors': [], 'success': True}, {'name': 'script file_b64', 'time': 0.11690378189086914, 'errors': [], 'success': True}, {'name': 'script file_text', 'time': 0.10085177421569824, 'errors': [], 'success': True}, {'name': 'script file_binary', 'time': 0.09117507934570312, 'errors': [], 'success': True}, {'name': 'script file_gzip', 'time': 0.09347057342529297, 'errors': [], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}
+2019-09-09 10:50:23,389 - tests.cloud_tests - DEBUG - found test data: {'nocloud-kvm': {'disco': ['bugs/lp1628337', 'modules/apt_configure_sources_list', 'modules/locale', 'modules/apt_configure_primary', 'modules/lxd_bridge', 'modules/apt_configure_security', 'modules/apt_pipelining_os', 'modules/ssh_import_id', 'modules/ntp_pools', 'modules/ssh_keys_generate', 'modules/ssh_auth_key_fingerprints_enable', 'modules/apt_configure_sources_keyserver', 'modules/bootcmd', 'modules/set_hostname_fqdn', 'modules/ssh_auth_key_fingerprints_disable', 'modules/final_message', 'modules/apt_configure_sources_key', 'modules/ntp_servers', 'modules/ntp_chrony', 'modules/write_files', 'modules/set_password', 'modules/ntp', 'modules/timezone', 'modules/keys_to_console', 'modules/debug_enable', 'modules/seed_random_data', 'modules/set_password_list', 'modules/user_groups', 'modules/debug_disable', 'modules/byobu', 'modules/apt_configure_proxy', 'modules/apt_configure_sources_ppa', 'modules/package_update_upgrade_install', 'modules/ntp_timesyncd', 'modules/lxd_dir', 'modules/apt_pipelining_disable', 'modules/runcmd', 'modules/set_hostname', 'modules/apt_configure_conf', 'modules/apt_configure_disable_suites', 'modules/set_password_list_string', 'modules/set_password_expire', 'modules/ca_certs', 'main/command_output_simple']}}
+
+2019-09-09 10:50:23,389 - tests.cloud_tests - INFO - test: platform='nocloud-kvm', os='disco' verifying test data
+2019-09-09 10:50:23,389 - tests.cloud_tests - DEBUG - verifying test data for bugs/lp1628337
+test_fetch_indices (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify no apt errors. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify can find ntp and install it. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 10:50:23,436 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Unexpected warnings should not be found in the log. ... ok
+test_sources_list (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Test sources.list includes sources. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:23,486 - tests.cloud_tests - DEBUG - verifying test data for modules/locale
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_locale (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale is set properly. ... ok
+test_locale_a (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale -a has both options. ... ok
+test_locale_gen (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test local.gen file has all entries. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:23,537 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_primary
+test_gatech_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test GaTech entries exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Unexpected warnings should not be found in the log. ... ok
+test_ubuntu_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test no default Ubuntu entries exist. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:23,613 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_bridge
+test_bridge (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test bridge config. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_lxc (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:23,751 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_security
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Unexpected warnings should not be found in the log. ... ok
+test_security_mirror (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Test security lines added and uncommented in source.list. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:23,796 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_os
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Unexpected warnings should not be found in the log. ... ok
+test_os_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+test 'os' settings does not write apt config file. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:23,842 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_import_id
+test_authorized_keys (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Test that ssh keys were imported. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:23,885 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_pools
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test dist config file is empty ... ok
+test_ntp_entires (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 10:50:23,931 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_keys_generate
+test_dsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa private key not generated. ... ok
+test_dsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa public key not generated. ... ok
+test_ecdsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ecdsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ed25519_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_ed25519_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Unexpected warnings should not be found in the log. ... ok
+test_rsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+test_rsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+
+----------------------------------------------------------------------
+Ran 13 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:23,975 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_enable
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Unexpected warnings should not be found in the log. ... ok
+test_syslog (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Verify output of syslog. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:24,023 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_keyserver
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test specific key added. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,068 - tests.cloud_tests - DEBUG - verifying test data for modules/bootcmd
+test_bootcmd_host (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Test boot cmd worked. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,113 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname_fqdn
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname output. ... ok
+test_hostname_fqdn (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname fqdn output. ... ok
+test_hosts (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test /etc/hosts file. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,157 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_disable
+test_cloud_init_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Verify disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,203 - tests.cloud_tests - DEBUG - verifying test data for modules/final_message
+test_final_message_string (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure final handles regular strings. ... ok
+test_final_message_subs (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Test variable substitution in final message. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:24,247 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_key
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test key list updated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,292 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_servers
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test config server entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:24,341 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_chrony
+test_chrony_entries (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Test chrony config entries ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,385 - tests.cloud_tests - DEBUG - verifying test data for modules/write_files
+test_b64 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test b64 encoded file reads as ascii. ... ok
+test_binary (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test binary file reads as executable. ... ok
+test_gzip (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test gzip file shows up as a shell script. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Unexpected warnings should not be found in the log. ... ok
+test_text (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test text shows up as ASCII text. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,429 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test ubuntu user in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,473 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test ntp installed ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,517 - tests.cloud_tests - DEBUG - verifying test data for modules/timezone
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Unexpected warnings should not be found in the log. ... ok
+test_timezone (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Test date prints correct timezone. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,558 - tests.cloud_tests - DEBUG - verifying test data for modules/keys_to_console
+test_excluded_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test excluded keys missing. ... ok
+test_expected_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test expected keys exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,601 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_enable
+test_debug_enable (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Test debug messages in cloud-init log. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,643 - tests.cloud_tests - DEBUG - verifying test data for modules/seed_random_data
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Unexpected warnings should not be found in the log. ... ok
+test_random_seed_data (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Test random data passed in exists. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,686 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 10:50:24,733 - tests.cloud_tests - DEBUG - verifying test data for modules/user_groups
+test_group_cloud_users (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloud users group exists. ... ok
+test_group_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu group exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Unexpected warnings should not be found in the log. ... ok
+test_user_barfoo (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test barfoo user exists. ... ok
+test_user_cloudy (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloudy user exists. ... ok
+test_user_foobar (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test foobar user exists. ... ok
+test_user_root_in_secret (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test root user is in 'secret' group. ... ok
+test_user_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu user exists. ... ok
+
+----------------------------------------------------------------------
+Ran 12 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:24,776 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_disable
+test_debug_disable (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Test verbose output missing from logs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,866 - tests.cloud_tests - DEBUG - verifying test data for modules/byobu
+test_byobu_installed (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu installed. ... ok
+test_byobu_launch_exists (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu-launch exists. ... ok
+test_byobu_profile_enabled (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu profile.d file exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,914 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_proxy
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Unexpected warnings should not be found in the log. ... ok
+test_proxy_config (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Test proxy options added to apt config. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:24,979 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_ppa
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Unexpected warnings should not be found in the log. ... ok
+test_ppa (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test specific ppa added. ... ok
+test_ppa_key (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test ppa key added. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,039 - tests.cloud_tests - DEBUG - verifying test data for modules/package_update_upgrade_install
+test_apt_history (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test apt history for update command. ... ok
+test_cloud_init_output (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test cloud-init-output for install & upgrade stuff. ... ok
+test_installed_sl (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test sl got installed. ... ok
+test_installed_tree (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test tree got installed. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:25,101 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_timesyncd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Unexpected warnings should not be found in the log. ... ok
+test_timesyncd_entries (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Test timesyncd config entries ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,145 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_dir
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_lxc (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,195 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_disable
+test_disable_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Test pipelining disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,238 - tests.cloud_tests - DEBUG - verifying test data for modules/runcmd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Unexpected warnings should not be found in the log. ... ok
+test_run_cmd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Test run command worked. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,290 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Test hostname command shows correct output. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,344 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_conf
+test_apt_conf_assumeyes (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config assumes true. ... ok
+test_apt_conf_fixbroken (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config fixes broken. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,465 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_disable_suites
+test_empty_sourcelist (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Test source list is empty. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,510 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list_string
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 10:50:25,556 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_expire
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test user frozen in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,599 - tests.cloud_tests - DEBUG - verifying test data for modules/ca_certs
+test_cert_installed (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test line from our cert exists. ... ok
+test_certs_updated (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test certs have been updated in /etc/ssl/certs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 10:50:25,645 - tests.cloud_tests - DEBUG - verifying test data for main/command_output_simple
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on nocloud-kvm'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by nocloud-kvm platform. ... ok
+test_instance_data_json_lxd (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by lxd platform. ... skipped 'Skipping lxd instance-data.json on nocloud-kvm'
+test_no_stages_errors (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Unexpected warnings should not be found in the log. ... ok
+test_output_file (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that the output file is not empty and has all stages. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 10:50:25,688 - tests.cloud_tests - INFO - test: platform='nocloud-kvm', os='disco' passed all tests
+2019-09-09 10:50:25,688 - tests.cloud_tests - DEBUG - 
+---- Verify summarized results:
+
+Platform: nocloud-kvm
+  Distro: disco
+    test modules passed:44 tests failed:0
+2019-09-09 10:50:25,688 - tests.cloud_tests - INFO - leaving data in /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-kvm/cloud-init/results
+___________________________________ summary ____________________________________
+  citest: commands succeeded
+  congratulations :)
++ RET=0
++ find . -name id_rsa* -delete
++ exit 0
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS
+=== End series d ===

--- a/manual/nocloud-lxd-sru-19.2.24.txt
+++ b/manual/nocloud-lxd-sru-19.2.24.txt
@@ -1,0 +1,7419 @@
+=== Begin series x ===
+Started by remote host 10.247.8.15
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd
+[cloud-init-integration-proposed-x-lxd] $ /bin/sh -xe /tmp/jenkins11171641027406059414.sh
++ release=xenial
++ release_ver=16.04
++ platform=lxd
++ set -e
++ sudo rm -Rf cloud-init
++ git clone https://git.launchpad.net/cloud-init
+Cloning into 'cloud-init'...
++ cd cloud-init
++ git tag --list
++ grep 16.04
++ tail -1
++ tag=ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
++ echo Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
+Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
++ git checkout ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1
+Note: checking out 'ubuntu/19.2-24-ge7881d5c-0ubuntu1_16.04.1'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at 2d95da3a releasing cloud-init version 19.2-24-ge7881d5c-0ubuntu1~16.04.1
++ mirror=http://archive.ubuntu.com/ubuntu/
++ hostname
++ [ -z  -a torkoal = torkoal ]
++ export TMPDIR=/var/lib/jenkins/tmp/
++ set +e
++ no_proxy=launchpad.net https_proxy=http://squid.internal:3128 tox -e citest -- run --os-name=xenial --platform=lxd --repo='deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main' --preserve-data --data-dir=./results --verbose
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/setup.py
+citest create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest
+citest installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/integration-requirements.txt
+citest inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/dist/cloud-init-19.2.zip
+citest installed: asn1crypto==0.24.0,attrs==19.1.0,bcrypt==3.1.7,boto3==1.5.9,botocore==1.8.50,certifi==2019.6.16,cffi==1.12.3,chardet==3.0.4,cloud-init==19.2,configobj==5.0.6,cryptography==2.4.2,docutils==0.15.2,idna==2.8,Jinja2==2.10.1,jmespath==0.9.4,jsonpatch==1.24,jsonpointer==2.0,jsonschema==3.0.2,linecache2==1.0.0,MarkupSafe==1.1.1,oauthlib==3.1.0,paramiko==2.4.2,pbr==5.4.3,pkg-resources==0.0.0,pyasn1==0.4.7,pycparser==2.19,pylxd==2.2.7,PyNaCl==1.3.0,pyrsistent==0.15.4,python-dateutil==2.8.0,python-simplestreams==0.1.0,PyYAML==5.1.2,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,s3transfer==0.1.13,six==1.12.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.3,ws4py==0.5.1
+citest runtests: PYTHONHASHSEED='4203836779'
+citest runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=xenial --platform=lxd --repo=deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main --preserve-data --data-dir=./results --verbose
+2019-09-08 10:21:11,618 - tests.cloud_tests - DEBUG - running with args: Namespace(data_dir='/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results', deb=None, feature_override={}, os_name=['xenial'], platform=['lxd'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo='deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main', result=None, rpm=None, script=None, subcmd='run', test_config=['/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1511485.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1611074.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1628337.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/add_apt_repositories.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/alter_completion_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/configure_instance_trusted_ca_certificates.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/configure_instances_ssh_keys.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/including_user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/install_arbitrary_packages.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/install_run_chef_recipes.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_apt_upgrade.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_commands.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_commands_first_boot.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/setup_run_puppet.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/examples/writing_out_arbitrary_files.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/main/command_output_simple.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_conf.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_disable_suites.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_primary.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_proxy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_security.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_key.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_keyserver.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_os.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/bootcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/byobu.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ca_certs.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/debug_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/debug_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/final_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/keys_to_console.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/landscape.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/locale.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/lxd_bridge.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/lxd_dir.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_chrony.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_pools.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_servers.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_timesyncd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/package_update_upgrade_install.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/runcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/seed_random_command.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/seed_random_data.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_hostname.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_hostname_fqdn.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_expire.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_list_string.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/snap.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/snappy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_import_id.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_generate.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_provided.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/timezone.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/tests/cloud_tests/testcases/modules/write_files.yaml'], upgrade=True, upgrade_full=False, verbose=True)
+2019-09-08 10:21:11,619 - tests.cloud_tests - DEBUG - using tmpdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results
+2019-09-08 10:21:11,627 - tests.cloud_tests - DEBUG - platform config: {'enabled': True, 'get_image_timeout': 300, 'create_instance_timeout': 60, 'private_key': 'cloud_init_rsa', 'public_key': 'cloud_init_rsa.pub', 'template_overrides': {'/var/lib/cloud/seed/nocloud-net/meta-data': {'when': ['create', 'copy'], 'template': 'cloud-init-meta.tpl'}, '/var/lib/cloud/seed/nocloud-net/network-config': {'when': ['create', 'copy'], 'template': 'cloud-init-network.tpl'}, '/var/lib/cloud/seed/nocloud-net/user-data': {'when': ['create', 'copy'], 'template': 'cloud-init-user.tpl', 'properties': {'default': '#cloud-config\n{}\n'}}, '/var/lib/cloud/seed/nocloud-net/vendor-data': {'when': ['create', 'copy'], 'template': 'cloud-init-vendor.tpl', 'properties': {'default': '#cloud-config\n{}\n'}}}, 'template_files': {'cloud-init-meta.tpl': '#cloud-config\ninstance-id: {{ container.name }}\nlocal-hostname: {{ container.name }}\n{{ config_get("user.meta-data", "") }}\n', 'cloud-init-network.tpl': '{% if config_get("user.network-config", "") == "" %}version: 1\nconfig:\n    - type: physical\n      name: eth0\n      subnets:\n          - type: {% if config_get("user.network_mode", "") == "link-local" %}manual{% else %}dhcp{% endif %}\n            control: auto{% else %}{{ config_get("user.network-config", "") }}{% endif %}\n', 'cloud-init-user.tpl': '{{ config_get("user.user-data", properties.default) }}\n', 'cloud-init-vendor.tpl': '{{ config_get("user.vendor-data", properties.default) }}\n'}, 'data_dir': '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results'}
+2019-09-08 10:21:11,627 - tests.cloud_tests - INFO - setting up platform: lxd
+2019-09-08 10:21:14,160 - tests.cloud_tests - DEBUG - os config: {'enabled': True, 'boot_timeout': 120, 'boot_clean_script': '#!/bin/bash\nrm -rf /var/log/cloud-init.log /var/log/cloud-init-output.log \\\n    /var/lib/cloud/ /run/cloud-init/ /var/log/syslog\n', 'system_ready_script': "# permit running or degraded state as both indicate complete boot\n[ $(systemctl is-system-running) = 'running' -o\n  $(systemctl is-system-running) = 'degraded' ]\n", 'cloud_init_ready_script': "[ -f '/run/cloud-init/result.json' ]\n", 'feature_groups': ['base', 'debian_base', 'ubuntu_specific'], 'features': {'apt': True, 'byobu': True, 'landscape': True, 'lxd': True, 'ppa': True, 'rpm': None, 'snap': True, 'hostname': True, 'apt_src_cont': True, 'apt_hist_fmt': True, 'daylight_time': True, 'apt_up_out': True, 'engb_locale': True, 'locale_gen': True, 'no_ntpdate': True, 'no_file_fmt_e': True, 'ppa_file_name': True, 'sshd': True, 'ssh_key_fmt': True, 'syslog': True, 'ubuntu_ntp': True, 'ubuntu_repos': True, 'ubuntu_user': True, 'lsb_release': True, 'sudo': True}, 'mirror_url': 'https://cloud-images.ubuntu.com/daily', 'mirror_dir': '/srv/citest/images', 'keyring': '/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg', 'version': 16.04, 'sstreams_server': 'https://cloud-images.ubuntu.com/daily', 'cache_base_image': True, 'override_templates': False, 'setup_overrides': None, 'release': 'xenial', 'os': 'ubuntu', 'alias': 'xenial', 'arch': 'amd64'}
+2019-09-08 10:21:14,160 - tests.cloud_tests - INFO - acquiring image for os: xenial
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:21:15,442 - tests.cloud_tests - DEBUG - updating args for setup with: None
+2019-09-08 10:21:18,761 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:21:18,762 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:21:24,287 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:21:32,987 - tests.cloud_tests - INFO - setting up ubuntu-xenial (build_name=server serial=20190903)
+2019-09-08 10:21:33,010 - tests.cloud_tests - DEBUG - enable repo: "deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main" in target
+2019-09-08 10:21:33,010 - tests.cloud_tests - DEBUG - executing "enable repo: "deb http://archive.ubuntu.com/ubuntu/ xenial-proposed main" in target"
+2019-09-08 10:21:40,951 - tests.cloud_tests - DEBUG - upgrading cloud-init
+2019-09-08 10:21:40,951 - tests.cloud_tests - DEBUG - executing "upgrading cloud-init"
+2019-09-08 10:21:47,474 - tests.cloud_tests - DEBUG - creating snapshot for xenial
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:21:48,397 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:21:48,398 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:21:49,313 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:21:54,654 - tests.cloud_tests - DEBUG - executing command: sh -c 'set -e; s="$1"; shift; cat > "$s"; trap "rm -f $s" EXIT; chmod +x "$s"; "$s" "$@"' runscript /tmp/LXDInstance-0000
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:21:54,891 - tests.cloud_tests - INFO - collecting test data for os: xenial
+2019-09-08 10:21:54,900 - tests.cloud_tests - WARNING - test config bugs/lp1511485 is not enabled, skipping
+2019-09-08 10:21:54,907 - tests.cloud_tests - WARNING - test config bugs/lp1611074 is not enabled, skipping
+2019-09-08 10:21:54,946 - tests.cloud_tests - INFO - collecting test data for test: bugs/lp1628337
+2019-09-08 10:21:55,593 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:21:55,594 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:21:56,510 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:22:09,938 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:22:09,938 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:22:10,144 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:22:10,144 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:22:10,347 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:22:10,347 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:22:10,526 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:22:10,527 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:22:10,746 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:22:10,747 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:22:10,947 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:22:10,947 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:22:11,130 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:22:11,130 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:22:11,354 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:22:11,354 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:22:11,522 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:22:11,522 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:22:11,817 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-bugs-lp1628337-yp0k6zv0jz40icyhub519cf) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:13,229 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-bugs-lp1628337-yp0k6zv0jz40icyhub519cf to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/bugs/lp1628337/console.log
+2019-09-08 10:22:13,229 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-bugs-lp1628337-yp0k6zv0jz40icyhub519cf) status=Stopped: deleting container.
+2019-09-08 10:22:13,474 - tests.cloud_tests - WARNING - test config examples/add_apt_repositories is not enabled, skipping
+2019-09-08 10:22:13,479 - tests.cloud_tests - WARNING - test config examples/alter_completion_message is not enabled, skipping
+2019-09-08 10:22:13,484 - tests.cloud_tests - WARNING - test config examples/configure_instance_trusted_ca_certificates is not enabled, skipping
+2019-09-08 10:22:13,492 - tests.cloud_tests - WARNING - test config examples/configure_instances_ssh_keys is not enabled, skipping
+2019-09-08 10:22:13,498 - tests.cloud_tests - WARNING - test config examples/including_user_groups is not enabled, skipping
+2019-09-08 10:22:13,502 - tests.cloud_tests - WARNING - test config examples/install_arbitrary_packages is not enabled, skipping
+2019-09-08 10:22:13,510 - tests.cloud_tests - WARNING - test config examples/install_run_chef_recipes is not enabled, skipping
+2019-09-08 10:22:13,514 - tests.cloud_tests - WARNING - test config examples/run_apt_upgrade is not enabled, skipping
+2019-09-08 10:22:13,519 - tests.cloud_tests - WARNING - test config examples/run_commands is not enabled, skipping
+2019-09-08 10:22:13,524 - tests.cloud_tests - WARNING - test config examples/run_commands_first_boot is not enabled, skipping
+2019-09-08 10:22:13,530 - tests.cloud_tests - WARNING - test config examples/setup_run_puppet is not enabled, skipping
+2019-09-08 10:22:13,535 - tests.cloud_tests - WARNING - test config examples/writing_out_arbitrary_files is not enabled, skipping
+2019-09-08 10:22:13,575 - tests.cloud_tests - INFO - collecting test data for test: main/command_output_simple
+2019-09-08 10:22:15,789 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:22:15,790 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:16,689 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:22:22,033 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:22:22,034 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:22:22,218 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:22:22,219 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:22:22,382 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:22:22,382 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:22:22,566 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:22:22,566 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:22:22,770 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:22:22,770 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:22:22,950 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:22:22,950 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:22:23,258 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:22:23,258 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:22:23,487 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:22:23,487 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:22:23,710 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:22:23,710 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:22:23,994 - tests.cloud_tests - DEBUG - running collect script: cloud-init-test-output
+2019-09-08 10:22:23,995 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-test-output"
+2019-09-08 10:22:24,191 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-main-command-output-simple-cgh5hij3izw) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:26,250 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-main-command-output-simple-cgh5hij3izw to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/main/command_output_simple/console.log
+2019-09-08 10:22:26,251 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-main-command-output-simple-cgh5hij3izw) status=Stopped: deleting container.
+2019-09-08 10:22:26,524 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_conf
+2019-09-08 10:22:27,317 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:22:27,318 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:28,323 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:22:33,653 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:22:33,654 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:22:33,878 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:22:33,879 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:22:34,099 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:22:34,099 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:22:34,271 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:22:34,271 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:22:34,499 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:22:34,499 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:22:34,694 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:22:34,694 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:22:34,863 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:22:34,863 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:22:35,086 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:22:35,086 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:22:35,271 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:22:35,271 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:22:35,575 - tests.cloud_tests - DEBUG - running collect script: 94cloud-init-config
+2019-09-08 10:22:35,575 - tests.cloud_tests - DEBUG - executing "collect: 94cloud-init-config"
+2019-09-08 10:22:35,786 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-conf-8f7uhay2fod) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:38,133 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-conf-8f7uhay2fod to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_conf/console.log
+2019-09-08 10:22:38,133 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-conf-8f7uhay2fod) status=Stopped: deleting container.
+2019-09-08 10:22:38,448 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_disable_suites
+2019-09-08 10:22:39,197 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:22:39,198 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:40,258 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:22:44,509 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:22:44,510 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:22:44,667 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:22:44,667 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:22:44,826 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:22:44,826 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:22:44,995 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:22:44,995 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:22:45,175 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:22:45,175 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:22:45,399 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:22:45,399 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:22:45,622 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:22:45,623 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:22:45,906 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:22:45,907 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:22:46,134 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:22:46,134 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:22:46,447 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:22:46,447 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:22:46,655 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-disable--lpy8d6h) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:48,972 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-disable--lpy8d6h to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_disable_suites/console.log
+2019-09-08 10:22:48,972 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-disable--lpy8d6h) status=Stopped: deleting container.
+2019-09-08 10:22:49,347 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_primary
+2019-09-08 10:22:50,145 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:22:50,146 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:51,099 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:22:56,429 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:22:56,430 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:22:56,583 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:22:56,583 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:22:56,727 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:22:56,727 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:22:56,882 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:22:56,882 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:22:57,054 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:22:57,054 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:22:57,231 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:22:57,231 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:22:57,398 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:22:57,398 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:22:57,594 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:22:57,595 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:22:57,754 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:22:57,754 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:22:57,998 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:22:57,998 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:22:58,168 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-primary-k7exs11c) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:22:59,995 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-primary-k7exs11c to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_primary/console.log
+2019-09-08 10:22:59,995 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-primary-k7exs11c) status=Stopped: deleting container.
+2019-09-08 10:23:00,331 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_proxy
+2019-09-08 10:23:01,053 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:23:01,054 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:02,233 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:23:06,481 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:23:06,482 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:23:06,710 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:23:06,711 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:23:06,854 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:23:06,854 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:23:06,986 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:23:06,986 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:23:07,154 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:23:07,154 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:23:07,338 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:23:07,338 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:23:07,490 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:23:07,490 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:23:07,658 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:23:07,658 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:23:07,826 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:23:07,826 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:23:08,054 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-aptproxy
+2019-09-08 10:23:08,055 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-aptproxy"
+2019-09-08 10:23:08,212 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-proxy-mm5mq6vx2q) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:10,326 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-proxy-mm5mq6vx2q to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_proxy/console.log
+2019-09-08 10:23:10,326 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-proxy-mm5mq6vx2q) status=Stopped: deleting container.
+2019-09-08 10:23:11,350 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_security
+2019-09-08 10:23:12,333 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:23:12,334 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:13,321 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:23:18,634 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:23:18,634 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:23:18,875 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:23:18,875 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:23:19,103 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:23:19,103 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:23:19,314 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:23:19,314 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:23:19,494 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:23:19,495 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:23:19,778 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:23:19,778 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:23:19,970 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:23:19,970 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:23:20,206 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:23:20,207 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:23:20,410 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:23:20,410 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:23:20,746 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:23:20,746 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:23:20,946 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-security-1x9q7np) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:23,137 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-security-1x9q7np to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_security/console.log
+2019-09-08 10:23:23,138 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-security-1x9q7np) status=Stopped: deleting container.
+2019-09-08 10:23:23,467 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_key
+2019-09-08 10:23:24,349 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:23:24,350 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:25,474 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:23:34,838 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:23:34,838 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:23:35,030 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:23:35,031 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:23:35,174 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:23:35,174 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:23:35,326 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:23:35,326 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:23:35,474 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:23:35,474 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:23:35,610 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:23:35,610 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:23:35,778 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:23:35,778 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:23:35,962 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:23:35,962 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:23:36,134 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:23:36,134 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:23:36,382 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:23:36,382 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:23:36,726 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-08 10:23:36,726 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-08 10:23:37,153 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--2k3419l) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:39,447 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--2k3419l to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_sources_key/console.log
+2019-09-08 10:23:39,448 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--2k3419l) status=Stopped: deleting container.
+2019-09-08 10:23:39,739 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_keyserver
+2019-09-08 10:23:40,901 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:23:40,902 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:41,973 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:23:51,318 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:23:51,318 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:23:51,527 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:23:51,527 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:23:51,751 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:23:51,751 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:23:51,967 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:23:51,967 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:23:52,171 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:23:52,171 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:23:52,391 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:23:52,391 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:23:52,551 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:23:52,551 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:23:52,746 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:23:52,746 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:23:52,943 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:23:52,943 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:23:53,195 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:23:53,195 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:23:53,411 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-08 10:23:53,411 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-08 10:23:53,766 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--rvheay5) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:23:56,153 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--rvheay5 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_sources_keyserver/console.log
+2019-09-08 10:23:56,153 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--rvheay5) status=Stopped: deleting container.
+2019-09-08 10:23:57,177 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_list
+2019-09-08 10:23:59,065 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:23:59,066 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:00,145 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:24:05,586 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:24:05,586 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:24:05,783 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:24:05,783 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:24:05,987 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:24:05,987 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:24:06,246 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:24:06,247 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:24:06,482 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:24:06,483 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:24:06,698 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:24:06,698 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:24:06,947 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:24:06,947 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:24:07,155 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:24:07,155 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:24:07,558 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:24:07,559 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:24:07,891 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:24:07,891 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:24:08,073 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--igo9rv9) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:10,926 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--igo9rv9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_sources_list/console.log
+2019-09-08 10:24:10,926 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--igo9rv9) status=Stopped: deleting container.
+2019-09-08 10:24:11,609 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_ppa
+2019-09-08 10:24:12,541 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:24:12,542 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:14,238 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:24:26,685 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:24:26,686 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:24:26,916 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:24:26,917 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:24:27,042 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:24:27,042 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:24:27,206 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:24:27,206 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:24:27,358 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:24:27,358 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:24:27,526 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:24:27,526 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:24:27,706 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:24:27,706 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:24:27,947 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:24:27,947 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:24:28,255 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:24:28,255 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:24:28,558 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-08 10:24:28,558 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-08 10:24:28,762 - tests.cloud_tests - DEBUG - running collect script: apt-key
+2019-09-08 10:24:28,762 - tests.cloud_tests - DEBUG - executing "collect: apt-key"
+2019-09-08 10:24:29,030 - tests.cloud_tests - DEBUG - running collect script: sources_full
+2019-09-08 10:24:29,030 - tests.cloud_tests - DEBUG - executing "collect: sources_full"
+2019-09-08 10:24:29,199 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--66z5k8p) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:30,839 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-configure-sources--66z5k8p to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_configure_sources_ppa/console.log
+2019-09-08 10:24:30,839 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-configure-sources--66z5k8p) status=Stopped: deleting container.
+2019-09-08 10:24:31,174 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_disable
+2019-09-08 10:24:32,897 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:24:32,898 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:33,780 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:24:38,101 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:24:38,102 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:24:38,263 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:24:38,263 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:24:38,495 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:24:38,495 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:24:38,702 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:24:38,702 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:24:38,907 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:24:38,907 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:24:39,074 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:24:39,074 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:24:39,243 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:24:39,243 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:24:39,427 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:24:39,427 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:24:39,582 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:24:39,582 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:24:39,899 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining
+2019-09-08 10:24:39,899 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining"
+2019-09-08 10:24:40,136 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-pipelining-disable-svy99or) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:41,900 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-pipelining-disable-svy99or to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_pipelining_disable/console.log
+2019-09-08 10:24:41,901 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-pipelining-disable-svy99or) status=Stopped: deleting container.
+2019-09-08 10:24:42,374 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_os
+2019-09-08 10:24:44,117 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:24:44,118 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:45,460 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:24:50,770 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:24:50,770 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:24:50,975 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:24:50,976 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:24:51,230 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:24:51,230 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:24:51,486 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:24:51,487 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:24:51,690 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:24:51,691 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:24:51,879 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:24:51,879 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:24:52,847 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:24:52,847 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:24:53,123 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:24:53,123 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:24:53,363 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:24:53,363 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:24:53,687 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining_not_written
+2019-09-08 10:24:53,687 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining_not_written"
+2019-09-08 10:24:53,914 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining_not_written exited 'b"ls: cannot access '/etc/apt/apt.conf.d/90cloud-init-pipelining': No such file or directory\n"' and had stderr: 0
+2019-09-08 10:24:53,923 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-pipelining-os-5ie5yzp3m274) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:55,660 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-apt-pipelining-os-5ie5yzp3m274 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/apt_pipelining_os/console.log
+2019-09-08 10:24:55,661 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-apt-pipelining-os-5ie5yzp3m274) status=Stopped: deleting container.
+2019-09-08 10:24:56,372 - tests.cloud_tests - INFO - collecting test data for test: modules/bootcmd
+2019-09-08 10:24:58,793 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:24:58,794 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:24:59,889 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:25:05,222 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:25:05,222 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:25:05,386 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:25:05,387 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:25:05,558 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:25:05,558 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:25:05,710 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:25:05,710 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:25:05,874 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:25:05,874 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:25:06,038 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:25:06,038 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:25:06,206 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:25:06,207 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:25:06,370 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:25:06,370 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:25:06,543 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:25:06,543 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:25:06,795 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-08 10:25:06,795 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-08 10:25:06,960 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-bootcmd-o359ycvkqlzyoonjo01a9q) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:08,288 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-bootcmd-o359ycvkqlzyoonjo01a9q to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/bootcmd/console.log
+2019-09-08 10:25:08,289 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-bootcmd-o359ycvkqlzyoonjo01a9q) status=Stopped: deleting container.
+2019-09-08 10:25:08,632 - tests.cloud_tests - INFO - collecting test data for test: modules/byobu
+2019-09-08 10:25:10,713 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:25:10,714 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:11,641 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:25:18,002 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:25:18,002 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:25:18,219 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:25:18,219 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:25:18,442 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:25:18,442 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:25:18,686 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:25:18,686 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:25:18,895 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:25:18,895 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:25:19,143 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:25:19,143 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:25:19,383 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:25:19,383 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:25:19,642 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:25:19,642 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:25:19,862 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:25:19,862 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:25:20,175 - tests.cloud_tests - DEBUG - running collect script: byobu_profile_enabled
+2019-09-08 10:25:20,175 - tests.cloud_tests - DEBUG - executing "collect: byobu_profile_enabled"
+2019-09-08 10:25:20,491 - tests.cloud_tests - DEBUG - running collect script: byobu_launch_exists
+2019-09-08 10:25:20,491 - tests.cloud_tests - DEBUG - executing "collect: byobu_launch_exists"
+2019-09-08 10:25:20,784 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-byobu-qpa6u8sqwd06re52zuuon1rc) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:22,861 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-byobu-qpa6u8sqwd06re52zuuon1rc to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/byobu/console.log
+2019-09-08 10:25:22,861 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-byobu-qpa6u8sqwd06re52zuuon1rc) status=Stopped: deleting container.
+2019-09-08 10:25:23,157 - tests.cloud_tests - INFO - collecting test data for test: modules/ca_certs
+2019-09-08 10:25:24,061 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:25:24,062 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:25,334 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:25:31,798 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:25:31,798 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:25:32,359 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:25:32,359 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:25:32,654 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:25:32,654 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:25:32,895 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:25:32,895 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:25:33,207 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:25:33,207 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:25:33,450 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:25:33,450 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:25:33,675 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:25:33,675 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:25:33,903 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:25:33,903 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:25:34,082 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:25:34,082 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:25:34,410 - tests.cloud_tests - DEBUG - running collect script: cert_links
+2019-09-08 10:25:34,410 - tests.cloud_tests - DEBUG - executing "collect: cert_links"
+2019-09-08 10:25:34,599 - tests.cloud_tests - DEBUG - running collect script: cert
+2019-09-08 10:25:34,599 - tests.cloud_tests - DEBUG - executing "collect: cert"
+2019-09-08 10:25:34,811 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ca-certs-hym32llyljf4kfnzcz4cl) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:36,422 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ca-certs-hym32llyljf4kfnzcz4cl to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ca_certs/console.log
+2019-09-08 10:25:36,422 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ca-certs-hym32llyljf4kfnzcz4cl) status=Stopped: deleting container.
+2019-09-08 10:25:38,034 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_disable
+2019-09-08 10:25:38,854 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:25:38,854 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:40,680 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:25:46,218 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:25:46,218 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:25:46,475 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:25:46,476 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:25:46,802 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:25:46,803 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:25:47,134 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:25:47,135 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:25:47,411 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:25:47,411 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:25:47,643 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:25:47,643 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:25:47,911 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:25:47,911 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:25:48,119 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:25:48,119 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:25:48,355 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:25:48,355 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:25:48,662 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-debug-disable-bhi5rbd294clpem8) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:50,047 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-debug-disable-bhi5rbd294clpem8 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/debug_disable/console.log
+2019-09-08 10:25:50,047 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-debug-disable-bhi5rbd294clpem8) status=Stopped: deleting container.
+2019-09-08 10:25:50,310 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_enable
+2019-09-08 10:25:51,133 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:25:51,134 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:25:53,749 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:25:58,013 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:25:58,014 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:25:58,210 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:25:58,211 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:25:58,390 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:25:58,390 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:25:58,583 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:25:58,583 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:25:58,790 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:25:58,790 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:25:58,970 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:25:58,970 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:25:59,163 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:25:59,163 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:25:59,387 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:25:59,387 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:25:59,582 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:25:59,582 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:25:59,934 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-debug-enable-vq8kqpj1g9ii43d51) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:01,838 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-debug-enable-vq8kqpj1g9ii43d51 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/debug_enable/console.log
+2019-09-08 10:26:01,839 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-debug-enable-vq8kqpj1g9ii43d51) status=Stopped: deleting container.
+2019-09-08 10:26:02,151 - tests.cloud_tests - INFO - collecting test data for test: modules/final_message
+2019-09-08 10:26:02,926 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:26:02,926 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:04,182 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:26:09,546 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:26:09,546 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:26:09,787 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:26:09,787 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:26:10,030 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:26:10,031 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:26:10,255 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:26:10,255 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:26:10,471 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:26:10,471 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:26:10,670 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:26:10,671 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:26:10,862 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:26:10,862 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:26:11,099 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:26:11,099 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:26:11,279 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:26:11,279 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:26:11,583 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-final-message-to26fstszlonit44) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:13,974 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-final-message-to26fstszlonit44 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/final_message/console.log
+2019-09-08 10:26:13,974 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-final-message-to26fstszlonit44) status=Stopped: deleting container.
+2019-09-08 10:26:14,219 - tests.cloud_tests - INFO - collecting test data for test: modules/keys_to_console
+2019-09-08 10:26:15,053 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:26:15,054 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:16,290 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:26:21,634 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:26:21,634 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:26:21,887 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:26:21,888 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:26:22,294 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:26:22,294 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:26:23,066 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:26:23,067 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:26:23,283 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:26:23,283 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:26:23,563 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:26:23,563 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:26:24,335 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:26:24,335 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:26:24,551 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:26:24,551 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:26:24,738 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:26:24,738 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:26:25,015 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-08 10:26:25,015 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-08 10:26:25,281 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-keys-to-console-zgtcfxz8340tf3) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:26,773 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-keys-to-console-zgtcfxz8340tf3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/keys_to_console/console.log
+2019-09-08 10:26:26,773 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-keys-to-console-zgtcfxz8340tf3) status=Stopped: deleting container.
+2019-09-08 10:26:27,332 - tests.cloud_tests - WARNING - test config modules/landscape is not enabled, skipping
+2019-09-08 10:26:27,378 - tests.cloud_tests - INFO - collecting test data for test: modules/locale
+2019-09-08 10:26:28,733 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:26:28,734 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:29,584 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:26:34,889 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:26:34,890 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:26:35,043 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:26:35,043 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:26:35,198 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:26:35,198 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:26:35,362 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:26:35,362 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:26:35,514 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:26:35,514 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:26:35,671 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:26:35,671 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:26:35,830 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:26:35,830 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:26:35,998 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:26:35,998 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:26:36,510 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:26:36,510 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:26:36,810 - tests.cloud_tests - DEBUG - running collect script: locale_default
+2019-09-08 10:26:36,810 - tests.cloud_tests - DEBUG - executing "collect: locale_default"
+2019-09-08 10:26:36,991 - tests.cloud_tests - DEBUG - running collect script: locale_a
+2019-09-08 10:26:36,991 - tests.cloud_tests - DEBUG - executing "collect: locale_a"
+2019-09-08 10:26:37,190 - tests.cloud_tests - DEBUG - running collect script: locale_gen
+2019-09-08 10:26:37,190 - tests.cloud_tests - DEBUG - executing "collect: locale_gen"
+2019-09-08 10:26:37,370 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-locale-ukakyv07wz56n4wtnf418n9) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:41,724 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-locale-ukakyv07wz56n4wtnf418n9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/locale/console.log
+2019-09-08 10:26:41,724 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-locale-ukakyv07wz56n4wtnf418n9) status=Stopped: deleting container.
+2019-09-08 10:26:42,012 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_bridge
+2019-09-08 10:26:42,829 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:26:42,830 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:26:43,943 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:26:58,358 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:26:58,358 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:26:58,587 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:26:58,587 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:26:58,767 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:26:58,767 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:26:59,118 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:26:59,118 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:26:59,326 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:26:59,326 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:26:59,518 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:26:59,518 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:26:59,691 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:26:59,691 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:26:59,879 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:26:59,879 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:27:00,050 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:27:00,050 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:27:00,314 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-08 10:27:00,314 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-08 10:27:00,474 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-08 10:27:00,475 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-08 10:27:00,634 - tests.cloud_tests - DEBUG - running collect script: lxc-bridge
+2019-09-08 10:27:00,634 - tests.cloud_tests - DEBUG - executing "collect: lxc-bridge"
+2019-09-08 10:27:00,817 - tests.cloud_tests - DEBUG - collect script lxc-bridge exited 'b'Device "lxdbr0" does not exist.\n'' and had stderr: 0
+2019-09-08 10:27:00,826 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-lxd-bridge-iva93s1qnj125fublmp) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:27:02,191 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-lxd-bridge-iva93s1qnj125fublmp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/lxd_bridge/console.log
+2019-09-08 10:27:02,191 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-lxd-bridge-iva93s1qnj125fublmp) status=Stopped: deleting container.
+2019-09-08 10:27:02,766 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_dir
+2019-09-08 10:27:04,910 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:27:04,910 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:27:05,772 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:27:18,146 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:27:18,146 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:27:18,363 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:27:18,363 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:27:18,555 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:27:18,555 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:27:18,718 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:27:18,718 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:27:18,894 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:27:18,894 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:27:19,162 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:27:19,162 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:27:19,367 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:27:19,367 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:27:19,618 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:27:19,619 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:27:20,031 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:27:20,031 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:27:20,363 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-08 10:27:20,363 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-08 10:27:20,595 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-08 10:27:20,595 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-08 10:27:20,784 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-lxd-dir-3j6jdhjf6nx42thaonod6g) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:27:22,375 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-lxd-dir-3j6jdhjf6nx42thaonod6g to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/lxd_dir/console.log
+2019-09-08 10:27:22,375 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-lxd-dir-3j6jdhjf6nx42thaonod6g) status=Stopped: deleting container.
+2019-09-08 10:27:22,664 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp
+2019-09-08 10:27:23,458 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:27:23,458 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:27:24,664 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:27:39,054 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:27:39,054 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:27:39,251 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:27:39,252 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:27:39,414 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:27:39,414 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:27:39,599 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:27:39,599 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:27:39,754 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:27:39,754 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:27:39,927 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:27:39,927 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:27:40,103 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:27:40,103 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:27:40,283 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:27:40,283 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:27:40,467 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:27:40,468 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:27:40,778 - tests.cloud_tests - DEBUG - running collect script: ntp_installed
+2019-09-08 10:27:40,778 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed"
+2019-09-08 10:27:40,991 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_empty
+2019-09-08 10:27:40,991 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_empty"
+2019-09-08 10:27:41,181 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_empty exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-08 10:27:41,183 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pool_list
+2019-09-08 10:27:41,183 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pool_list"
+2019-09-08 10:27:41,357 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-4i0e8mgtj1yyloc9l2di3q08iw) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:27:43,404 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-4i0e8mgtj1yyloc9l2di3q08iw to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ntp/console.log
+2019-09-08 10:27:43,404 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-4i0e8mgtj1yyloc9l2di3q08iw) status=Stopped: deleting container.
+2019-09-08 10:27:43,692 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_chrony
+2019-09-08 10:27:44,329 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:27:44,330 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:27:45,356 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:27:59,765 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:27:59,766 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:27:59,974 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:27:59,974 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:28:00,167 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:28:00,167 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:28:00,390 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:28:00,390 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:28:00,574 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:28:00,574 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:28:00,862 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:28:00,862 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:28:01,098 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:28:01,099 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:28:01,339 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:28:01,339 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:28:01,555 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:28:01,555 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:28:01,935 - tests.cloud_tests - DEBUG - running collect script: chrony_conf
+2019-09-08 10:28:01,935 - tests.cloud_tests - DEBUG - executing "collect: chrony_conf"
+2019-09-08 10:28:02,118 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-chrony-b7opsxx8f3d17thpxcf) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:28:03,577 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-chrony-b7opsxx8f3d17thpxcf to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ntp_chrony/console.log
+2019-09-08 10:28:03,577 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-chrony-b7opsxx8f3d17thpxcf) status=Stopped: deleting container.
+2019-09-08 10:28:03,850 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_pools
+2019-09-08 10:28:06,685 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:28:06,686 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:28:08,107 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:28:22,622 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:28:22,622 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:28:22,875 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:28:22,875 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:28:23,231 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:28:23,231 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:28:23,435 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:28:23,435 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:28:23,638 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:28:23,638 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:28:23,894 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:28:23,894 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:28:24,107 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:28:24,107 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:28:24,583 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:28:24,583 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:28:24,791 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:28:24,791 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:28:25,123 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_pools
+2019-09-08 10:28:25,123 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_pools"
+2019-09-08 10:28:25,310 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_pools
+2019-09-08 10:28:25,311 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_pools"
+2019-09-08 10:28:25,562 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_pools exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-08 10:28:25,563 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pools
+2019-09-08 10:28:25,563 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pools"
+2019-09-08 10:28:25,743 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-08 10:28:25,743 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-08 10:28:25,936 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-pools-kmgvizkmbqkiftip1h1q) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:28:27,315 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-pools-kmgvizkmbqkiftip1h1q to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ntp_pools/console.log
+2019-09-08 10:28:27,315 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-pools-kmgvizkmbqkiftip1h1q) status=Stopped: deleting container.
+2019-09-08 10:28:27,622 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_servers
+2019-09-08 10:28:28,473 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:28:28,474 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:28:29,560 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:28:43,041 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:28:43,042 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:28:43,307 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:28:43,307 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:28:43,591 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:28:43,591 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:28:43,830 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:28:43,830 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:28:44,022 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:28:44,022 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:28:44,242 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:28:44,242 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:28:44,518 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:28:44,519 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:28:44,786 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:28:44,786 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:28:45,042 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:28:45,042 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:28:45,355 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_servers
+2019-09-08 10:28:45,355 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_servers"
+2019-09-08 10:28:45,635 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_servers
+2019-09-08 10:28:45,635 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_servers"
+2019-09-08 10:28:45,833 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_servers exited 'b'cat: /etc/ntp.conf.dist: No such file or directory\n'' and had stderr: 0
+2019-09-08 10:28:45,834 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_servers
+2019-09-08 10:28:45,835 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_servers"
+2019-09-08 10:28:46,058 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-08 10:28:46,059 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-08 10:28:46,745 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-servers-on7n11vk7d19j2cmlz) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:28:48,487 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-servers-on7n11vk7d19j2cmlz to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ntp_servers/console.log
+2019-09-08 10:28:48,488 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-servers-on7n11vk7d19j2cmlz) status=Stopped: deleting container.
+2019-09-08 10:28:48,752 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_timesyncd
+2019-09-08 10:28:49,541 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:28:49,542 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:28:50,711 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:28:56,054 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:28:56,054 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:28:56,260 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:28:56,260 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:28:56,487 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:28:56,487 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:28:56,767 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:28:56,767 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:28:57,023 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:28:57,023 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:28:57,827 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:28:57,827 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:28:58,247 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:28:58,247 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:28:58,475 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:28:58,475 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:28:58,723 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:28:58,723 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:28:59,010 - tests.cloud_tests - DEBUG - running collect script: timesyncd_conf
+2019-09-08 10:28:59,010 - tests.cloud_tests - DEBUG - executing "collect: timesyncd_conf"
+2019-09-08 10:28:59,193 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-timesyncd-ah1efna5nzqoiee4) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:00,566 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ntp-timesyncd-ah1efna5nzqoiee4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ntp_timesyncd/console.log
+2019-09-08 10:29:00,566 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ntp-timesyncd-ah1efna5nzqoiee4) status=Stopped: deleting container.
+2019-09-08 10:29:00,817 - tests.cloud_tests - INFO - collecting test data for test: modules/package_update_upgrade_install
+2019-09-08 10:29:01,690 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:29:01,690 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:02,950 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:29:23,674 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:29:23,674 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:29:24,231 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:29:24,231 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:29:24,447 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:29:24,447 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:29:24,695 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:29:24,695 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:29:24,923 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:29:24,923 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:29:25,108 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:29:25,108 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:29:25,303 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:29:25,303 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:29:25,527 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:29:25,527 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:29:25,759 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:29:25,759 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:29:26,038 - tests.cloud_tests - DEBUG - running collect script: apt_history_cmdline
+2019-09-08 10:29:26,038 - tests.cloud_tests - DEBUG - executing "collect: apt_history_cmdline"
+2019-09-08 10:29:26,218 - tests.cloud_tests - DEBUG - running collect script: dpkg_show
+2019-09-08 10:29:26,218 - tests.cloud_tests - DEBUG - executing "collect: dpkg_show"
+2019-09-08 10:29:26,404 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-package-update-upgrade-fxne32z) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:27,753 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-package-update-upgrade-fxne32z to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/package_update_upgrade_install/console.log
+2019-09-08 10:29:27,754 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-package-update-upgrade-fxne32z) status=Stopped: deleting container.
+2019-09-08 10:29:28,041 - tests.cloud_tests - INFO - collecting test data for test: modules/runcmd
+2019-09-08 10:29:28,677 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:29:28,678 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:30,343 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:29:34,618 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:29:34,618 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:29:34,791 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:29:34,791 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:29:34,963 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:29:34,963 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:29:36,055 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:29:36,055 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:29:36,255 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:29:36,255 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:29:36,455 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:29:36,455 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:29:36,675 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:29:36,675 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:29:37,003 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:29:37,003 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:29:37,226 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:29:37,226 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:29:37,511 - tests.cloud_tests - DEBUG - running collect script: run_cmd
+2019-09-08 10:29:37,511 - tests.cloud_tests - DEBUG - executing "collect: run_cmd"
+2019-09-08 10:29:37,806 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-runcmd-10d2dkrg5lorw6y22jlvedp) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:39,251 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-runcmd-10d2dkrg5lorw6y22jlvedp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/runcmd/console.log
+2019-09-08 10:29:39,251 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-runcmd-10d2dkrg5lorw6y22jlvedp) status=Stopped: deleting container.
+2019-09-08 10:29:39,487 - tests.cloud_tests - WARNING - test config modules/seed_random_command is not enabled, skipping
+2019-09-08 10:29:39,560 - tests.cloud_tests - INFO - collecting test data for test: modules/seed_random_data
+2019-09-08 10:29:40,358 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:29:40,358 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:41,645 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:29:46,941 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:29:46,942 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:29:47,143 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:29:47,143 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:29:47,326 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:29:47,326 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:29:47,499 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:29:47,499 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:29:47,711 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:29:47,711 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:29:47,910 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:29:47,910 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:29:48,078 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:29:48,078 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:29:48,323 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:29:48,323 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:29:48,550 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:29:48,550 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:29:48,963 - tests.cloud_tests - DEBUG - running collect script: seed_data
+2019-09-08 10:29:48,963 - tests.cloud_tests - DEBUG - executing "collect: seed_data"
+2019-09-08 10:29:49,221 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-seed-random-data-k0ta88q1lu52d) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:51,126 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-seed-random-data-k0ta88q1lu52d to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/seed_random_data/console.log
+2019-09-08 10:29:51,126 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-seed-random-data-k0ta88q1lu52d) status=Stopped: deleting container.
+2019-09-08 10:29:51,440 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname
+2019-09-08 10:29:52,422 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:29:52,422 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:29:54,218 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:30:00,598 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:30:00,598 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:30:01,075 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:30:01,075 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:30:01,242 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:30:01,243 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:30:01,415 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:30:01,415 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:30:01,623 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:30:01,623 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:30:02,175 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:30:02,175 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:30:02,599 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:30:02,599 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:30:03,295 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:30:03,295 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:30:03,510 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:30:03,511 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:30:03,807 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-08 10:30:03,807 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-08 10:30:04,050 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-08 10:30:04,050 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-08 10:30:04,328 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-08 10:30:04,329 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-08 10:30:04,630 - tests.cloud_tests - DEBUG - collect script fqdn exited 'b'hostname: Name or service not known'' and had stderr: 1
+2019-09-08 10:30:04,637 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-hostname-2n5w3gdy1d5gp87g2) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:06,602 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-hostname-2n5w3gdy1d5gp87g2 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/set_hostname/console.log
+2019-09-08 10:30:06,603 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-hostname-2n5w3gdy1d5gp87g2) status=Stopped: deleting container.
+2019-09-08 10:30:07,900 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname_fqdn
+2019-09-08 10:30:10,717 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:30:10,718 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:11,932 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:30:17,329 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:30:17,330 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:30:17,563 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:30:17,563 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:30:17,743 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:30:17,743 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:30:17,955 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:30:17,955 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:30:18,194 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:30:18,194 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:30:18,399 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:30:18,399 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:30:18,607 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:30:18,607 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:30:18,782 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:30:18,783 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:30:18,994 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:30:18,995 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:30:19,283 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-08 10:30:19,283 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-08 10:30:19,522 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-08 10:30:19,522 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-08 10:30:19,719 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-08 10:30:19,719 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-08 10:30:19,942 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-hostname-fqdn-cl4tebemfw04) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:22,178 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-hostname-fqdn-cl4tebemfw04 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/set_hostname_fqdn/console.log
+2019-09-08 10:30:22,178 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-hostname-fqdn-cl4tebemfw04) status=Stopped: deleting container.
+2019-09-08 10:30:22,501 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password
+2019-09-08 10:30:23,397 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:30:23,398 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:24,633 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:30:30,205 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:30:30,206 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:30:30,659 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:30:30,659 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:30:30,875 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:30:30,875 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:30:31,115 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:30:31,115 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:30:31,371 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:30:31,371 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:30:31,547 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:30:31,547 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:30:31,735 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:30:31,735 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:30:31,915 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:30:31,915 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:30:32,118 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:30:32,118 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:30:32,426 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-08 10:30:32,426 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-08 10:30:32,651 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-08 10:30:32,651 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-08 10:30:32,859 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-u0wwrw7mds1w7lcgy) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:34,226 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-u0wwrw7mds1w7lcgy to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/set_password/console.log
+2019-09-08 10:30:34,227 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-u0wwrw7mds1w7lcgy) status=Stopped: deleting container.
+2019-09-08 10:30:34,532 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_expire
+2019-09-08 10:30:35,210 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:30:35,210 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:37,380 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:30:42,698 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:30:42,698 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:30:42,886 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:30:42,887 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:30:43,078 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:30:43,078 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:30:43,298 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:30:43,298 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:30:43,482 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:30:43,482 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:30:43,871 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:30:43,871 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:30:44,143 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:30:44,143 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:30:44,379 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:30:44,379 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:30:44,667 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:30:44,667 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:30:45,032 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-08 10:30:45,032 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-08 10:30:45,319 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-08 10:30:45,319 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-08 10:30:45,523 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-expire-uk83z0bd4b) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:47,359 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-expire-uk83z0bd4b to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/set_password_expire/console.log
+2019-09-08 10:30:47,373 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-expire-uk83z0bd4b) status=Stopped: deleting container.
+2019-09-08 10:30:47,952 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list
+2019-09-08 10:30:48,785 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:30:48,786 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:49,849 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:30:55,246 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:30:55,246 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:30:55,516 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:30:55,516 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:30:55,747 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:30:55,747 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:30:55,942 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:30:55,943 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:30:56,171 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:30:56,171 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:30:56,370 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:30:56,371 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:30:56,579 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:30:56,579 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:30:56,799 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:30:56,799 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:30:57,022 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:30:57,022 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:30:57,323 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-08 10:30:57,323 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-08 10:30:57,559 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-08 10:30:57,559 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-08 10:30:57,796 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-list-tektqj86h69o) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:30:59,212 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-list-tektqj86h69o to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/set_password_list/console.log
+2019-09-08 10:30:59,212 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-list-tektqj86h69o) status=Stopped: deleting container.
+2019-09-08 10:30:59,512 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list_string
+2019-09-08 10:31:00,197 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:31:00,198 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:01,068 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:31:06,426 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:31:06,426 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:31:06,635 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:31:06,635 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:31:06,839 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:31:06,839 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:31:07,063 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:31:07,063 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:31:07,294 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:31:07,294 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:31:07,470 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:31:07,471 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:31:07,691 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:31:07,691 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:31:07,943 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:31:07,943 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:31:08,183 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:31:08,183 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:31:08,466 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-08 10:31:08,467 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-08 10:31:08,702 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-08 10:31:08,702 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-08 10:31:08,894 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-list-stri-wjg8smw) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:11,106 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-set-password-list-stri-wjg8smw to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/set_password_list_string/console.log
+2019-09-08 10:31:11,106 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-set-password-list-stri-wjg8smw) status=Stopped: deleting container.
+2019-09-08 10:31:11,350 - tests.cloud_tests - WARNING - test config modules/snap is not enabled, skipping
+2019-09-08 10:31:11,355 - tests.cloud_tests - WARNING - test config modules/snappy is not enabled, skipping
+2019-09-08 10:31:11,398 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_disable
+2019-09-08 10:31:12,581 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:31:12,582 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:13,908 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:31:20,214 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:31:20,215 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:31:20,439 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:31:20,439 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:31:20,614 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:31:20,615 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:31:20,775 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:31:20,775 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:31:20,950 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:31:20,951 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:31:21,142 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:31:21,142 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:31:21,315 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:31:21,315 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:31:21,507 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:31:21,507 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:31:21,703 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:31:21,703 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:31:21,967 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-08 10:31:21,967 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-08 10:31:22,162 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-0g8huqp) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:23,594 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-0g8huqp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ssh_auth_key_fingerprints_disable/console.log
+2019-09-08 10:31:23,595 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-0g8huqp) status=Stopped: deleting container.
+2019-09-08 10:31:23,901 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_enable
+2019-09-08 10:31:24,689 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:31:24,690 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:25,626 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:31:30,958 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:31:30,958 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:31:31,139 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:31:31,139 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:31:31,331 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:31:31,331 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:31:31,555 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:31:31,555 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:31:31,790 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:31:31,790 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:31:32,031 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:31:32,031 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:31:32,247 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:31:32,247 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:31:32,506 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:31:32,506 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:31:32,759 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:31:32,759 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:31:33,054 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-08 10:31:33,055 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-08 10:31:33,342 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-nf9zloe) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:34,896 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-nf9zloe to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ssh_auth_key_fingerprints_enable/console.log
+2019-09-08 10:31:34,896 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-auth-key-fingerpri-nf9zloe) status=Stopped: deleting container.
+2019-09-08 10:31:35,232 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_import_id
+2019-09-08 10:31:35,985 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:31:35,986 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:37,097 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:31:44,565 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:31:44,566 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:31:44,815 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:31:44,816 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:31:45,034 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:31:45,035 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:31:45,198 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:31:45,198 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:31:45,374 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:31:45,374 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:31:45,542 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:31:45,542 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:31:45,715 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:31:45,715 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:31:45,895 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:31:45,895 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:31:46,066 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:31:46,067 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:31:46,346 - tests.cloud_tests - DEBUG - running collect script: auth_keys_ubuntu
+2019-09-08 10:31:46,347 - tests.cloud_tests - DEBUG - executing "collect: auth_keys_ubuntu"
+2019-09-08 10:31:46,545 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-import-id-oxg7wsycqeaebmj1) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:47,786 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-import-id-oxg7wsycqeaebmj1 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ssh_import_id/console.log
+2019-09-08 10:31:47,786 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-import-id-oxg7wsycqeaebmj1) status=Stopped: deleting container.
+2019-09-08 10:31:48,047 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_keys_generate
+2019-09-08 10:31:49,477 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:31:49,478 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:31:50,395 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:31:55,894 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:31:55,894 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:31:56,067 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:31:56,067 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:31:56,246 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:31:56,246 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:31:56,394 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:31:56,394 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:31:56,562 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:31:56,562 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:31:56,726 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:31:56,726 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:31:56,890 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:31:56,890 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:31:57,050 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:31:57,050 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:31:57,202 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:31:57,202 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:31:57,447 - tests.cloud_tests - DEBUG - running collect script: dsa_public
+2019-09-08 10:31:57,447 - tests.cloud_tests - DEBUG - executing "collect: dsa_public"
+2019-09-08 10:31:57,609 - tests.cloud_tests - DEBUG - collect script dsa_public exited 'b'cat: /etc/ssh/ssh_host_dsa_key.pub: No such file or directory'' and had stderr: 1
+2019-09-08 10:31:57,610 - tests.cloud_tests - DEBUG - running collect script: dsa_private
+2019-09-08 10:31:57,610 - tests.cloud_tests - DEBUG - executing "collect: dsa_private"
+2019-09-08 10:31:57,761 - tests.cloud_tests - DEBUG - collect script dsa_private exited 'b'cat: /etc/ssh/ssh_host_dsa_key: No such file or directory'' and had stderr: 1
+2019-09-08 10:31:57,762 - tests.cloud_tests - DEBUG - running collect script: rsa_public
+2019-09-08 10:31:57,763 - tests.cloud_tests - DEBUG - executing "collect: rsa_public"
+2019-09-08 10:31:57,937 - tests.cloud_tests - DEBUG - collect script rsa_public exited 'b'cat: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory'' and had stderr: 1
+2019-09-08 10:31:57,938 - tests.cloud_tests - DEBUG - running collect script: rsa_private
+2019-09-08 10:31:57,939 - tests.cloud_tests - DEBUG - executing "collect: rsa_private"
+2019-09-08 10:31:58,110 - tests.cloud_tests - DEBUG - collect script rsa_private exited 'b'cat: /etc/ssh/ssh_host_rsa_key: No such file or directory'' and had stderr: 1
+2019-09-08 10:31:58,110 - tests.cloud_tests - DEBUG - running collect script: ecdsa_public
+2019-09-08 10:31:58,111 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_public"
+2019-09-08 10:31:58,258 - tests.cloud_tests - DEBUG - running collect script: ecdsa_private
+2019-09-08 10:31:58,258 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_private"
+2019-09-08 10:31:58,426 - tests.cloud_tests - DEBUG - running collect script: ed25519_public
+2019-09-08 10:31:58,426 - tests.cloud_tests - DEBUG - executing "collect: ed25519_public"
+2019-09-08 10:31:58,591 - tests.cloud_tests - DEBUG - running collect script: ed25519_private
+2019-09-08 10:31:58,591 - tests.cloud_tests - DEBUG - executing "collect: ed25519_private"
+2019-09-08 10:31:58,792 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-keys-generate-ykccyrmbydr8) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:01,172 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-ssh-keys-generate-ykccyrmbydr8 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/ssh_keys_generate/console.log
+2019-09-08 10:32:01,172 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-ssh-keys-generate-ykccyrmbydr8) status=Stopped: deleting container.
+2019-09-08 10:32:01,492 - tests.cloud_tests - WARNING - test config modules/ssh_keys_provided is not enabled, skipping
+2019-09-08 10:32:01,535 - tests.cloud_tests - INFO - collecting test data for test: modules/timezone
+2019-09-08 10:32:02,401 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:32:02,402 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:03,612 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:32:08,942 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:32:08,942 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:32:09,155 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:32:09,155 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:32:09,382 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:32:09,382 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:32:09,583 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:32:09,583 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:32:09,835 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:32:09,835 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:32:10,047 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:32:10,047 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:32:10,303 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:32:10,303 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:32:10,498 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:32:10,499 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:32:10,763 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:32:10,763 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:32:11,487 - tests.cloud_tests - DEBUG - running collect script: timezone
+2019-09-08 10:32:11,487 - tests.cloud_tests - DEBUG - executing "collect: timezone"
+2019-09-08 10:32:11,818 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-timezone-d8mi77vktzpp85g71ui54) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:13,747 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-timezone-d8mi77vktzpp85g71ui54 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/timezone/console.log
+2019-09-08 10:32:13,748 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-timezone-d8mi77vktzpp85g71ui54) status=Stopped: deleting container.
+2019-09-08 10:32:14,119 - tests.cloud_tests - INFO - collecting test data for test: modules/user_groups
+2019-09-08 10:32:14,942 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:32:14,942 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:16,277 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:32:21,602 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:32:21,602 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:32:21,779 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:32:21,779 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:32:21,967 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:32:21,967 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:32:22,130 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:32:22,130 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:32:22,290 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:32:22,291 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:32:22,431 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:32:22,431 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:32:22,594 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:32:22,594 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:32:22,791 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:32:22,791 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:32:22,966 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:32:22,966 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:32:23,227 - tests.cloud_tests - DEBUG - running collect script: group_ubuntu
+2019-09-08 10:32:23,227 - tests.cloud_tests - DEBUG - executing "collect: group_ubuntu"
+2019-09-08 10:32:23,378 - tests.cloud_tests - DEBUG - running collect script: group_cloud_users
+2019-09-08 10:32:23,379 - tests.cloud_tests - DEBUG - executing "collect: group_cloud_users"
+2019-09-08 10:32:23,530 - tests.cloud_tests - DEBUG - running collect script: user_ubuntu
+2019-09-08 10:32:23,530 - tests.cloud_tests - DEBUG - executing "collect: user_ubuntu"
+2019-09-08 10:32:23,738 - tests.cloud_tests - DEBUG - running collect script: user_foobar
+2019-09-08 10:32:23,738 - tests.cloud_tests - DEBUG - executing "collect: user_foobar"
+2019-09-08 10:32:23,882 - tests.cloud_tests - DEBUG - running collect script: user_barfoo
+2019-09-08 10:32:23,882 - tests.cloud_tests - DEBUG - executing "collect: user_barfoo"
+2019-09-08 10:32:24,058 - tests.cloud_tests - DEBUG - running collect script: user_cloudy
+2019-09-08 10:32:24,059 - tests.cloud_tests - DEBUG - executing "collect: user_cloudy"
+2019-09-08 10:32:24,231 - tests.cloud_tests - DEBUG - running collect script: root_groups
+2019-09-08 10:32:24,231 - tests.cloud_tests - DEBUG - executing "collect: root_groups"
+2019-09-08 10:32:24,395 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-user-groups-9dxpgwsqaxljlpym1t) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:26,983 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-user-groups-9dxpgwsqaxljlpym1t to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/user_groups/console.log
+2019-09-08 10:32:26,984 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-user-groups-9dxpgwsqaxljlpym1t) status=Stopped: deleting container.
+2019-09-08 10:32:27,303 - tests.cloud_tests - INFO - collecting test data for test: modules/write_files
+2019-09-08 10:32:28,065 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-08 10:32:28,066 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:28,954 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-08 10:32:34,326 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-08 10:32:34,326 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-08 10:32:34,519 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-08 10:32:34,519 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-08 10:32:34,750 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-08 10:32:34,750 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-08 10:32:34,959 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-08 10:32:34,959 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-08 10:32:35,158 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-08 10:32:35,158 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-08 10:32:35,334 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-08 10:32:35,335 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-08 10:32:35,543 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-08 10:32:35,543 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-08 10:32:35,766 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-08 10:32:35,766 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-08 10:32:35,938 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-08 10:32:35,938 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-08 10:32:36,191 - tests.cloud_tests - DEBUG - running collect script: file_b64
+2019-09-08 10:32:36,191 - tests.cloud_tests - DEBUG - executing "collect: file_b64"
+2019-09-08 10:32:36,434 - tests.cloud_tests - DEBUG - running collect script: file_text
+2019-09-08 10:32:36,434 - tests.cloud_tests - DEBUG - executing "collect: file_text"
+2019-09-08 10:32:36,647 - tests.cloud_tests - DEBUG - running collect script: file_binary
+2019-09-08 10:32:36,647 - tests.cloud_tests - DEBUG - executing "collect: file_binary"
+2019-09-08 10:32:36,866 - tests.cloud_tests - DEBUG - running collect script: file_gzip
+2019-09-08 10:32:36,866 - tests.cloud_tests - DEBUG - executing "collect: file_gzip"
+2019-09-08 10:32:37,113 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-write-files-vu1wycsvceigygu4rj) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-08 10:32:39,320 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-xenial-modules-write-files-vu1wycsvceigygu4rj to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results/lxd/xenial/modules/write_files/console.log
+2019-09-08 10:32:39,321 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-modules-write-files-vu1wycsvceigygu4rj) status=Stopped: deleting container.
+2019-09-08 10:32:39,521 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-snapshot-onbr08vl06h2w3hw6kd6rpj0hwgad) status=Frozen: deleting container.
+2019-09-08 10:32:39,584 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-snapshot-onbr08vl06h2w3hw6kd6rpj0hwgad) status=Running: shutting down (wait=True)
+2019-09-08 10:32:41,494 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-image-modification-1n0733o6iatvdq0sls6) status=Running: deleting container.
+2019-09-08 10:32:41,511 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-xenial-image-modification-1n0733o6iatvdq0sls6) status=Running: shutting down (wait=True)
+2019-09-08 10:32:43,465 - tests.cloud_tests - DEBUG - collect stages: {'name': 'collect data', 'time': 691.8460109233856, 'errors': [], 'stages': [{'name': 'collect for platform: lxd', 'time': 689.3444132804871, 'errors': [], 'stages': [{'name': 'set up and collect data for os: xenial', 'time': 686.052099943161, 'errors': [], 'stages': [{'name': 'set up for ubuntu-xenial', 'time': 14.467163562774658, 'errors': [], 'stages': [{'name': 'setup func for --repo, enable repo', 'time': 7.938965559005737, 'errors': [], 'success': True}, {'name': 'setup func for --upgrade, upgrade cloud-init', 'time': 6.528162956237793, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect test data for xenial', 'time': 644.6295881271362, 'errors': [], 'stages': [{}, {}, {'name': 'collect for test: bugs/lp1628337', 'time': 16.176899194717407, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.303983688354492, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20609569549560547, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.20316529273986816, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1795351505279541, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2198774814605713, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.200453519821167, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.18348336219787598, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2239367961883545, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1680307388305664, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2881789207458496, 'errors': [], 'success': True}], 'success': True}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {'name': 'collect for test: main/command_output_simple', 'time': 8.344369411468506, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.1915812492370605, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.185089111328125, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.163712739944458, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.18393182754516602, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20413780212402344, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1798253059387207, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.3080322742462158, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22847771644592285, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.22341585159301758, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2843756675720215, 'errors': [], 'success': True}, {'name': 'script cloud-init-test-output', 'time': 0.19163227081298828, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_conf', 'time': 8.387601137161255, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.262238025665283, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.22515296936035156, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.22012543678283691, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17193031311035156, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.22836947441101074, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19530820846557617, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1685938835144043, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22323870658874512, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18456625938415527, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3040122985839844, 'errors': [], 'success': True}, {'name': 'script 94cloud-init-config', 'time': 0.2038712501525879, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_disable_suites', 'time': 7.352756500244141, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 5.215246915817261, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1572127342224121, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15937113761901855, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16890907287597656, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17970967292785645, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.22422409057617188, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22358107566833496, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.28391551971435547, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2277524471282959, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3125879764556885, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.20007014274597168, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_primary', 'time': 7.939779996871948, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.206998348236084, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15371131896972656, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1434798240661621, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15559124946594238, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17190098762512207, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17684221267700195, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16733598709106445, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1960604190826416, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15978097915649414, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24396610260009766, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.16394662857055664, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_proxy', 'time': 7.099000692367554, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 5.3740074634552, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.22920584678649902, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1436312198638916, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1318964958190918, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16809487342834473, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18392109870910645, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15195035934448242, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16802144050598145, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16797089576721191, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2282547950744629, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-aptproxy', 'time': 0.15189290046691895, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_security', 'time': 8.543830394744873, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.238639831542969, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.241499662399292, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.22769451141357422, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2113802433013916, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.18024802207946777, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.28374409675598145, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19200348854064941, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23610520362854004, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2038271427154541, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.33598828315734863, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.19250869750976562, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_key', 'time': 12.74027705192566, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.431146383285522, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1929175853729248, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14365100860595703, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15200376510620117, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1479184627532959, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13603639602661133, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1681663990020752, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.18395018577575684, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17185401916503906, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24800562858581543, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.3440895080566406, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.42035818099975586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_keyserver', 'time': 12.783587455749512, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.34248661994934, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20961904525756836, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.22363924980163574, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.21634602546691895, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20366406440734863, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21969294548034668, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1600198745727539, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1953752040863037, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.19669079780578613, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2521343231201172, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.21576976776123047, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.34790849685668945, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_list', 'time': 8.89794921875, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.416858434677124, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1972038745880127, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2037825584411621, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.25986671447753906, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.23583078384399414, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2158665657043457, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.24859189987182617, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.20780491828918457, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.4036834239959717, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.33222413063049316, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.17603206634521484, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_ppa', 'time': 16.60618782043457, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.097260475158691, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.23117661476135254, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.12552547454833984, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1641099452972412, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15204858779907227, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16787457466125488, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.18015122413635254, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.24043011665344238, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.30809545516967773, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.30330443382263184, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.20396757125854492, 'errors': [], 'success': True}, {'name': 'script apt-key', 'time': 0.26797986030578613, 'errors': [], 'success': True}, {'name': 'script sources_full', 'time': 0.16405677795410156, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_disable', 'time': 7.1918861865997314, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 5.162911891937256, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16116094589233398, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.23194575309753418, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20757365226745605, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20456910133361816, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16738319396972656, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16870331764221191, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1839749813079834, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15546274185180664, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3164553642272949, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining', 'time': 0.23155975341796875, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_os', 'time': 9.756158828735352, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.610797882080078, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20574212074279785, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2547330856323242, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2562675476074219, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20410966873168945, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18820595741271973, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.9681179523468018, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2760310173034668, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.23990511894226074, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3238027095794678, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining_not_written', 'time': 0.22824358940124512, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/bootcmd', 'time': 8.117101192474365, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.384388208389282, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16487908363342285, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1717391014099121, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15187764167785645, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1640760898590088, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1639728546142578, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16821742057800293, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1638634204864502, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17273831367492676, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2517380714416504, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.15943288803100586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/byobu', 'time': 10.022989273071289, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.246203660964966, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.21754193305969238, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.22308015823364258, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.24403166770935059, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20839929580688477, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.24788880348205566, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2399444580078125, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.25968170166015625, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2199084758758545, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.31258392333984375, 'errors': [], 'success': True}, {'name': 'script byobu_profile_enabled', 'time': 0.3159458637237549, 'errors': [], 'success': True}, {'name': 'script byobu_launch_exists', 'time': 0.28753089904785156, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ca_certs', 'time': 10.683696746826172, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.678555965423584, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.5612270832061768, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.29512667655944824, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.24047350883483887, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.3121020793914795, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.24340200424194336, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22448205947875977, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22810125350952148, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17937660217285156, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.32790398597717285, 'errors': [], 'success': True}, {'name': 'script cert_links', 'time': 0.18864202499389648, 'errors': [], 'success': True}, {'name': 'script cert', 'time': 0.20404911041259766, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_disable', 'time': 9.73299264907837, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.295974969863892, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2577245235443115, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.3270728588104248, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.3319840431213379, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2763688564300537, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.23192119598388672, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2679464817047119, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.20795106887817383, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.23602509498596191, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.29984569549560547, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_enable', 'time': 8.70057487487793, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.787010908126831, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.19710993766784668, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1797773838043213, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1922929286956787, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20764899253845215, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1799473762512207, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19274139404296875, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2238759994506836, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.19538116455078125, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.34462594985961914, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/final_message', 'time': 8.562257051467896, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.532905340194702, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2416529655456543, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.24307799339294434, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.22429156303405762, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.21589899063110352, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1997230052947998, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1918773651123047, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23650479316711426, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1800084114074707, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.29611802101135254, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/keys_to_console', 'time': 10.17908501625061, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.538096189498901, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2538597583770752, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.4068903923034668, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.772144079208374, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.21619677543640137, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.28001999855041504, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.7721157073974609, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.21588706970214844, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18744730949401855, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2767341136932373, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.2595076560974121, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/locale', 'time': 8.586151123046875, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.112806081771851, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15331292152404785, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15537071228027344, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16410160064697266, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1519622802734375, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15637564659118652, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15948104858398438, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16808605194091797, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.5120425224304199, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2999250888824463, 'errors': [], 'success': True}, {'name': 'script locale_default', 'time': 0.18043875694274902, 'errors': [], 'success': True}, {'name': 'script locale_a', 'time': 0.19945001602172852, 'errors': [], 'success': True}, {'name': 'script locale_gen', 'time': 0.1725907325744629, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_bridge', 'time': 17.939469575881958, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.478182554244995, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.22951173782348633, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17955636978149414, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.3515658378601074, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20796680450439453, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19185853004455566, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17258191108703613, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.18784523010253906, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17170190811157227, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2639167308807373, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.1602935791015625, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.15957331657409668, 'errors': [], 'success': True}, {'name': 'script lxc-bridge', 'time': 0.18470191955566406, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_dir', 'time': 15.822756290435791, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 13.19014835357666, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2176823616027832, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19139528274536133, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16344809532165527, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17612075805664062, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.26787614822387695, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20458459854125977, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2515840530395508, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.4122328758239746, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3323018550872803, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.23183846473693848, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.18332958221435547, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp', 'time': 17.85148310661316, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.554298639297485, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.19779706001281738, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16285490989685059, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.18446660041809082, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1555795669555664, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1724705696105957, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17595720291137695, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17988252639770508, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18462800979614258, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.31096553802490234, 'errors': [], 'success': True}, {'name': 'script ntp_installed', 'time': 0.21257328987121582, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_empty', 'time': 0.19196391105651855, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pool_list', 'time': 0.16782402992248535, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_chrony', 'time': 17.741642236709595, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.396414518356323, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20820140838623047, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19290447235107422, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.22362160682678223, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1840832233428955, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2879207134246826, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2361617088317871, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.24019503593444824, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.21620845794677734, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.38011789321899414, 'errors': [], 'success': True}, {'name': 'script chrony_conf', 'time': 0.17561769485473633, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_pools', 'time': 19.20635485649109, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.897682905197144, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2534008026123047, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.3555946350097656, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20398187637329102, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20360398292541504, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2558786869049072, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2125396728515625, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.47599244117736816, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.20792841911315918, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.33206820487976074, 'errors': [], 'success': True}, {'name': 'script ntp_installed_pools', 'time': 0.18752288818359375, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_pools', 'time': 0.2525362968444824, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pools', 'time': 0.17975378036499023, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.18759965896606445, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_servers', 'time': 18.22563934326172, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.528669118881226, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2651200294494629, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.284151554107666, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2394092082977295, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.19201326370239258, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21997809410095215, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2761538028717041, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.26775455474853516, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2561070919036865, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.312427282333374, 'errors': [], 'success': True}, {'name': 'script ntp_installed_servers', 'time': 0.28023314476013184, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_servers', 'time': 0.1995086669921875, 'errors': [], 'success': True}, {'name': 'script ntp_conf_servers', 'time': 0.22396230697631836, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.6799118518829346, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_timesyncd', 'time': 9.60953402519226, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.476418733596802, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20641231536865234, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.22682404518127441, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.27999162673950195, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2560129165649414, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.8039836883544922, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.4200718402862549, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22803163528442383, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.24785137176513672, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2875173091888428, 'errors': [], 'success': True}, {'name': 'script timesyncd_conf', 'time': 0.17619800567626953, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/package_update_upgrade_install', 'time': 24.664175987243652, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 21.939489126205444, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.5575418472290039, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.21553730964660645, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.24812650680541992, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.22778630256652832, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18486642837524414, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19492793083190918, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22437572479248047, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.23195409774780273, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.27925872802734375, 'errors': [], 'success': True}, {'name': 'script apt_history_cmdline', 'time': 0.1799921989440918, 'errors': [], 'success': True}, {'name': 'script dpkg_show', 'time': 0.18005943298339844, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/runcmd', 'time': 9.084722518920898, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 5.903542757034302, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1736915111541748, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17142081260681152, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 1.091951608657837, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20028018951416016, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19963598251342773, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22005248069763184, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.32822084426879883, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.22320318222045898, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2847623825073242, 'errors': [], 'success': True}, {'name': 'script run_cmd', 'time': 0.287736177444458, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/seed_random_data', 'time': 8.454948663711548, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.181979656219482, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20169663429260254, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.18312716484069824, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17250394821166992, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2120685577392578, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19925832748413086, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16809630393981934, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.24440836906433105, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.22741961479187012, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.4129369258880615, 'errors': [], 'success': True}, {'name': 'script seed_data', 'time': 0.2512545585632324, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname', 'time': 12.167229175567627, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 8.134037971496582, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.47698020935058594, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16771507263183594, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17221426963806152, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2082231044769287, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.5516560077667236, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.4242212772369385, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.6957943439483643, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.21579813957214355, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2962038516998291, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.24357247352600098, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.2780337333679199, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.30254459381103516, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname_fqdn', 'time': 9.156401634216309, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.551331281661987, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2332921028137207, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.18005800247192383, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.21186614036560059, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.23958516120910645, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.20435857772827148, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20795392990112305, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1756737232208252, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.21204662322998047, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.28832530975341797, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.2394256591796875, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.19662213325500488, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.21564006805419922, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password', 'time': 9.395805835723877, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.751051187515259, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.4536406993865967, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.21556544303894043, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.23992919921875, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2559685707092285, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17600345611572266, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1881875991821289, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1798555850982666, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2035808563232422, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.307966947555542, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.2242734432220459, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.19957327842712402, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_expire', 'time': 10.257529735565186, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.440273284912109, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1887955665588379, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19187092781066895, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2198805809020996, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.18395233154296875, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.3883812427520752, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.27202486991882324, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23596835136413574, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.28817129135131836, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3647804260253906, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.28708505630493164, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.19611573219299316, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list', 'time': 8.953367471694946, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.40878963470459, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2701289653778076, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.23079228401184082, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.19579386711120605, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.22806429862976074, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19987916946411133, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20817136764526367, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.21981406211853027, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.22360706329345703, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3006892204284668, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.23577308654785156, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.23163771629333496, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list_string', 'time': 8.648725271224976, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.187323093414307, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20970439910888672, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.20335054397583008, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2240734100341797, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2315380573272705, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17618656158447266, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2202460765838623, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2519221305847168, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2402663230895996, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2834584712982178, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.23581290245056152, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.18462824821472168, 'errors': [], 'success': True}], 'success': True}, {}, {}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_disable', 'time': 9.494787216186523, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.554379224777222, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.22490429878234863, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17525649070739746, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16008901596069336, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1757488250732422, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19170761108398438, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17258882522583008, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19184017181396484, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.19623947143554688, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2639656066894531, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.1878657341003418, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_enable', 'time': 8.606518745422363, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.2292375564575195, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18157315254211426, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19144797325134277, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.22399401664733887, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.23545312881469727, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.24036145210266113, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.21613860130310059, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.259549617767334, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.25255322456359863, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.29559993743896484, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.2804083824157715, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_import_id', 'time': 10.51440143585205, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 8.541436433792114, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2499525547027588, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.21901488304138184, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16365885734558105, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17617368698120117, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1679096221923828, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1724224090576172, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1799907684326172, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17171788215637207, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.27992987632751465, 'errors': [], 'success': True}, {'name': 'script auth_keys_ubuntu', 'time': 0.19200539588928223, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_keys_generate', 'time': 9.250215291976929, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.3574981689453125, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17351865768432617, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1791079044342041, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14801526069641113, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16805481910705566, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16387367248535156, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16403675079345703, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16004705429077148, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15183186531066895, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24444937705993652, 'errors': [], 'success': True}, {'name': 'script dsa_public', 'time': 0.1637709140777588, 'errors': [], 'success': True}, {'name': 'script dsa_private', 'time': 0.15209722518920898, 'errors': [], 'success': True}, {'name': 'script rsa_public', 'time': 0.17605090141296387, 'errors': [], 'success': True}, {'name': 'script rsa_private', 'time': 0.1720132827758789, 'errors': [], 'success': True}, {'name': 'script ecdsa_public', 'time': 0.14751601219177246, 'errors': [], 'success': True}, {'name': 'script ecdsa_private', 'time': 0.16807794570922852, 'errors': [], 'success': True}, {'name': 'script ed25519_public', 'time': 0.1644134521484375, 'errors': [], 'success': True}, {'name': 'script ed25519_private', 'time': 0.1955718994140625, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/timezone', 'time': 9.337286233901978, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.467971324920654, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.21322083473205566, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.22747182846069336, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20049643516540527, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.25188612937927246, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21219921112060547, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2560994625091553, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19532108306884766, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2646031379699707, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.7242856025695801, 'errors': [], 'success': True}, {'name': 'script timezone', 'time': 0.3235166072845459, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/user_groups', 'time': 9.353716850280762, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.565063953399658, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17755842208862305, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.18767905235290527, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16339778900146484, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16031289100646973, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14003324508666992, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1634981632232666, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19667744636535645, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17531824111938477, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2606053352355957, 'errors': [], 'success': True}, {'name': 'script group_ubuntu', 'time': 0.1516246795654297, 'errors': [], 'success': True}, {'name': 'script group_cloud_users', 'time': 0.15181851387023926, 'errors': [], 'success': True}, {'name': 'script user_ubuntu', 'time': 0.2081303596496582, 'errors': [], 'success': True}, {'name': 'script user_foobar', 'time': 0.14377689361572266, 'errors': [], 'success': True}, {'name': 'script user_barfoo', 'time': 0.17632675170898438, 'errors': [], 'success': True}, {'name': 'script user_cloudy', 'time': 0.17215514183044434, 'errors': [], 'success': True}, {'name': 'script root_groups', 'time': 0.15947246551513672, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/write_files', 'time': 8.982603073120117, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.2014195919036865, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1930854320526123, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.23160219192504883, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20827555656433105, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.19967412948608398, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17612028121948242, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20819473266601562, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22365903854370117, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17189955711364746, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2525503635406494, 'errors': [], 'success': True}, {'name': 'script file_b64', 'time': 0.24348092079162598, 'errors': [], 'success': True}, {'name': 'script file_text', 'time': 0.21250009536743164, 'errors': [], 'success': True}, {'name': 'script file_binary', 'time': 0.21944761276245117, 'errors': [], 'success': True}, {'name': 'script file_gzip', 'time': 0.24043726921081543, 'errors': [], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}
+2019-09-08 10:32:43,468 - tests.cloud_tests - DEBUG - found test data: {'lxd': {'xenial': ['bugs/lp1628337', 'modules/apt_configure_sources_list', 'modules/locale', 'modules/apt_configure_primary', 'modules/lxd_bridge', 'modules/apt_configure_security', 'modules/apt_pipelining_os', 'modules/ssh_import_id', 'modules/ntp_pools', 'modules/ssh_keys_generate', 'modules/ssh_auth_key_fingerprints_enable', 'modules/apt_configure_sources_keyserver', 'modules/bootcmd', 'modules/set_hostname_fqdn', 'modules/ssh_auth_key_fingerprints_disable', 'modules/final_message', 'modules/apt_configure_sources_key', 'modules/ntp_servers', 'modules/ntp_chrony', 'modules/write_files', 'modules/set_password', 'modules/ntp', 'modules/timezone', 'modules/keys_to_console', 'modules/debug_enable', 'modules/seed_random_data', 'modules/set_password_list', 'modules/user_groups', 'modules/debug_disable', 'modules/byobu', 'modules/apt_configure_proxy', 'modules/apt_configure_sources_ppa', 'modules/package_update_upgrade_install', 'modules/ntp_timesyncd', 'modules/lxd_dir', 'modules/apt_pipelining_disable', 'modules/runcmd', 'modules/set_hostname', 'modules/apt_configure_conf', 'modules/apt_configure_disable_suites', 'modules/set_password_list_string', 'modules/set_password_expire', 'modules/ca_certs', 'main/command_output_simple']}}
+
+2019-09-08 10:32:43,468 - tests.cloud_tests - INFO - test: platform='lxd', os='xenial' verifying test data
+2019-09-08 10:32:43,468 - tests.cloud_tests - DEBUG - verifying test data for bugs/lp1628337
+test_fetch_indices (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify no apt errors. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify can find ntp and install it. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,514 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Unexpected warnings should not be found in the log. ... ok
+test_sources_list (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Test sources.list includes sources. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:43,558 - tests.cloud_tests - DEBUG - verifying test data for modules/locale
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by lxd platform. ... ok
+test_locale (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale is set properly. ... ok
+test_locale_a (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale -a has both options. ... ok
+test_locale_gen (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test local.gen file has all entries. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,602 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_primary
+test_gatech_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test GaTech entries exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Unexpected warnings should not be found in the log. ... ok
+test_ubuntu_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test no default Ubuntu entries exist. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,647 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_bridge
+test_bridge (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test bridge config. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by lxd platform. ... ok
+test_lxc (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,697 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_security
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Unexpected warnings should not be found in the log. ... ok
+test_security_mirror (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Test security lines added and uncommented in source.list. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,741 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_os
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Unexpected warnings should not be found in the log. ... ok
+test_os_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+test 'os' settings does not write apt config file. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,786 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_import_id
+test_authorized_keys (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Test that ssh keys were imported. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,827 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_pools
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test dist config file is empty ... ok
+test_ntp_entires (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.004s
+
+OK (skipped=2)
+2019-09-08 10:32:43,891 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_keys_generate
+test_dsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa private key not generated. ... ok
+test_dsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa public key not generated. ... ok
+test_ecdsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ecdsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ed25519_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_ed25519_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Unexpected warnings should not be found in the log. ... ok
+test_rsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+test_rsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+
+----------------------------------------------------------------------
+Ran 13 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,936 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_enable
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Unexpected warnings should not be found in the log. ... ok
+test_syslog (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Verify output of syslog. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:43,978 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_keyserver
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test specific key added. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,025 - tests.cloud_tests - DEBUG - verifying test data for modules/bootcmd
+test_bootcmd_host (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Test boot cmd worked. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,068 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname_fqdn
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname output. ... ok
+test_hostname_fqdn (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname fqdn output. ... ok
+test_hosts (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test /etc/hosts file. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,111 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_disable
+test_cloud_init_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Verify disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,152 - tests.cloud_tests - DEBUG - verifying test data for modules/final_message
+test_final_message_string (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure final handles regular strings. ... ok
+test_final_message_subs (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Test variable substitution in final message. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:44,196 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_key
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test key list updated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,240 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_servers
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test config server entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:44,339 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_chrony
+test_chrony_entries (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Test chrony config entries ... skipped 'No support for chrony on containers <= artful. LP: #1589780'
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by ec2 platform. ... skipped 'No support for chrony on containers <= artful. LP: #1589780'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'No support for chrony on containers <= artful. LP: #1589780'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by lxd platform. ... skipped 'No support for chrony on containers <= artful. LP: #1589780'
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Ensure that there were no errors in any stage. ... skipped 'No support for chrony on containers <= artful. LP: #1589780'
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Unexpected warnings should not be found in the log. ... skipped 'No support for chrony on containers <= artful. LP: #1589780'
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.000s
+
+OK (skipped=6)
+2019-09-08 10:32:44,397 - tests.cloud_tests - DEBUG - verifying test data for modules/write_files
+test_b64 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test b64 encoded file reads as ascii. ... ok
+test_binary (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test binary file reads as executable. ... ok
+test_gzip (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test gzip file shows up as a shell script. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Unexpected warnings should not be found in the log. ... ok
+test_text (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test text shows up as ASCII text. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,439 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test ubuntu user in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,480 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test ntp installed ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,524 - tests.cloud_tests - DEBUG - verifying test data for modules/timezone
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Unexpected warnings should not be found in the log. ... ok
+test_timezone (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Test date prints correct timezone. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,565 - tests.cloud_tests - DEBUG - verifying test data for modules/keys_to_console
+test_excluded_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test excluded keys missing. ... ok
+test_expected_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test expected keys exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,610 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_enable
+test_debug_enable (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Test debug messages in cloud-init log. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,652 - tests.cloud_tests - DEBUG - verifying test data for modules/seed_random_data
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Unexpected warnings should not be found in the log. ... ok
+test_random_seed_data (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Test random data passed in exists. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,697 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.020s
+
+OK (skipped=2)
+2019-09-08 10:32:44,760 - tests.cloud_tests - DEBUG - verifying test data for modules/user_groups
+test_group_cloud_users (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloud users group exists. ... ok
+test_group_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu group exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Unexpected warnings should not be found in the log. ... ok
+test_user_barfoo (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test barfoo user exists. ... ok
+test_user_cloudy (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloudy user exists. ... ok
+test_user_foobar (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test foobar user exists. ... ok
+test_user_root_in_secret (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test root user is in 'secret' group. ... ok
+test_user_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu user exists. ... ok
+
+----------------------------------------------------------------------
+Ran 12 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:44,806 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_disable
+test_debug_disable (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Test verbose output missing from logs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,850 - tests.cloud_tests - DEBUG - verifying test data for modules/byobu
+test_byobu_installed (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu installed. ... ok
+test_byobu_launch_exists (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu-launch exists. ... ok
+test_byobu_profile_enabled (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu profile.d file exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,892 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_proxy
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Unexpected warnings should not be found in the log. ... ok
+test_proxy_config (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Test proxy options added to apt config. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:44,935 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_ppa
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Unexpected warnings should not be found in the log. ... ok
+test_ppa (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test specific ppa added. ... ok
+test_ppa_key (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test ppa key added. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,000 - tests.cloud_tests - DEBUG - verifying test data for modules/package_update_upgrade_install
+test_apt_history (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test apt history for update command. ... ok
+test_cloud_init_output (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test cloud-init-output for install & upgrade stuff. ... ok
+test_installed_sl (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test sl got installed. ... ok
+test_installed_tree (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test tree got installed. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:45,053 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_timesyncd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Unexpected warnings should not be found in the log. ... ok
+test_timesyncd_entries (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Test timesyncd config entries ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,097 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_dir
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by lxd platform. ... ok
+test_lxc (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,140 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_disable
+test_disable_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Test pipelining disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:45,188 - tests.cloud_tests - DEBUG - verifying test data for modules/runcmd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Unexpected warnings should not be found in the log. ... ok
+test_run_cmd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Test run command worked. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,282 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Test hostname command shows correct output. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,327 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_conf
+test_apt_conf_assumeyes (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config assumes true. ... ok
+test_apt_conf_fixbroken (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config fixes broken. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,377 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_disable_suites
+test_empty_sourcelist (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Test source list is empty. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,420 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list_string
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-08 10:32:45,467 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_expire
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test user frozen in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,509 - tests.cloud_tests - DEBUG - verifying test data for modules/ca_certs
+test_cert_installed (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test line from our cert exists. ... ok
+test_certs_updated (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test certs have been updated in /etc/ssl/certs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-08 10:32:45,555 - tests.cloud_tests - DEBUG - verifying test data for main/command_output_simple
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Unexpected warnings should not be found in the log. ... ok
+test_output_file (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that the output file is not empty and has all stages. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-08 10:32:45,599 - tests.cloud_tests - INFO - test: platform='lxd', os='xenial' passed all tests
+2019-09-08 10:32:45,600 - tests.cloud_tests - DEBUG - 
+---- Verify summarized results:
+
+Platform: lxd
+  Distro: xenial
+    test modules passed:44 tests failed:0
+2019-09-08 10:32:45,600 - tests.cloud_tests - INFO - leaving data in /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-x-lxd/cloud-init/results
+___________________________________ summary ____________________________________
+  citest: commands succeeded
+  congratulations :)
++ RET=0
++ find . -name id_rsa* -delete
++ exit 0
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS
+=== End series x ===
+=== Begin series b ===
+Started by remote host 10.247.8.15
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd
+[cloud-init-integration-proposed-b-lxd] $ /bin/sh -xe /tmp/jenkins14563598334340670395.sh
++ release=bionic
++ release_ver=18.04
++ platform=lxd
++ set -e
++ sudo rm -Rf cloud-init
++ git clone https://git.launchpad.net/cloud-init
+Cloning into 'cloud-init'...
++ cd cloud-init
++ git tag --list
++ grep 18.04
++ tail -1
++ tag=ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
++ echo Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
+Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
++ git checkout ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1
+Note: checking out 'ubuntu/19.2-24-ge7881d5c-0ubuntu1_18.04.1'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at 22acf15e releasing cloud-init version 19.2-24-ge7881d5c-0ubuntu1~18.04.1
++ mirror=http://archive.ubuntu.com/ubuntu/
++ hostname
++ [ -z  -a torkoal = torkoal ]
++ export TMPDIR=/var/lib/jenkins/tmp/
++ set +e
++ no_proxy=launchpad.net https_proxy=http://squid.internal:3128 tox -e citest -- run --os-name=bionic --platform=lxd --repo='deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main' --preserve-data --data-dir=./results --verbose
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/setup.py
+citest create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest
+citest installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/integration-requirements.txt
+citest inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/dist/cloud-init-19.2.zip
+citest installed: asn1crypto==0.24.0,attrs==19.1.0,bcrypt==3.1.7,boto3==1.5.9,botocore==1.8.50,certifi==2019.6.16,cffi==1.12.3,chardet==3.0.4,cloud-init==19.2,configobj==5.0.6,cryptography==2.4.2,docutils==0.15.2,idna==2.8,Jinja2==2.10.1,jmespath==0.9.4,jsonpatch==1.24,jsonpointer==2.0,jsonschema==3.0.2,linecache2==1.0.0,MarkupSafe==1.1.1,oauthlib==3.1.0,paramiko==2.4.2,pbr==5.4.3,pkg-resources==0.0.0,pyasn1==0.4.7,pycparser==2.19,pylxd==2.2.7,PyNaCl==1.3.0,pyrsistent==0.15.4,python-dateutil==2.8.0,python-simplestreams==0.1.0,PyYAML==5.1.2,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,s3transfer==0.1.13,six==1.12.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.3,ws4py==0.5.1
+citest runtests: PYTHONHASHSEED='4086161548'
+citest runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=bionic --platform=lxd --repo=deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main --preserve-data --data-dir=./results --verbose
+2019-09-09 10:49:59,554 - tests.cloud_tests - DEBUG - running with args: Namespace(data_dir='/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results', deb=None, feature_override={}, os_name=['bionic'], platform=['lxd'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo='deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main', result=None, rpm=None, script=None, subcmd='run', test_config=['/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1511485.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1611074.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1628337.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/add_apt_repositories.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/alter_completion_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/configure_instance_trusted_ca_certificates.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/configure_instances_ssh_keys.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/including_user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/install_arbitrary_packages.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/install_run_chef_recipes.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_apt_upgrade.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_commands.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_commands_first_boot.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/setup_run_puppet.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/examples/writing_out_arbitrary_files.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/main/command_output_simple.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_conf.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_disable_suites.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_primary.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_proxy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_security.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_key.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_keyserver.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_os.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/bootcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/byobu.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ca_certs.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/debug_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/debug_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/final_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/keys_to_console.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/landscape.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/locale.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/lxd_bridge.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/lxd_dir.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_chrony.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_pools.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_servers.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_timesyncd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/package_update_upgrade_install.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/runcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/seed_random_command.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/seed_random_data.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_hostname.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_hostname_fqdn.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_expire.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_list_string.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/snap.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/snappy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_import_id.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_generate.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_provided.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/timezone.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/tests/cloud_tests/testcases/modules/write_files.yaml'], upgrade=True, upgrade_full=False, verbose=True)
+2019-09-09 10:49:59,554 - tests.cloud_tests - DEBUG - using tmpdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results
+2019-09-09 10:49:59,562 - tests.cloud_tests - DEBUG - platform config: {'enabled': True, 'get_image_timeout': 300, 'create_instance_timeout': 60, 'private_key': 'cloud_init_rsa', 'public_key': 'cloud_init_rsa.pub', 'template_overrides': {'/var/lib/cloud/seed/nocloud-net/meta-data': {'when': ['create', 'copy'], 'template': 'cloud-init-meta.tpl'}, '/var/lib/cloud/seed/nocloud-net/network-config': {'when': ['create', 'copy'], 'template': 'cloud-init-network.tpl'}, '/var/lib/cloud/seed/nocloud-net/user-data': {'when': ['create', 'copy'], 'template': 'cloud-init-user.tpl', 'properties': {'default': '#cloud-config\n{}\n'}}, '/var/lib/cloud/seed/nocloud-net/vendor-data': {'when': ['create', 'copy'], 'template': 'cloud-init-vendor.tpl', 'properties': {'default': '#cloud-config\n{}\n'}}}, 'template_files': {'cloud-init-meta.tpl': '#cloud-config\ninstance-id: {{ container.name }}\nlocal-hostname: {{ container.name }}\n{{ config_get("user.meta-data", "") }}\n', 'cloud-init-network.tpl': '{% if config_get("user.network-config", "") == "" %}version: 1\nconfig:\n    - type: physical\n      name: eth0\n      subnets:\n          - type: {% if config_get("user.network_mode", "") == "link-local" %}manual{% else %}dhcp{% endif %}\n            control: auto{% else %}{{ config_get("user.network-config", "") }}{% endif %}\n', 'cloud-init-user.tpl': '{{ config_get("user.user-data", properties.default) }}\n', 'cloud-init-vendor.tpl': '{{ config_get("user.vendor-data", properties.default) }}\n'}, 'data_dir': '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results'}
+2019-09-09 10:49:59,562 - tests.cloud_tests - INFO - setting up platform: lxd
+2019-09-09 10:50:01,511 - tests.cloud_tests - DEBUG - os config: {'enabled': True, 'boot_timeout': 120, 'boot_clean_script': '#!/bin/bash\nrm -rf /var/log/cloud-init.log /var/log/cloud-init-output.log \\\n    /var/lib/cloud/ /run/cloud-init/ /var/log/syslog\n', 'system_ready_script': "# permit running or degraded state as both indicate complete boot\n[ $(systemctl is-system-running) = 'running' -o\n  $(systemctl is-system-running) = 'degraded' ]\n", 'cloud_init_ready_script': "[ -f '/run/cloud-init/result.json' ]\n", 'feature_groups': ['base', 'debian_base', 'ubuntu_specific'], 'features': {'apt': True, 'byobu': True, 'landscape': True, 'lxd': True, 'ppa': True, 'rpm': None, 'snap': True, 'hostname': True, 'apt_src_cont': True, 'apt_hist_fmt': True, 'daylight_time': True, 'apt_up_out': True, 'engb_locale': True, 'locale_gen': True, 'no_ntpdate': True, 'no_file_fmt_e': True, 'ppa_file_name': True, 'sshd': True, 'ssh_key_fmt': True, 'syslog': True, 'ubuntu_ntp': True, 'ubuntu_repos': True, 'ubuntu_user': True, 'lsb_release': True, 'sudo': True}, 'mirror_url': 'https://cloud-images.ubuntu.com/daily', 'mirror_dir': '/srv/citest/images', 'keyring': '/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg', 'version': 18.04, 'sstreams_server': 'https://cloud-images.ubuntu.com/daily', 'cache_base_image': True, 'override_templates': False, 'setup_overrides': None, 'release': 'bionic', 'os': 'ubuntu', 'alias': 'bionic', 'arch': 'amd64'}
+2019-09-09 10:50:01,511 - tests.cloud_tests - INFO - acquiring image for os: bionic
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:50:01,882 - tests.cloud_tests - DEBUG - updating args for setup with: None
+2019-09-09 10:50:02,986 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:50:02,986 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:50:08,763 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:50:19,414 - tests.cloud_tests - INFO - setting up ubuntu-bionic (build_name=server serial=20190905)
+2019-09-09 10:50:19,438 - tests.cloud_tests - DEBUG - enable repo: "deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main" in target
+2019-09-09 10:50:19,438 - tests.cloud_tests - DEBUG - executing "enable repo: "deb http://archive.ubuntu.com/ubuntu/ bionic-proposed main" in target"
+2019-09-09 10:50:27,440 - tests.cloud_tests - DEBUG - upgrading cloud-init
+2019-09-09 10:50:27,441 - tests.cloud_tests - DEBUG - executing "upgrading cloud-init"
+2019-09-09 10:50:34,686 - tests.cloud_tests - DEBUG - creating snapshot for bionic
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:50:35,373 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:50:35,374 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:50:36,444 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:50:45,806 - tests.cloud_tests - DEBUG - executing command: sh -c 'set -e; s="$1"; shift; cat > "$s"; trap "rm -f $s" EXIT; chmod +x "$s"; "$s" "$@"' runscript /tmp/LXDInstance-0000
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:50:46,039 - tests.cloud_tests - INFO - collecting test data for os: bionic
+2019-09-09 10:50:46,048 - tests.cloud_tests - WARNING - test config bugs/lp1511485 is not enabled, skipping
+2019-09-09 10:50:46,055 - tests.cloud_tests - WARNING - test config bugs/lp1611074 is not enabled, skipping
+2019-09-09 10:50:46,105 - tests.cloud_tests - INFO - collecting test data for test: bugs/lp1628337
+2019-09-09 10:50:46,829 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:50:46,830 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:50:47,910 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:50:57,262 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:50:57,262 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:50:57,415 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:50:57,415 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:50:57,574 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:50:57,575 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:50:58,586 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:50:58,587 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:50:58,758 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:50:58,758 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:50:58,962 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:50:58,962 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:50:59,143 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:50:59,143 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:50:59,330 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:50:59,331 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:50:59,522 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:50:59,522 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:50:59,831 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-bugs-lp1628337-gg8cyid07hvq9v0miexichb) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:03,968 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-bugs-lp1628337-gg8cyid07hvq9v0miexichb to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/bugs/lp1628337/console.log
+2019-09-09 10:51:03,969 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-bugs-lp1628337-gg8cyid07hvq9v0miexichb) status=Stopped: deleting container.
+2019-09-09 10:51:04,225 - tests.cloud_tests - WARNING - test config examples/add_apt_repositories is not enabled, skipping
+2019-09-09 10:51:04,229 - tests.cloud_tests - WARNING - test config examples/alter_completion_message is not enabled, skipping
+2019-09-09 10:51:04,235 - tests.cloud_tests - WARNING - test config examples/configure_instance_trusted_ca_certificates is not enabled, skipping
+2019-09-09 10:51:04,243 - tests.cloud_tests - WARNING - test config examples/configure_instances_ssh_keys is not enabled, skipping
+2019-09-09 10:51:04,249 - tests.cloud_tests - WARNING - test config examples/including_user_groups is not enabled, skipping
+2019-09-09 10:51:04,253 - tests.cloud_tests - WARNING - test config examples/install_arbitrary_packages is not enabled, skipping
+2019-09-09 10:51:04,260 - tests.cloud_tests - WARNING - test config examples/install_run_chef_recipes is not enabled, skipping
+2019-09-09 10:51:04,264 - tests.cloud_tests - WARNING - test config examples/run_apt_upgrade is not enabled, skipping
+2019-09-09 10:51:04,269 - tests.cloud_tests - WARNING - test config examples/run_commands is not enabled, skipping
+2019-09-09 10:51:04,273 - tests.cloud_tests - WARNING - test config examples/run_commands_first_boot is not enabled, skipping
+2019-09-09 10:51:04,279 - tests.cloud_tests - WARNING - test config examples/setup_run_puppet is not enabled, skipping
+2019-09-09 10:51:04,284 - tests.cloud_tests - WARNING - test config examples/writing_out_arbitrary_files is not enabled, skipping
+2019-09-09 10:51:04,322 - tests.cloud_tests - INFO - collecting test data for test: main/command_output_simple
+2019-09-09 10:51:05,017 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:51:05,018 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:05,907 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:51:14,274 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:51:14,274 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:51:14,471 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:51:14,471 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:51:14,643 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:51:14,643 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:51:14,835 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:51:14,835 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:51:14,994 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:51:14,994 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:51:15,167 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:51:15,167 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:51:15,327 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:51:15,327 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:51:15,519 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:51:15,519 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:51:15,686 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:51:15,686 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:51:15,951 - tests.cloud_tests - DEBUG - running collect script: cloud-init-test-output
+2019-09-09 10:51:15,951 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-test-output"
+2019-09-09 10:51:16,135 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-main-command-output-simple-yvhm1fa7hw9) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:21,993 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-main-command-output-simple-yvhm1fa7hw9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/main/command_output_simple/console.log
+2019-09-09 10:51:21,993 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-main-command-output-simple-yvhm1fa7hw9) status=Stopped: deleting container.
+2019-09-09 10:51:22,252 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_conf
+2019-09-09 10:51:23,581 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:51:23,582 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:25,667 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:51:34,033 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:51:34,034 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:51:34,190 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:51:34,191 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:51:34,514 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:51:34,514 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:51:34,691 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:51:34,691 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:51:34,862 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:51:34,862 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:51:35,011 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:51:35,011 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:51:35,182 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:51:35,183 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:51:35,362 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:51:35,362 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:51:35,514 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:51:35,514 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:51:35,782 - tests.cloud_tests - DEBUG - running collect script: 94cloud-init-config
+2019-09-09 10:51:35,782 - tests.cloud_tests - DEBUG - executing "collect: 94cloud-init-config"
+2019-09-09 10:51:35,948 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-conf-wh3aum4fum3) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:41,591 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-conf-wh3aum4fum3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_conf/console.log
+2019-09-09 10:51:41,591 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-conf-wh3aum4fum3) status=Stopped: deleting container.
+2019-09-09 10:51:41,852 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_disable_suites
+2019-09-09 10:51:42,449 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:51:42,450 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:43,319 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:51:51,681 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:51:51,682 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:51:51,838 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:51:51,838 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:51:52,014 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:51:52,015 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:51:52,174 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:51:52,174 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:51:52,338 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:51:52,338 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:51:52,510 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:51:52,510 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:51:52,662 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:51:52,662 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:51:52,830 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:51:52,830 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:51:53,002 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:51:53,002 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:51:53,242 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:51:53,242 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:51:53,436 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-disable--ql5pntv) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:51:59,228 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-disable--ql5pntv to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_disable_suites/console.log
+2019-09-09 10:51:59,228 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-disable--ql5pntv) status=Stopped: deleting container.
+2019-09-09 10:51:59,476 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_primary
+2019-09-09 10:52:00,085 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:52:00,086 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:00,960 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:52:10,301 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:52:10,302 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:52:10,462 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:52:10,463 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:52:10,626 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:52:10,626 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:52:10,818 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:52:10,818 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:52:10,971 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:52:10,971 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:52:11,126 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:52:11,126 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:52:11,274 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:52:11,274 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:52:11,430 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:52:11,430 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:52:11,598 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:52:11,598 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:52:11,822 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:52:11,822 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:52:11,987 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-primary-u36s7mt6) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:16,900 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-primary-u36s7mt6 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_primary/console.log
+2019-09-09 10:52:16,900 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-primary-u36s7mt6) status=Stopped: deleting container.
+2019-09-09 10:52:17,152 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_proxy
+2019-09-09 10:52:17,717 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:52:17,718 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:18,472 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:52:26,809 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:52:26,810 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:52:26,986 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:52:26,987 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:52:27,130 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:52:27,130 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:52:27,294 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:52:27,294 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:52:27,438 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:52:27,438 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:52:27,582 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:52:27,582 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:52:27,734 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:52:27,734 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:52:27,878 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:52:27,878 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:52:28,014 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:52:28,014 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:52:28,238 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-aptproxy
+2019-09-09 10:52:28,238 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-aptproxy"
+2019-09-09 10:52:28,387 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-proxy-16qo7nm7ci) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:34,542 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-proxy-16qo7nm7ci to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_proxy/console.log
+2019-09-09 10:52:34,543 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-proxy-16qo7nm7ci) status=Stopped: deleting container.
+2019-09-09 10:52:34,842 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_security
+2019-09-09 10:52:35,413 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:52:35,414 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:36,224 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:52:45,570 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:52:45,570 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:52:45,738 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:52:45,739 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:52:45,910 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:52:45,910 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:52:46,078 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:52:46,078 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:52:46,222 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:52:46,222 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:52:46,374 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:52:46,374 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:52:46,522 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:52:46,522 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:52:46,682 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:52:46,682 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:52:46,830 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:52:46,830 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:52:47,062 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:52:47,062 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:52:47,203 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-security-4umcgrn) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:52,248 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-security-4umcgrn to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_security/console.log
+2019-09-09 10:52:52,248 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-security-4umcgrn) status=Stopped: deleting container.
+2019-09-09 10:52:52,481 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_key
+2019-09-09 10:52:53,081 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:52:53,082 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:52:53,828 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:53:03,165 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:53:03,166 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:53:03,334 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:53:03,334 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:53:03,474 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:53:03,474 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:53:03,622 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:53:03,622 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:53:03,766 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:53:03,766 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:53:03,906 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:53:03,906 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:53:04,050 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:53:04,050 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:53:04,198 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:53:04,198 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:53:04,326 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:53:04,326 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:53:04,546 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:53:04,546 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:53:04,670 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:53:04,670 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:53:04,917 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:53:04,923 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--i95ps5a) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:06,838 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--i95ps5a to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_sources_key/console.log
+2019-09-09 10:53:06,838 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--i95ps5a) status=Stopped: deleting container.
+2019-09-09 10:53:07,068 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_keyserver
+2019-09-09 10:53:07,637 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:53:07,638 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:08,332 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:53:17,669 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:53:17,670 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:53:17,839 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:53:17,839 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:53:17,982 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:53:17,982 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:53:18,130 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:53:18,130 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:53:18,286 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:53:18,286 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:53:18,414 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:53:18,414 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:53:18,562 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:53:18,562 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:53:18,718 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:53:18,718 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:53:18,870 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:53:18,870 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:53:19,098 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:53:19,098 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:53:19,234 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-09 10:53:19,234 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-09 10:53:19,493 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:53:19,499 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--0w23wls) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:21,764 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--0w23wls to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_sources_keyserver/console.log
+2019-09-09 10:53:21,764 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--0w23wls) status=Stopped: deleting container.
+2019-09-09 10:53:21,987 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_list
+2019-09-09 10:53:22,557 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:53:22,558 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:23,384 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:53:31,733 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:53:31,734 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:53:31,898 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:53:31,898 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:53:32,062 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:53:32,062 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:53:32,258 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:53:32,258 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:53:32,426 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:53:32,426 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:53:32,594 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:53:32,594 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:53:32,750 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:53:32,750 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:53:32,918 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:53:32,918 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:53:33,070 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:53:33,070 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:53:33,314 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:53:33,314 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:53:33,491 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--ffdvrt8) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:39,351 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--ffdvrt8 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_sources_list/console.log
+2019-09-09 10:53:39,351 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--ffdvrt8) status=Stopped: deleting container.
+2019-09-09 10:53:39,567 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_ppa
+2019-09-09 10:53:40,153 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:53:40,154 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:40,976 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:53:54,381 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:53:54,382 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:53:54,566 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:53:54,567 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:53:54,750 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:53:54,750 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:53:54,922 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:53:54,922 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:53:55,094 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:53:55,094 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:53:55,290 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:53:55,290 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:53:55,439 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:53:55,439 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:53:55,615 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:53:55,615 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:53:55,803 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:53:55,803 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:53:56,059 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-09 10:53:56,059 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-09 10:53:56,230 - tests.cloud_tests - DEBUG - running collect script: apt-key
+2019-09-09 10:53:56,231 - tests.cloud_tests - DEBUG - executing "collect: apt-key"
+2019-09-09 10:53:56,501 - tests.cloud_tests - DEBUG - collect script apt-key exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-09 10:53:56,502 - tests.cloud_tests - DEBUG - running collect script: sources_full
+2019-09-09 10:53:56,502 - tests.cloud_tests - DEBUG - executing "collect: sources_full"
+2019-09-09 10:53:56,675 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--ekfez61) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:58,047 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-configure-sources--ekfez61 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_configure_sources_ppa/console.log
+2019-09-09 10:53:58,048 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-configure-sources--ekfez61) status=Stopped: deleting container.
+2019-09-09 10:53:58,293 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_disable
+2019-09-09 10:53:58,881 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:53:58,882 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:53:59,681 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:54:09,073 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:54:09,074 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:54:09,238 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:54:09,238 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:54:09,390 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:54:09,390 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:54:09,542 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:54:09,542 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:54:10,182 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:54:10,182 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:54:10,342 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:54:10,342 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:54:10,499 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:54:10,499 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:54:10,678 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:54:10,678 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:54:10,822 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:54:10,822 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:54:11,082 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining
+2019-09-09 10:54:11,082 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining"
+2019-09-09 10:54:11,219 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-pipelining-disable-p8pa68x) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:54:15,701 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-pipelining-disable-p8pa68x to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_pipelining_disable/console.log
+2019-09-09 10:54:15,702 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-pipelining-disable-p8pa68x) status=Stopped: deleting container.
+2019-09-09 10:54:15,957 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_os
+2019-09-09 10:54:16,553 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:54:16,554 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:54:17,388 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:54:26,793 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:54:26,794 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:54:26,982 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:54:26,983 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:54:27,142 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:54:27,142 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:54:27,310 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:54:27,310 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:54:27,478 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:54:27,478 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:54:27,654 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:54:27,654 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:54:27,830 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:54:27,830 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:54:27,998 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:54:27,998 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:54:28,142 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:54:28,142 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:54:28,386 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining_not_written
+2019-09-09 10:54:28,386 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining_not_written"
+2019-09-09 10:54:28,545 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining_not_written exited 'b"ls: cannot access '/etc/apt/apt.conf.d/90cloud-init-pipelining': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:54:28,552 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-pipelining-os-ha3ncr5dmn01) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:54:33,346 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-apt-pipelining-os-ha3ncr5dmn01 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/apt_pipelining_os/console.log
+2019-09-09 10:54:33,347 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-apt-pipelining-os-ha3ncr5dmn01) status=Stopped: deleting container.
+2019-09-09 10:54:33,665 - tests.cloud_tests - INFO - collecting test data for test: modules/bootcmd
+2019-09-09 10:54:34,265 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:54:34,266 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:54:35,009 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:54:44,365 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:54:44,366 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:54:44,518 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:54:44,519 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:54:44,658 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:54:44,658 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:54:44,806 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:54:44,806 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:54:44,958 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:54:44,958 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:54:45,102 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:54:45,102 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:54:45,250 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:54:45,250 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:54:45,466 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:54:45,466 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:54:45,614 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:54:45,614 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:54:45,854 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 10:54:45,854 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 10:54:46,023 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-bootcmd-92m9qnt1x47gq3bt74pohm) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:54:51,028 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-bootcmd-92m9qnt1x47gq3bt74pohm to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/bootcmd/console.log
+2019-09-09 10:54:51,028 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-bootcmd-92m9qnt1x47gq3bt74pohm) status=Stopped: deleting container.
+2019-09-09 10:54:51,283 - tests.cloud_tests - INFO - collecting test data for test: modules/byobu
+2019-09-09 10:54:51,817 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:54:51,818 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:54:52,681 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:55:01,510 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:55:01,510 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:55:01,670 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:55:01,670 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:55:01,850 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:55:01,850 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:55:02,034 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:55:02,034 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:55:02,182 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:55:02,182 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:55:02,342 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:55:02,342 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:55:02,486 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:55:02,486 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:55:02,638 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:55:02,638 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:55:02,783 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:55:02,783 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:55:03,074 - tests.cloud_tests - DEBUG - running collect script: byobu_profile_enabled
+2019-09-09 10:55:03,074 - tests.cloud_tests - DEBUG - executing "collect: byobu_profile_enabled"
+2019-09-09 10:55:03,307 - tests.cloud_tests - DEBUG - running collect script: byobu_launch_exists
+2019-09-09 10:55:03,307 - tests.cloud_tests - DEBUG - executing "collect: byobu_launch_exists"
+2019-09-09 10:55:03,558 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-byobu-eocb46pkd31vkxoe7yyx2glu) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:55:08,658 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-byobu-eocb46pkd31vkxoe7yyx2glu to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/byobu/console.log
+2019-09-09 10:55:08,659 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-byobu-eocb46pkd31vkxoe7yyx2glu) status=Stopped: deleting container.
+2019-09-09 10:55:08,912 - tests.cloud_tests - INFO - collecting test data for test: modules/ca_certs
+2019-09-09 10:55:09,537 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:55:09,538 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:55:10,395 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:55:19,813 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:55:19,814 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:55:20,030 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:55:20,031 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:55:20,290 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:55:20,290 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:55:20,470 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:55:20,470 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:55:20,674 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:55:20,674 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:55:20,926 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:55:20,926 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:55:21,214 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:55:21,214 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:55:21,602 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:55:21,602 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:55:21,902 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:55:21,902 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:55:22,126 - tests.cloud_tests - DEBUG - running collect script: cert_links
+2019-09-09 10:55:22,126 - tests.cloud_tests - DEBUG - executing "collect: cert_links"
+2019-09-09 10:55:22,386 - tests.cloud_tests - DEBUG - running collect script: cert
+2019-09-09 10:55:22,386 - tests.cloud_tests - DEBUG - executing "collect: cert"
+2019-09-09 10:55:22,619 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ca-certs-7pcnfd0w2v6zbbxe28i8r) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:55:26,337 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ca-certs-7pcnfd0w2v6zbbxe28i8r to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ca_certs/console.log
+2019-09-09 10:55:26,337 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ca-certs-7pcnfd0w2v6zbbxe28i8r) status=Stopped: deleting container.
+2019-09-09 10:55:26,625 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_disable
+2019-09-09 10:55:27,533 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:55:27,534 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:55:28,321 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:55:37,818 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:55:37,818 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:55:38,067 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:55:38,067 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:55:38,322 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:55:38,322 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:55:38,526 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:55:38,526 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:55:38,714 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:55:38,714 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:55:38,902 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:55:38,903 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:55:39,078 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:55:39,078 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:55:39,286 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:55:39,287 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:55:39,447 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:55:39,447 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:55:39,700 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-debug-disable-tvzoixpf9g7xmjyx) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:55:44,270 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-debug-disable-tvzoixpf9g7xmjyx to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/debug_disable/console.log
+2019-09-09 10:55:44,271 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-debug-disable-tvzoixpf9g7xmjyx) status=Stopped: deleting container.
+2019-09-09 10:55:44,524 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_enable
+2019-09-09 10:55:45,133 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:55:45,134 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:55:45,840 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:55:55,245 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:55:55,246 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:55:55,458 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:55:55,459 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:55:55,698 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:55:55,698 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:55:55,990 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:55:55,990 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:55:56,199 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:55:56,199 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:55:56,518 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:55:56,519 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:55:56,738 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:55:56,738 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:55:57,023 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:55:57,023 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:55:57,198 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:55:57,198 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:55:57,544 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-debug-enable-3i5xf2pbyxdzckp3s) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:01,935 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-debug-enable-3i5xf2pbyxdzckp3s to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/debug_enable/console.log
+2019-09-09 10:56:01,936 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-debug-enable-3i5xf2pbyxdzckp3s) status=Stopped: deleting container.
+2019-09-09 10:56:02,242 - tests.cloud_tests - INFO - collecting test data for test: modules/final_message
+2019-09-09 10:56:02,929 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:56:02,930 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:03,857 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:56:12,209 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:56:12,210 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:56:12,387 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:56:12,387 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:56:12,550 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:56:12,550 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:56:12,850 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:56:12,850 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:56:13,014 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:56:13,014 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:56:13,206 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:56:13,206 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:56:13,366 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:56:13,366 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:56:13,538 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:56:13,538 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:56:13,694 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:56:13,695 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:56:13,968 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-final-message-75jlkuvg9eq05ioa) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:19,818 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-final-message-75jlkuvg9eq05ioa to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/final_message/console.log
+2019-09-09 10:56:19,818 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-final-message-75jlkuvg9eq05ioa) status=Stopped: deleting container.
+2019-09-09 10:56:20,081 - tests.cloud_tests - INFO - collecting test data for test: modules/keys_to_console
+2019-09-09 10:56:20,613 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:56:20,614 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:21,388 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:56:29,826 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:56:29,826 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:56:29,995 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:56:29,995 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:56:30,230 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:56:30,230 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:56:30,434 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:56:30,434 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:56:30,738 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:56:30,739 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:56:31,194 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:56:31,194 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:56:31,434 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:56:31,434 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:56:31,662 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:56:31,662 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:56:31,818 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:56:31,818 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:56:32,171 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 10:56:32,171 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 10:56:32,407 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-keys-to-console-cknwgcczacuz2i) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:37,535 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-keys-to-console-cknwgcczacuz2i to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/keys_to_console/console.log
+2019-09-09 10:56:37,535 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-keys-to-console-cknwgcczacuz2i) status=Stopped: deleting container.
+2019-09-09 10:56:37,774 - tests.cloud_tests - WARNING - test config modules/landscape is not enabled, skipping
+2019-09-09 10:56:37,857 - tests.cloud_tests - INFO - collecting test data for test: modules/locale
+2019-09-09 10:56:38,749 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:56:38,750 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:39,735 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:56:48,093 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:56:48,094 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:56:48,259 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:56:48,259 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:56:48,422 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:56:48,422 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:56:48,570 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:56:48,570 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:56:48,730 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:56:48,730 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:56:48,890 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:56:48,890 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:56:49,050 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:56:49,050 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:56:49,218 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:56:49,218 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:56:49,370 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:56:49,370 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:56:49,626 - tests.cloud_tests - DEBUG - running collect script: locale_default
+2019-09-09 10:56:49,626 - tests.cloud_tests - DEBUG - executing "collect: locale_default"
+2019-09-09 10:56:49,770 - tests.cloud_tests - DEBUG - running collect script: locale_a
+2019-09-09 10:56:49,770 - tests.cloud_tests - DEBUG - executing "collect: locale_a"
+2019-09-09 10:56:49,918 - tests.cloud_tests - DEBUG - running collect script: locale_gen
+2019-09-09 10:56:49,918 - tests.cloud_tests - DEBUG - executing "collect: locale_gen"
+2019-09-09 10:56:50,075 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-locale-ey3w7ecwd55mx9ep0ypptxc) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:55,689 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-locale-ey3w7ecwd55mx9ep0ypptxc to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/locale/console.log
+2019-09-09 10:56:55,690 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-locale-ey3w7ecwd55mx9ep0ypptxc) status=Stopped: deleting container.
+2019-09-09 10:56:55,920 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_bridge
+2019-09-09 10:56:56,509 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:56:56,510 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:56:57,317 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:57:14,749 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:57:14,750 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:57:14,918 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:57:14,919 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:57:15,066 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:57:15,066 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:57:15,227 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:57:15,227 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:57:15,370 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:57:15,370 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:57:15,534 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:57:15,535 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:57:15,706 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:57:15,706 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:57:15,882 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:57:15,882 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:57:16,042 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:57:16,042 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:57:16,282 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 10:57:16,282 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 10:57:16,438 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 10:57:16,438 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 10:57:16,582 - tests.cloud_tests - DEBUG - running collect script: lxc-bridge
+2019-09-09 10:57:16,582 - tests.cloud_tests - DEBUG - executing "collect: lxc-bridge"
+2019-09-09 10:57:16,739 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-lxd-bridge-qj9dcw8l3zricl01fnc) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:57:18,509 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-lxd-bridge-qj9dcw8l3zricl01fnc to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/lxd_bridge/console.log
+2019-09-09 10:57:18,510 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-lxd-bridge-qj9dcw8l3zricl01fnc) status=Stopped: deleting container.
+2019-09-09 10:57:18,754 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_dir
+2019-09-09 10:57:19,341 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:57:19,342 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:57:20,164 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:57:37,693 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:57:37,694 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:57:37,927 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:57:37,927 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:57:38,126 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:57:38,127 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:57:38,306 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:57:38,306 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:57:38,514 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:57:38,514 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:57:38,710 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:57:38,710 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:57:38,902 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:57:38,902 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:57:39,202 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:57:39,202 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:57:39,350 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:57:39,350 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:57:39,602 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-09 10:57:39,602 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-09 10:57:39,794 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-09 10:57:39,795 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-09 10:57:39,975 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-lxd-dir-ur9jqphcw5y56wle99zhqd) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:57:46,430 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-lxd-dir-ur9jqphcw5y56wle99zhqd to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/lxd_dir/console.log
+2019-09-09 10:57:46,431 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-lxd-dir-ur9jqphcw5y56wle99zhqd) status=Stopped: deleting container.
+2019-09-09 10:57:46,672 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp
+2019-09-09 10:57:47,466 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:57:47,466 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:57:48,465 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:58:03,126 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:58:03,126 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:58:03,407 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:58:03,407 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:58:03,675 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:58:03,675 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:58:03,990 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:58:03,990 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:58:04,226 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:58:04,226 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:58:04,550 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:58:04,550 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:58:04,799 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:58:04,799 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:58:05,114 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:58:05,114 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:58:05,402 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:58:05,402 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:58:05,698 - tests.cloud_tests - DEBUG - running collect script: ntp_installed
+2019-09-09 10:58:05,698 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed"
+2019-09-09 10:58:05,906 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_empty
+2019-09-09 10:58:05,906 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_empty"
+2019-09-09 10:58:06,241 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_empty exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:58:06,242 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pool_list
+2019-09-09 10:58:06,242 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pool_list"
+2019-09-09 10:58:06,491 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-26nil1yxzd2eki2wca5xva621a) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:58:10,940 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-26nil1yxzd2eki2wca5xva621a to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ntp/console.log
+2019-09-09 10:58:10,940 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-26nil1yxzd2eki2wca5xva621a) status=Stopped: deleting container.
+2019-09-09 10:58:11,177 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_chrony
+2019-09-09 10:58:12,278 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:58:12,278 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:58:13,946 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:58:28,405 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:58:28,406 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:58:28,554 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:58:28,555 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:58:28,894 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:58:28,894 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:58:29,038 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:58:29,038 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:58:29,194 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:58:29,194 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:58:29,362 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:58:29,362 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:58:29,510 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:58:29,510 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:58:29,678 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:58:29,678 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:58:29,846 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:58:29,846 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:58:30,106 - tests.cloud_tests - DEBUG - running collect script: chrony_conf
+2019-09-09 10:58:30,106 - tests.cloud_tests - DEBUG - executing "collect: chrony_conf"
+2019-09-09 10:58:30,255 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-chrony-xybdiezm64bz00g36el) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:58:31,484 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-chrony-xybdiezm64bz00g36el to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ntp_chrony/console.log
+2019-09-09 10:58:31,484 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-chrony-xybdiezm64bz00g36el) status=Stopped: deleting container.
+2019-09-09 10:58:31,729 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_pools
+2019-09-09 10:58:32,297 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:58:32,298 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:58:33,088 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:58:46,629 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:58:46,630 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:58:46,875 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:58:46,875 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:58:47,066 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:58:47,067 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:58:47,295 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:58:47,295 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:58:47,567 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:58:47,567 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:58:47,850 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:58:47,850 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:58:48,010 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:58:48,010 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:58:48,298 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:58:48,299 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:58:48,526 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:58:48,526 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:58:48,870 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_pools
+2019-09-09 10:58:48,870 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_pools"
+2019-09-09 10:58:49,102 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_pools
+2019-09-09 10:58:49,103 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_pools"
+2019-09-09 10:58:49,289 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_pools exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-09 10:58:49,290 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pools
+2019-09-09 10:58:49,290 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pools"
+2019-09-09 10:58:49,438 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 10:58:49,438 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 10:58:49,631 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-pools-qaaw7s3jyecy5rptq3vx) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:58:54,707 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-pools-qaaw7s3jyecy5rptq3vx to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ntp_pools/console.log
+2019-09-09 10:58:54,708 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-pools-qaaw7s3jyecy5rptq3vx) status=Stopped: deleting container.
+2019-09-09 10:58:54,962 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_servers
+2019-09-09 10:58:55,573 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:58:55,574 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:58:56,441 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:59:10,957 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:59:10,958 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:59:11,111 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:59:11,111 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:59:11,266 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:59:11,266 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:59:11,410 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:59:11,410 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:59:11,558 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:59:11,559 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:59:11,714 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:59:11,714 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:59:11,866 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:59:11,866 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:59:12,050 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:59:12,050 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:59:12,210 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:59:12,210 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:59:12,462 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_servers
+2019-09-09 10:59:12,463 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_servers"
+2019-09-09 10:59:12,634 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_servers
+2019-09-09 10:59:12,634 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_servers"
+2019-09-09 10:59:12,801 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_servers exited 'b'cat: /etc/ntp.conf.dist: No such file or directory\n'' and had stderr: 0
+2019-09-09 10:59:12,802 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_servers
+2019-09-09 10:59:12,802 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_servers"
+2019-09-09 10:59:12,974 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-09 10:59:12,974 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-09 10:59:13,139 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-servers-sjahsakjlxtt81f80u) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:59:14,422 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-servers-sjahsakjlxtt81f80u to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ntp_servers/console.log
+2019-09-09 10:59:14,422 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-servers-sjahsakjlxtt81f80u) status=Stopped: deleting container.
+2019-09-09 10:59:14,744 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_timesyncd
+2019-09-09 10:59:15,389 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:59:15,390 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:59:16,213 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:59:24,569 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:59:24,570 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:59:24,722 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:59:24,722 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:59:24,854 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:59:24,854 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:59:24,994 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:59:24,994 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:59:25,142 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:59:25,142 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:59:25,270 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:59:25,270 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:59:25,434 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:59:25,434 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:59:25,594 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:59:25,594 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:59:25,730 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:59:25,730 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:59:25,978 - tests.cloud_tests - DEBUG - running collect script: timesyncd_conf
+2019-09-09 10:59:25,978 - tests.cloud_tests - DEBUG - executing "collect: timesyncd_conf"
+2019-09-09 10:59:26,127 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-timesyncd-cwps8la1xpraixos) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:59:32,082 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ntp-timesyncd-cwps8la1xpraixos to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ntp_timesyncd/console.log
+2019-09-09 10:59:32,082 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ntp-timesyncd-cwps8la1xpraixos) status=Stopped: deleting container.
+2019-09-09 10:59:32,283 - tests.cloud_tests - INFO - collecting test data for test: modules/package_update_upgrade_install
+2019-09-09 10:59:32,817 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:59:32,818 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:59:33,508 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 10:59:51,961 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 10:59:51,962 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 10:59:52,118 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 10:59:52,118 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 10:59:52,270 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 10:59:52,270 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 10:59:52,414 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 10:59:52,414 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 10:59:52,570 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 10:59:52,570 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 10:59:52,722 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 10:59:52,722 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 10:59:52,870 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 10:59:52,870 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 10:59:53,030 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 10:59:53,030 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 10:59:53,166 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 10:59:53,166 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 10:59:53,370 - tests.cloud_tests - DEBUG - running collect script: apt_history_cmdline
+2019-09-09 10:59:53,370 - tests.cloud_tests - DEBUG - executing "collect: apt_history_cmdline"
+2019-09-09 10:59:53,534 - tests.cloud_tests - DEBUG - running collect script: dpkg_show
+2019-09-09 10:59:53,534 - tests.cloud_tests - DEBUG - executing "collect: dpkg_show"
+2019-09-09 10:59:53,695 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-package-update-upgrade-vmijenh) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 10:59:58,216 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-package-update-upgrade-vmijenh to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/package_update_upgrade_install/console.log
+2019-09-09 10:59:58,216 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-package-update-upgrade-vmijenh) status=Stopped: deleting container.
+2019-09-09 10:59:58,501 - tests.cloud_tests - INFO - collecting test data for test: modules/runcmd
+2019-09-09 10:59:59,189 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 10:59:59,190 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:00,051 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:00:08,909 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:00:08,910 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:00:09,062 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:00:09,062 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:00:09,226 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:00:09,226 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:00:09,391 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:00:09,391 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:00:09,562 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:00:09,562 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:00:09,714 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:00:09,714 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:00:09,866 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:00:09,866 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:00:10,062 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:00:10,062 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:00:10,198 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:00:10,198 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:00:10,442 - tests.cloud_tests - DEBUG - running collect script: run_cmd
+2019-09-09 11:00:10,442 - tests.cloud_tests - DEBUG - executing "collect: run_cmd"
+2019-09-09 11:00:10,623 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-runcmd-9w7ujcserfk8uqim0bctfxj) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:18,010 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-runcmd-9w7ujcserfk8uqim0bctfxj to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/runcmd/console.log
+2019-09-09 11:00:18,010 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-runcmd-9w7ujcserfk8uqim0bctfxj) status=Stopped: deleting container.
+2019-09-09 11:00:18,319 - tests.cloud_tests - WARNING - test config modules/seed_random_command is not enabled, skipping
+2019-09-09 11:00:18,357 - tests.cloud_tests - INFO - collecting test data for test: modules/seed_random_data
+2019-09-09 11:00:18,925 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:00:18,926 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:19,714 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:00:29,061 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:00:29,062 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:00:29,215 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:00:29,215 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:00:29,362 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:00:29,362 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:00:29,514 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:00:29,514 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:00:29,670 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:00:29,670 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:00:29,822 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:00:29,823 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:00:29,974 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:00:29,974 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:00:30,130 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:00:30,130 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:00:30,299 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:00:30,299 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:00:30,551 - tests.cloud_tests - DEBUG - running collect script: seed_data
+2019-09-09 11:00:30,551 - tests.cloud_tests - DEBUG - executing "collect: seed_data"
+2019-09-09 11:00:30,703 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-seed-random-data-gklk1co8o7iok) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:35,569 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-seed-random-data-gklk1co8o7iok to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/seed_random_data/console.log
+2019-09-09 11:00:35,570 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-seed-random-data-gklk1co8o7iok) status=Stopped: deleting container.
+2019-09-09 11:00:35,852 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname
+2019-09-09 11:00:36,425 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:00:36,426 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:37,212 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:00:42,529 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:00:42,530 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:00:42,666 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:00:42,666 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:00:42,822 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:00:42,822 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:00:43,058 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:00:43,058 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:00:43,226 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:00:43,226 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:00:43,398 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:00:43,398 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:00:43,550 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:00:43,550 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:00:43,722 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:00:43,722 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:00:43,874 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:00:43,874 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:00:44,118 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 11:00:44,118 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 11:00:44,271 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 11:00:44,272 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 11:00:44,426 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 11:00:44,426 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 11:00:44,575 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-hostname-39z1rigjbpdyka0h3) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:48,139 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-hostname-39z1rigjbpdyka0h3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/set_hostname/console.log
+2019-09-09 11:00:48,139 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-hostname-39z1rigjbpdyka0h3) status=Stopped: deleting container.
+2019-09-09 11:00:49,567 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname_fqdn
+2019-09-09 11:00:50,125 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:00:50,126 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:50,915 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:00:56,253 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:00:56,254 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:00:56,406 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:00:56,406 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:00:56,550 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:00:56,550 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:00:56,710 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:00:56,710 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:00:56,874 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:00:56,874 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:00:57,054 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:00:57,054 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:00:57,198 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:00:57,198 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:00:57,342 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:00:57,342 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:00:57,486 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:00:57,486 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:00:57,714 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-09 11:00:57,714 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-09 11:00:57,870 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-09 11:00:57,870 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-09 11:00:58,038 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-09 11:00:58,039 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-09 11:00:58,199 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-hostname-fqdn-ttrufi2jzdox) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:00:59,454 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-hostname-fqdn-ttrufi2jzdox to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/set_hostname_fqdn/console.log
+2019-09-09 11:00:59,454 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-hostname-fqdn-ttrufi2jzdox) status=Stopped: deleting container.
+2019-09-09 11:00:59,686 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password
+2019-09-09 11:01:00,213 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:01:00,214 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:01,029 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:01:09,369 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:01:09,370 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:01:09,514 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:01:09,514 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:01:09,662 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:01:09,662 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:01:09,818 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:01:09,818 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:01:09,970 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:01:09,970 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:01:10,118 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:01:10,118 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:01:10,278 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:01:10,278 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:01:10,434 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:01:10,434 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:01:10,574 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:01:10,574 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:01:10,818 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:01:10,818 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:01:10,982 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:01:10,982 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:01:11,148 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-a558summh2vovi5fr) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:17,097 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-a558summh2vovi5fr to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/set_password/console.log
+2019-09-09 11:01:17,097 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-a558summh2vovi5fr) status=Stopped: deleting container.
+2019-09-09 11:01:17,334 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_expire
+2019-09-09 11:01:17,873 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:01:17,874 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:18,656 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:01:27,006 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:01:27,006 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:01:27,166 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:01:27,167 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:01:27,338 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:01:27,338 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:01:27,498 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:01:27,498 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:01:27,658 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:01:27,658 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:01:27,822 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:01:27,822 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:01:27,998 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:01:27,998 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:01:28,162 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:01:28,162 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:01:28,310 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:01:28,310 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:01:28,562 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:01:28,562 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:01:28,738 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:01:28,738 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:01:28,926 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-expire-924fdxs1tg) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:34,726 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-expire-924fdxs1tg to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/set_password_expire/console.log
+2019-09-09 11:01:34,726 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-expire-924fdxs1tg) status=Stopped: deleting container.
+2019-09-09 11:01:34,982 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list
+2019-09-09 11:01:35,585 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:01:35,586 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:36,959 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:01:45,321 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:01:45,322 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:01:45,502 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:01:45,502 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:01:45,662 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:01:45,662 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:01:45,810 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:01:45,810 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:01:45,962 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:01:45,962 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:01:46,098 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:01:46,098 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:01:46,258 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:01:46,258 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:01:46,430 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:01:46,430 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:01:46,790 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:01:46,790 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:01:47,054 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:01:47,054 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:01:47,210 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:01:47,210 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:01:47,363 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-list-mxnit3nnxvej) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:52,895 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-list-mxnit3nnxvej to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/set_password_list/console.log
+2019-09-09 11:01:52,895 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-list-mxnit3nnxvej) status=Stopped: deleting container.
+2019-09-09 11:01:53,145 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list_string
+2019-09-09 11:01:53,701 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:01:53,702 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:01:54,451 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:02:02,801 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:02:02,802 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:02:03,007 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:02:03,007 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:02:03,162 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:02:03,163 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:02:03,310 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:02:03,310 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:02:03,478 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:02:03,478 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:02:03,630 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:02:03,630 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:02:03,770 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:02:03,770 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:02:03,926 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:02:03,926 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:02:04,062 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:02:04,062 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:02:04,282 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-09 11:02:04,282 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-09 11:02:04,446 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-09 11:02:04,446 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-09 11:02:04,600 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-list-stri-9z6llno) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:02:10,316 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-set-password-list-stri-9z6llno to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/set_password_list_string/console.log
+2019-09-09 11:02:10,316 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-set-password-list-stri-9z6llno) status=Stopped: deleting container.
+2019-09-09 11:02:10,525 - tests.cloud_tests - WARNING - test config modules/snap is not enabled, skipping
+2019-09-09 11:02:10,530 - tests.cloud_tests - WARNING - test config modules/snappy is not enabled, skipping
+2019-09-09 11:02:10,567 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_disable
+2019-09-09 11:02:11,105 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:02:11,106 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:02:11,996 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:02:21,357 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:02:21,358 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:02:21,526 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:02:21,526 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:02:21,666 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:02:21,666 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:02:21,802 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:02:21,802 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:02:21,958 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:02:21,958 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:02:22,102 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:02:22,102 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:02:22,254 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:02:22,254 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:02:22,402 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:02:22,402 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:02:22,554 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:02:22,554 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:02:22,782 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 11:02:22,783 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 11:02:22,957 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-8eq3q40) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:02:27,993 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-8eq3q40 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ssh_auth_key_fingerprints_disable/console.log
+2019-09-09 11:02:27,993 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-8eq3q40) status=Stopped: deleting container.
+2019-09-09 11:02:28,265 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_enable
+2019-09-09 11:02:29,133 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:02:29,134 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:02:29,915 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:02:38,269 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:02:38,270 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:02:38,435 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:02:38,435 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:02:38,578 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:02:38,579 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:02:38,738 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:02:38,739 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:02:38,898 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:02:38,898 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:02:39,042 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:02:39,042 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:02:39,190 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:02:39,190 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:02:39,346 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:02:39,346 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:02:39,486 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:02:39,486 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:02:39,718 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-09 11:02:39,718 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-09 11:02:39,879 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-t4dszjg) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:02:45,935 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-t4dszjg to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ssh_auth_key_fingerprints_enable/console.log
+2019-09-09 11:02:45,936 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-auth-key-fingerpri-t4dszjg) status=Stopped: deleting container.
+2019-09-09 11:02:46,175 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_import_id
+2019-09-09 11:02:46,733 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:02:46,734 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:02:47,582 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:02:55,953 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:02:55,954 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:02:56,118 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:02:56,119 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:02:56,266 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:02:56,266 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:02:56,422 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:02:56,422 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:02:56,578 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:02:56,578 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:02:56,718 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:02:56,718 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:02:56,874 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:02:56,874 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:02:57,038 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:02:57,038 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:02:57,178 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:02:57,178 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:02:57,398 - tests.cloud_tests - DEBUG - running collect script: auth_keys_ubuntu
+2019-09-09 11:02:57,398 - tests.cloud_tests - DEBUG - executing "collect: auth_keys_ubuntu"
+2019-09-09 11:02:57,551 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-import-id-7yh29yn5xk1xb0uj) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:03,595 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-import-id-7yh29yn5xk1xb0uj to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ssh_import_id/console.log
+2019-09-09 11:03:03,595 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-import-id-7yh29yn5xk1xb0uj) status=Stopped: deleting container.
+2019-09-09 11:03:03,825 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_keys_generate
+2019-09-09 11:03:04,421 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:03:04,422 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:05,264 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:03:14,145 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:03:14,146 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:03:14,310 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:03:14,311 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:03:14,466 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:03:14,466 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:03:14,634 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:03:14,634 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:03:14,802 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:03:14,802 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:03:14,942 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:03:14,942 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:03:15,086 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:03:15,086 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:03:15,258 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:03:15,258 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:03:15,414 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:03:15,414 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:03:15,642 - tests.cloud_tests - DEBUG - running collect script: dsa_public
+2019-09-09 11:03:15,642 - tests.cloud_tests - DEBUG - executing "collect: dsa_public"
+2019-09-09 11:03:15,909 - tests.cloud_tests - DEBUG - collect script dsa_public exited 'b'cat: /etc/ssh/ssh_host_dsa_key.pub: No such file or directory'' and had stderr: 1
+2019-09-09 11:03:15,910 - tests.cloud_tests - DEBUG - running collect script: dsa_private
+2019-09-09 11:03:15,910 - tests.cloud_tests - DEBUG - executing "collect: dsa_private"
+2019-09-09 11:03:16,081 - tests.cloud_tests - DEBUG - collect script dsa_private exited 'b'cat: /etc/ssh/ssh_host_dsa_key: No such file or directory'' and had stderr: 1
+2019-09-09 11:03:16,082 - tests.cloud_tests - DEBUG - running collect script: rsa_public
+2019-09-09 11:03:16,082 - tests.cloud_tests - DEBUG - executing "collect: rsa_public"
+2019-09-09 11:03:16,245 - tests.cloud_tests - DEBUG - collect script rsa_public exited 'b'cat: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory'' and had stderr: 1
+2019-09-09 11:03:16,246 - tests.cloud_tests - DEBUG - running collect script: rsa_private
+2019-09-09 11:03:16,246 - tests.cloud_tests - DEBUG - executing "collect: rsa_private"
+2019-09-09 11:03:16,398 - tests.cloud_tests - DEBUG - collect script rsa_private exited 'b'cat: /etc/ssh/ssh_host_rsa_key: No such file or directory'' and had stderr: 1
+2019-09-09 11:03:16,398 - tests.cloud_tests - DEBUG - running collect script: ecdsa_public
+2019-09-09 11:03:16,399 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_public"
+2019-09-09 11:03:16,558 - tests.cloud_tests - DEBUG - running collect script: ecdsa_private
+2019-09-09 11:03:16,558 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_private"
+2019-09-09 11:03:16,714 - tests.cloud_tests - DEBUG - running collect script: ed25519_public
+2019-09-09 11:03:16,714 - tests.cloud_tests - DEBUG - executing "collect: ed25519_public"
+2019-09-09 11:03:16,878 - tests.cloud_tests - DEBUG - running collect script: ed25519_private
+2019-09-09 11:03:16,878 - tests.cloud_tests - DEBUG - executing "collect: ed25519_private"
+2019-09-09 11:03:17,019 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-keys-generate-vfeyy5trmey4) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:18,225 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-ssh-keys-generate-vfeyy5trmey4 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/ssh_keys_generate/console.log
+2019-09-09 11:03:18,226 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-ssh-keys-generate-vfeyy5trmey4) status=Stopped: deleting container.
+2019-09-09 11:03:18,436 - tests.cloud_tests - WARNING - test config modules/ssh_keys_provided is not enabled, skipping
+2019-09-09 11:03:18,474 - tests.cloud_tests - INFO - collecting test data for test: modules/timezone
+2019-09-09 11:03:19,057 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:03:19,058 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:19,952 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:03:29,390 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:03:29,390 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:03:29,555 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:03:29,555 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:03:29,714 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:03:29,714 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:03:29,862 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:03:29,862 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:03:30,026 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:03:30,026 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:03:30,166 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:03:30,166 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:03:30,334 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:03:30,334 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:03:30,486 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:03:30,486 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:03:30,638 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:03:30,638 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:03:30,894 - tests.cloud_tests - DEBUG - running collect script: timezone
+2019-09-09 11:03:30,895 - tests.cloud_tests - DEBUG - executing "collect: timezone"
+2019-09-09 11:03:31,067 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-timezone-34iy7h5qvw8rfv7fvokrt) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:36,065 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-timezone-34iy7h5qvw8rfv7fvokrt to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/timezone/console.log
+2019-09-09 11:03:36,065 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-timezone-34iy7h5qvw8rfv7fvokrt) status=Stopped: deleting container.
+2019-09-09 11:03:36,288 - tests.cloud_tests - INFO - collecting test data for test: modules/user_groups
+2019-09-09 11:03:36,989 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:03:36,990 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:37,805 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:03:47,169 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:03:47,170 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:03:47,310 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:03:47,310 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:03:47,442 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:03:47,442 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:03:47,586 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:03:47,586 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:03:47,726 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:03:47,726 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:03:47,886 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:03:47,886 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:03:48,042 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:03:48,042 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:03:48,198 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:03:48,198 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:03:48,334 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:03:48,335 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:03:48,582 - tests.cloud_tests - DEBUG - running collect script: group_ubuntu
+2019-09-09 11:03:48,583 - tests.cloud_tests - DEBUG - executing "collect: group_ubuntu"
+2019-09-09 11:03:48,734 - tests.cloud_tests - DEBUG - running collect script: group_cloud_users
+2019-09-09 11:03:48,734 - tests.cloud_tests - DEBUG - executing "collect: group_cloud_users"
+2019-09-09 11:03:48,874 - tests.cloud_tests - DEBUG - running collect script: user_ubuntu
+2019-09-09 11:03:48,874 - tests.cloud_tests - DEBUG - executing "collect: user_ubuntu"
+2019-09-09 11:03:49,022 - tests.cloud_tests - DEBUG - running collect script: user_foobar
+2019-09-09 11:03:49,022 - tests.cloud_tests - DEBUG - executing "collect: user_foobar"
+2019-09-09 11:03:49,183 - tests.cloud_tests - DEBUG - running collect script: user_barfoo
+2019-09-09 11:03:49,183 - tests.cloud_tests - DEBUG - executing "collect: user_barfoo"
+2019-09-09 11:03:49,338 - tests.cloud_tests - DEBUG - running collect script: user_cloudy
+2019-09-09 11:03:49,338 - tests.cloud_tests - DEBUG - executing "collect: user_cloudy"
+2019-09-09 11:03:49,514 - tests.cloud_tests - DEBUG - running collect script: root_groups
+2019-09-09 11:03:49,514 - tests.cloud_tests - DEBUG - executing "collect: root_groups"
+2019-09-09 11:03:49,664 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-user-groups-atonsriu6iyt8xl0kn) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:53,756 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-user-groups-atonsriu6iyt8xl0kn to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/user_groups/console.log
+2019-09-09 11:03:53,757 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-user-groups-atonsriu6iyt8xl0kn) status=Stopped: deleting container.
+2019-09-09 11:03:54,008 - tests.cloud_tests - INFO - collecting test data for test: modules/write_files
+2019-09-09 11:03:54,649 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-09 11:03:54,650 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:03:55,468 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-09 11:04:03,818 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-09 11:04:03,818 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-09 11:04:03,986 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-09 11:04:03,987 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-09 11:04:04,126 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-09 11:04:04,126 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-09 11:04:04,310 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-09 11:04:04,310 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-09 11:04:04,474 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-09 11:04:04,474 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-09 11:04:04,610 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-09 11:04:04,610 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-09 11:04:04,742 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-09 11:04:04,742 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-09 11:04:04,894 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-09 11:04:04,894 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-09 11:04:05,054 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-09 11:04:05,054 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-09 11:04:05,274 - tests.cloud_tests - DEBUG - running collect script: file_b64
+2019-09-09 11:04:05,274 - tests.cloud_tests - DEBUG - executing "collect: file_b64"
+2019-09-09 11:04:05,438 - tests.cloud_tests - DEBUG - running collect script: file_text
+2019-09-09 11:04:05,438 - tests.cloud_tests - DEBUG - executing "collect: file_text"
+2019-09-09 11:04:05,602 - tests.cloud_tests - DEBUG - running collect script: file_binary
+2019-09-09 11:04:05,602 - tests.cloud_tests - DEBUG - executing "collect: file_binary"
+2019-09-09 11:04:05,770 - tests.cloud_tests - DEBUG - running collect script: file_gzip
+2019-09-09 11:04:05,770 - tests.cloud_tests - DEBUG - executing "collect: file_gzip"
+2019-09-09 11:04:05,927 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-write-files-d571o1cqaxqiizs2nh) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-09 11:04:11,448 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-bionic-modules-write-files-d571o1cqaxqiizs2nh to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results/lxd/bionic/modules/write_files/console.log
+2019-09-09 11:04:11,449 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-modules-write-files-d571o1cqaxqiizs2nh) status=Stopped: deleting container.
+2019-09-09 11:04:11,647 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-snapshot-u0m7shc5s9yxoj1pkwn456z95n6mx) status=Frozen: deleting container.
+2019-09-09 11:04:11,717 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-snapshot-u0m7shc5s9yxoj1pkwn456z95n6mx) status=Running: shutting down (wait=True)
+2019-09-09 11:04:13,137 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-image-modification-n3a2cg85p3dfasdf8xg) status=Running: deleting container.
+2019-09-09 11:04:13,147 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-bionic-image-modification-n3a2cg85p3dfasdf8xg) status=Running: shutting down (wait=True)
+2019-09-09 11:04:15,326 - tests.cloud_tests - DEBUG - collect stages: {'name': 'collect data', 'time': 855.7713186740875, 'errors': [], 'stages': [{'name': 'collect for platform: lxd', 'time': 853.8867657184601, 'errors': [], 'stages': [{'name': 'set up and collect data for os: bionic', 'time': 851.254497051239, 'errors': [], 'stages': [{'name': 'set up for ubuntu-bionic', 'time': 15.251335620880127, 'errors': [], 'stages': [{'name': 'setup func for --repo, enable repo', 'time': 7.99914026260376, 'errors': [], 'success': True}, {'name': 'setup func for --upgrade, upgrade cloud-init', 'time': 7.2521445751190186, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect test data for bionic', 'time': 805.6074118614197, 'errors': [], 'stages': [{}, {}, {'name': 'collect for test: bugs/lp1628337', 'time': 12.722815752029419, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.158178567886353, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15301990509033203, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15974783897399902, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 1.0119996070861816, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17186594009399414, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.20387482643127441, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.18083715438842773, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.18753838539123535, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1915745735168457, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.30405735969543457, 'errors': [], 'success': True}], 'success': True}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {'name': 'collect for test: main/command_output_simple', 'time': 11.063490867614746, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.206976413726807, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.19687247276306152, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1721506118774414, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.19184064865112305, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15946650505065918, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17264604568481445, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16025829315185547, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19173693656921387, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1673722267150879, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.264448881149292, 'errors': [], 'success': True}, {'name': 'script cloud-init-test-output', 'time': 0.1795663833618164, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_conf', 'time': 12.298821926116943, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.389981031417847, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15707850456237793, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.32369017601013184, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.176497220993042, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17154479026794434, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14833307266235352, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17185187339782715, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17976832389831543, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15195250511169434, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.26793789863586426, 'errors': [], 'success': True}, {'name': 'script 94cloud-init-config', 'time': 0.16004085540771484, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_disable_suites', 'time': 10.937157154083252, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.188450336456299, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1569681167602539, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17603564262390137, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15978550910949707, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1638329029083252, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17214584350585938, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1519012451171875, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16812729835510254, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17180466651916504, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24007725715637207, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.1878981590270996, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_primary', 'time': 11.765207052230835, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.08460021018982, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16091346740722656, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16375112533569336, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.19194436073303223, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15249013900756836, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15541577339172363, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14798521995544434, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15610003471374512, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16794228553771973, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2241230010986328, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.15981674194335938, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_proxy', 'time': 10.619703769683838, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.046956300735474, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17706584930419922, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14363360404968262, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16401958465576172, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14401912689208984, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14392638206481934, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15197014808654785, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.14408040046691895, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1359100341796875, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2240293025970459, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-aptproxy', 'time': 0.14397859573364258, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_security', 'time': 11.746533393859863, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.11799144744873, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16889381408691406, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1717679500579834, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1678609848022461, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.144028902053833, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1519627571105957, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14794015884399414, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1601395606994629, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14781475067138672, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.23206520080566406, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.13592815399169922, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_key', 'time': 11.794384956359863, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.04133415222168, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16894030570983887, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.13972854614257812, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14797258377075195, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14409422874450684, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1399848461151123, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1439223289489746, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.14803409576416016, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.12804865837097168, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.22003173828125, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.1238248348236084, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.24834322929382324, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_keyserver', 'time': 11.814621925354004, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.989762783050537, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16977572441101074, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14298152923583984, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1478862762451172, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15597152709960938, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.12799310684204102, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1478869915008545, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15615582466125488, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15185260772705078, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.22817444801330566, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.13593673706054688, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.2601146697998047, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_list', 'time': 10.883729934692383, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.130979061126709, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16495156288146973, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16379356384277344, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.19595766067504883, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1680305004119873, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16795063018798828, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15613508224487305, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16785669326782227, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15198612213134766, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24406957626342773, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.17189383506774902, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_ppa', 'time': 16.482051849365234, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.193356037139893, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18501782417297363, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.18364977836608887, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17203879356384277, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17213034629821777, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1957859992980957, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14856791496276855, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1760091781616211, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18799662590026855, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2560279369354248, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.17180299758911133, 'errors': [], 'success': True}, {'name': 'script apt-key', 'time': 0.2717430591583252, 'errors': [], 'success': True}, {'name': 'script sources_full', 'time': 0.16776347160339355, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_disable', 'time': 12.285651206970215, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.145055532455444, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1648266315460205, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1518535614013672, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1518995761871338, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.6399674415588379, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1600358486175537, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1564483642578125, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17948293685913086, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14412856101989746, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.25988173484802246, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining', 'time': 0.1319408416748047, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_os', 'time': 11.945082664489746, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.192169666290283, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18904447555541992, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15955471992492676, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1679847240447998, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1681821346282959, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17598605155944824, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17578649520874023, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16806912422180176, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14395499229431152, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2440323829650879, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining_not_written', 'time': 0.16019129753112793, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/bootcmd', 'time': 11.70906138420105, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.056283712387085, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15301275253295898, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.13959026336669922, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14799737930297852, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15202116966247559, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14402055740356445, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14801573753356934, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.21600770950317383, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14792728424072266, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24013781547546387, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.1639399528503418, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/byobu', 'time': 11.682458400726318, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.641402244567871, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16079235076904297, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1797175407409668, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.18393659591674805, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1479792594909668, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.160017728805542, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14395999908447266, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1519761085510254, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14462685585021973, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2914714813232422, 'errors': [], 'success': True}, {'name': 'script byobu_profile_enabled', 'time': 0.23247790336608887, 'errors': [], 'success': True}, {'name': 'script byobu_launch_exists', 'time': 0.24393773078918457, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ca_certs', 'time': 13.002415180206299, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.20172119140625, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2170259952545166, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.25968360900878906, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1799314022064209, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20401668548583984, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2520167827606201, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2879674434661865, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.38802123069763184, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.29996776580810547, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.22404122352600098, 'errors': [], 'success': True}, {'name': 'script cert_links', 'time': 0.26003003120422363, 'errors': [], 'success': True}, {'name': 'script cert', 'time': 0.2278454303741455, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_disable', 'time': 12.122971534729004, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.246220827102661, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2491450309753418, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.25543904304504395, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20401310920715332, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1879887580871582, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18829751014709473, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17564845085144043, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.20842909812927246, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1600508689880371, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24761128425598145, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_enable', 'time': 12.36628246307373, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.073407173156738, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.21306371688842773, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.23970961570739746, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2919340133666992, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20854973793029785, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.3196103572845459, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.21979928016662598, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.28456711769104004, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17539548873901367, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3401310443878174, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/final_message', 'time': 10.984112977981567, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.231427431106567, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1771392822265625, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16348648071289062, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2999863624572754, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16404294967651367, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1920769214630127, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15987777709960938, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17196321487426758, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15626931190490723, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2677295207977295, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/keys_to_console', 'time': 11.747075080871582, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.170403003692627, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1690504550933838, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.23572182655334473, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2039778232574463, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.304088830947876, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.45580577850341797, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.23989653587341309, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2279062271118164, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1560075283050537, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3525521755218506, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.23150205612182617, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/locale', 'time': 11.275632619857788, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.298803329467773, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16544866561889648, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16321587562561035, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14814305305480957, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1599438190460205, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15987491607666016, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16002583503723145, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16797256469726562, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15229058265686035, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2557790279388428, 'errors': [], 'success': True}, {'name': 'script locale_default', 'time': 0.14392995834350586, 'errors': [], 'success': True}, {'name': 'script locale_a', 'time': 0.14804625511169434, 'errors': [], 'success': True}, {'name': 'script locale_gen', 'time': 0.15201807022094727, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_bridge', 'time': 20.17986750602722, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 18.195106267929077, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16908693313598633, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14763689041137695, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1604936122894287, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14349985122680664, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1643080711364746, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17170095443725586, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17597055435180664, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15997672080993652, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.23999905586242676, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.15599870681762695, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.1441328525543213, 'errors': [], 'success': True}, {'name': 'script lxc-bridge', 'time': 0.1518092155456543, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_dir', 'time': 20.56868553161621, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 18.291971683502197, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.23323583602905273, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19984078407287598, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17969441413879395, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2079148292541504, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1961052417755127, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19188261032104492, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2999536991119385, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1482255458831787, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.25182247161865234, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.19218993186950684, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.17570257186889648, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp', 'time': 18.97105574607849, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.610466003417969, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2813377380371094, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.26781368255615234, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.3155198097229004, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.23597025871276855, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.3240020275115967, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2486248016357422, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.31534266471862793, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2879829406738281, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2960398197174072, 'errors': [], 'success': True}, {'name': 'script ntp_installed', 'time': 0.20786190032958984, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_empty', 'time': 0.3361968994140625, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pool_list', 'time': 0.24374771118164062, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_chrony', 'time': 17.92603039741516, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 16.081342458724976, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.14913582801818848, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.33982181549072266, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1439657211303711, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1556715965270996, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16803836822509766, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1481332778930664, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16803455352783203, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1677567958831787, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2601447105407715, 'errors': [], 'success': True}, {'name': 'script chrony_conf', 'time': 0.1438586711883545, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_pools', 'time': 17.279237508773804, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 14.28231167793274, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.24532556533813477, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19170665740966797, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.22822093963623047, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2721235752105713, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.28357410430908203, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1599271297454834, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2881755828857422, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.22763848304748535, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.34417057037353516, 'errors': [], 'success': True}, {'name': 'script ntp_installed_pools', 'time': 0.23221039772033691, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_pools', 'time': 0.18775415420532227, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pools', 'time': 0.14789795875549316, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.18802237510681152, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_servers', 'time': 17.516725778579712, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.339931964874268, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15338778495788574, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1554858684539795, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14381980895996094, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14825105667114258, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15566635131835938, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1520371437072754, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.18406224250793457, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15999126434326172, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2522599697113037, 'errors': [], 'success': True}, {'name': 'script ntp_installed_servers', 'time': 0.17178893089294434, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_servers', 'time': 0.1680610179901123, 'errors': [], 'success': True}, {'name': 'script ntp_conf_servers', 'time': 0.17197060585021973, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.15983939170837402, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_timesyncd', 'time': 10.689857482910156, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.137232542037964, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1528472900390625, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.13175296783447266, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14002537727355957, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14793682098388672, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1279764175415039, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16403770446777344, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15996241569519043, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13597726821899414, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24803972244262695, 'errors': [], 'success': True}, {'name': 'script timesyncd_conf', 'time': 0.14394474029541016, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/package_update_upgrade_install', 'time': 20.836459398269653, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.107757568359375, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15702390670776367, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1516704559326172, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1441206932067871, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15610408782958984, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1518416404724121, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14796972274780273, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15986227989196777, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13602185249328613, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2040855884552002, 'errors': [], 'success': True}, {'name': 'script apt_history_cmdline', 'time': 0.16400384902954102, 'errors': [], 'success': True}, {'name': 'script dpkg_show', 'time': 0.15586209297180176, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/runcmd', 'time': 11.382155418395996, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.673656463623047, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15284276008605957, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16369318962097168, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.164597749710083, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17160367965698242, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1516735553741455, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15202546119689941, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1959681510925293, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13600468635559082, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24403119087219238, 'errors': [], 'success': True}, {'name': 'script run_cmd', 'time': 0.1759357452392578, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/seed_random_data', 'time': 11.726832866668701, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.089821815490723, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15325593948364258, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1473555564880371, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15230226516723633, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15571880340576172, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15232014656066895, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1517338752746582, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15584540367126465, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1687028408050537, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.25196146965026855, 'errors': [], 'success': True}, {'name': 'script seed_data', 'time': 0.14768409729003906, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname', 'time': 8.098936319351196, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.058268785476685, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.13690567016601562, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15574193000793457, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.23592901229858398, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16810345649719238, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17190337181091309, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15199828147888184, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17217659950256348, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15195155143737793, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24393439292907715, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.15335798263549805, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.15471839904785156, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.14380955696105957, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname_fqdn', 'time': 8.019484519958496, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.07855486869812, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15302443504333496, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14378905296325684, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15988755226135254, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16401457786560059, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18004775047302246, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14382553100585938, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.14413046836853027, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1439189910888672, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.22809886932373047, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.15592265129089355, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.16828465461730957, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.15583491325378418, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password', 'time': 10.883263111114502, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.110538721084595, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.14489126205444336, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14789295196533203, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1558547019958496, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15207171440124512, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14796781539916992, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16009163856506348, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15581631660461426, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13997244834899902, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24419021606445312, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.16388535499572754, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.15994691848754883, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_expire', 'time': 11.001481056213379, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.084993124008179, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1609659194946289, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17178010940551758, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16003847122192383, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1599581241607666, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16400957107543945, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17595911026000977, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16385293006896973, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14792633056640625, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2519972324371338, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.17588090896606445, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.18396830558776855, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list', 'time': 11.726496696472168, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.689840316772461, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1810321807861328, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15967512130737305, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1479659080505371, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15203261375427246, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13602042198181152, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15993189811706543, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17196369171142578, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.35998988151550293, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2640063762664795, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.1559438705444336, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.14795231819152832, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list_string', 'time': 10.85251522064209, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.059597253799438, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20548486709594727, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1555924415588379, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14763736724853516, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1681356430053711, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15181589126586914, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.13996100425720215, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15597271919250488, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13591885566711426, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.22003674507141113, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.16399860382080078, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.148223876953125, 'errors': [], 'success': True}], 'success': True}, {}, {}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_disable', 'time': 11.798578977584839, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.205402851104736, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1689896583557129, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.13958072662353516, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.13597941398620605, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15606164932250977, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1441202163696289, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15190720558166504, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1479475498199463, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15205907821655273, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2284259796142578, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.16797780990600586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_enable', 'time': 10.695161581039429, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.090511083602905, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16534423828125, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14368772506713867, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15990138053894043, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15977191925048828, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1438426971435547, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14793848991394043, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15605807304382324, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13994860649108887, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2321619987487793, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.15584039688110352, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_import_id', 'time': 10.766533851623535, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.173938512802124, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1650395393371582, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.147660493850708, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15587949752807617, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15626049041748047, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13974237442016602, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15606427192687988, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16391682624816895, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13992810249328613, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2200460433959961, 'errors': [], 'success': True}, {'name': 'script auth_keys_ubuntu', 'time': 0.1479356288909912, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_keys_generate', 'time': 12.540186643600464, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.671560287475586, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16491413116455078, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1557769775390625, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16810321807861328, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1677384376525879, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14010953903198242, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1440885066986084, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17196011543273926, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15591049194335938, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.22796368598937988, 'errors': [], 'success': True}, {'name': 'script dsa_public', 'time': 0.26819348335266113, 'errors': [], 'success': True}, {'name': 'script dsa_private', 'time': 0.17196130752563477, 'errors': [], 'success': True}, {'name': 'script rsa_public', 'time': 0.16397857666015625, 'errors': [], 'success': True}, {'name': 'script rsa_private', 'time': 0.1521434783935547, 'errors': [], 'success': True}, {'name': 'script ecdsa_public', 'time': 0.15970802307128906, 'errors': [], 'success': True}, {'name': 'script ecdsa_private', 'time': 0.1558387279510498, 'errors': [], 'success': True}, {'name': 'script ed25519_public', 'time': 0.1640613079071045, 'errors': [], 'success': True}, {'name': 'script ed25519_private', 'time': 0.13594484329223633, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/timezone', 'time': 11.959392786026001, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.286862850189209, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1650092601776123, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1594703197479248, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14803290367126465, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1639542579650879, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13993024826049805, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1681983470916748, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15198063850402832, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15196824073791504, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.25617218017578125, 'errors': [], 'success': True}, {'name': 'script timezone', 'time': 0.16767024993896484, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/user_groups', 'time': 12.613017082214355, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.123878240585327, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1409282684326172, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.13167524337768555, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14403128623962402, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.13994932174682617, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1599903106689453, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1560530662536621, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15601205825805664, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.13627123832702637, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24814891815185547, 'errors': [], 'success': True}, {'name': 'script group_ubuntu', 'time': 0.1515178680419922, 'errors': [], 'success': True}, {'name': 'script group_cloud_users', 'time': 0.13999009132385254, 'errors': [], 'success': True}, {'name': 'script user_ubuntu', 'time': 0.14794492721557617, 'errors': [], 'success': True}, {'name': 'script user_foobar', 'time': 0.1606154441833496, 'errors': [], 'success': True}, {'name': 'script user_barfoo', 'time': 0.1554720401763916, 'errors': [], 'success': True}, {'name': 'script user_cloudy', 'time': 0.17592191696166992, 'errors': [], 'success': True}, {'name': 'script root_groups', 'time': 0.14438176155090332, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/write_files', 'time': 11.21373987197876, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.109313726425171, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16859650611877441, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.13956618309020996, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1840522289276123, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1639726161956787, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1361236572265625, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.13192367553710938, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1520373821258545, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1601123809814453, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2198011875152588, 'errors': [], 'success': True}, {'name': 'script file_b64', 'time': 0.16401243209838867, 'errors': [], 'success': True}, {'name': 'script file_text', 'time': 0.16389942169189453, 'errors': [], 'success': True}, {'name': 'script file_binary', 'time': 0.16799378395080566, 'errors': [], 'success': True}, {'name': 'script file_gzip', 'time': 0.15215635299682617, 'errors': [], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}
+2019-09-09 11:04:15,328 - tests.cloud_tests - DEBUG - found test data: {'lxd': {'bionic': ['bugs/lp1628337', 'modules/apt_configure_sources_list', 'modules/locale', 'modules/apt_configure_primary', 'modules/lxd_bridge', 'modules/apt_configure_security', 'modules/apt_pipelining_os', 'modules/ssh_import_id', 'modules/ntp_pools', 'modules/ssh_keys_generate', 'modules/ssh_auth_key_fingerprints_enable', 'modules/apt_configure_sources_keyserver', 'modules/bootcmd', 'modules/set_hostname_fqdn', 'modules/ssh_auth_key_fingerprints_disable', 'modules/final_message', 'modules/apt_configure_sources_key', 'modules/ntp_servers', 'modules/ntp_chrony', 'modules/write_files', 'modules/set_password', 'modules/ntp', 'modules/timezone', 'modules/keys_to_console', 'modules/debug_enable', 'modules/seed_random_data', 'modules/set_password_list', 'modules/user_groups', 'modules/debug_disable', 'modules/byobu', 'modules/apt_configure_proxy', 'modules/apt_configure_sources_ppa', 'modules/package_update_upgrade_install', 'modules/ntp_timesyncd', 'modules/lxd_dir', 'modules/apt_pipelining_disable', 'modules/runcmd', 'modules/set_hostname', 'modules/apt_configure_conf', 'modules/apt_configure_disable_suites', 'modules/set_password_list_string', 'modules/set_password_expire', 'modules/ca_certs', 'main/command_output_simple']}}
+
+2019-09-09 11:04:15,328 - tests.cloud_tests - INFO - test: platform='lxd', os='bionic' verifying test data
+2019-09-09 11:04:15,328 - tests.cloud_tests - DEBUG - verifying test data for bugs/lp1628337
+test_fetch_indices (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify no apt errors. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify can find ntp and install it. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,369 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Unexpected warnings should not be found in the log. ... ok
+test_sources_list (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Test sources.list includes sources. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:04:15,412 - tests.cloud_tests - DEBUG - verifying test data for modules/locale
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by lxd platform. ... ok
+test_locale (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale is set properly. ... ok
+test_locale_a (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale -a has both options. ... ok
+test_locale_gen (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test local.gen file has all entries. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,453 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_primary
+test_gatech_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test GaTech entries exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Unexpected warnings should not be found in the log. ... ok
+test_ubuntu_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test no default Ubuntu entries exist. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,494 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_bridge
+test_bridge (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test bridge config. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by lxd platform. ... ok
+test_lxc (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,533 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_security
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Unexpected warnings should not be found in the log. ... ok
+test_security_mirror (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Test security lines added and uncommented in source.list. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,573 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_os
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Unexpected warnings should not be found in the log. ... ok
+test_os_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+test 'os' settings does not write apt config file. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,614 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_import_id
+test_authorized_keys (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Test that ssh keys were imported. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,653 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_pools
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test dist config file is empty ... ok
+test_ntp_entires (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 11:04:15,695 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_keys_generate
+test_dsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa private key not generated. ... ok
+test_dsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa public key not generated. ... ok
+test_ecdsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ecdsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ed25519_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_ed25519_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Unexpected warnings should not be found in the log. ... ok
+test_rsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+test_rsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+
+----------------------------------------------------------------------
+Ran 13 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,735 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_enable
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Unexpected warnings should not be found in the log. ... ok
+test_syslog (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Verify output of syslog. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,793 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_keyserver
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test specific key added. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,836 - tests.cloud_tests - DEBUG - verifying test data for modules/bootcmd
+test_bootcmd_host (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Test boot cmd worked. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,876 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname_fqdn
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname output. ... ok
+test_hostname_fqdn (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname fqdn output. ... ok
+test_hosts (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test /etc/hosts file. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,916 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_disable
+test_cloud_init_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Verify disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:15,954 - tests.cloud_tests - DEBUG - verifying test data for modules/final_message
+test_final_message_string (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure final handles regular strings. ... ok
+test_final_message_subs (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Test variable substitution in final message. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:04:15,996 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_key
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test key list updated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,038 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_servers
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test config server entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.003s
+
+OK (skipped=2)
+2019-09-09 11:04:16,079 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_chrony
+test_chrony_entries (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Test chrony config entries ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,118 - tests.cloud_tests - DEBUG - verifying test data for modules/write_files
+test_b64 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test b64 encoded file reads as ascii. ... ok
+test_binary (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test binary file reads as executable. ... ok
+test_gzip (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test gzip file shows up as a shell script. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Unexpected warnings should not be found in the log. ... ok
+test_text (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test text shows up as ASCII text. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,158 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test ubuntu user in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,198 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test ntp installed ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,239 - tests.cloud_tests - DEBUG - verifying test data for modules/timezone
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Unexpected warnings should not be found in the log. ... ok
+test_timezone (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Test date prints correct timezone. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,278 - tests.cloud_tests - DEBUG - verifying test data for modules/keys_to_console
+test_excluded_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test excluded keys missing. ... ok
+test_expected_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test expected keys exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,319 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_enable
+test_debug_enable (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Test debug messages in cloud-init log. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,359 - tests.cloud_tests - DEBUG - verifying test data for modules/seed_random_data
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Unexpected warnings should not be found in the log. ... ok
+test_random_seed_data (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Test random data passed in exists. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,398 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-09 11:04:16,442 - tests.cloud_tests - DEBUG - verifying test data for modules/user_groups
+test_group_cloud_users (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloud users group exists. ... ok
+test_group_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu group exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Unexpected warnings should not be found in the log. ... ok
+test_user_barfoo (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test barfoo user exists. ... ok
+test_user_cloudy (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloudy user exists. ... ok
+test_user_foobar (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test foobar user exists. ... ok
+test_user_root_in_secret (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test root user is in 'secret' group. ... ok
+test_user_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu user exists. ... ok
+
+----------------------------------------------------------------------
+Ran 12 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:04:16,485 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_disable
+test_debug_disable (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Test verbose output missing from logs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,523 - tests.cloud_tests - DEBUG - verifying test data for modules/byobu
+test_byobu_installed (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu installed. ... ok
+test_byobu_launch_exists (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu-launch exists. ... ok
+test_byobu_profile_enabled (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu profile.d file exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,564 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_proxy
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Unexpected warnings should not be found in the log. ... ok
+test_proxy_config (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Test proxy options added to apt config. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,603 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_ppa
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Unexpected warnings should not be found in the log. ... ok
+test_ppa (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test specific ppa added. ... ok
+test_ppa_key (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test ppa key added. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,641 - tests.cloud_tests - DEBUG - verifying test data for modules/package_update_upgrade_install
+test_apt_history (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test apt history for update command. ... ok
+test_cloud_init_output (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test cloud-init-output for install & upgrade stuff. ... ok
+test_installed_sl (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test sl got installed. ... ok
+test_installed_tree (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test tree got installed. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:04:16,679 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_timesyncd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Unexpected warnings should not be found in the log. ... ok
+test_timesyncd_entries (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Test timesyncd config entries ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,714 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_dir
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by lxd platform. ... ok
+test_lxc (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,750 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_disable
+test_disable_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Test pipelining disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,792 - tests.cloud_tests - DEBUG - verifying test data for modules/runcmd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Unexpected warnings should not be found in the log. ... ok
+test_run_cmd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Test run command worked. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,832 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Test hostname command shows correct output. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,868 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_conf
+test_apt_conf_assumeyes (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config assumes true. ... ok
+test_apt_conf_fixbroken (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config fixes broken. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,908 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_disable_suites
+test_empty_sourcelist (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Test source list is empty. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:16,947 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list_string
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.005s
+
+OK (skipped=2)
+2019-09-09 11:04:16,990 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_expire
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test user frozen in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:17,028 - tests.cloud_tests - DEBUG - verifying test data for modules/ca_certs
+test_cert_installed (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test line from our cert exists. ... ok
+test_certs_updated (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test certs have been updated in /etc/ssl/certs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-09 11:04:17,071 - tests.cloud_tests - DEBUG - verifying test data for main/command_output_simple
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Unexpected warnings should not be found in the log. ... ok
+test_output_file (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that the output file is not empty and has all stages. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-09 11:04:17,112 - tests.cloud_tests - INFO - test: platform='lxd', os='bionic' passed all tests
+2019-09-09 11:04:17,112 - tests.cloud_tests - DEBUG - 
+---- Verify summarized results:
+
+Platform: lxd
+  Distro: bionic
+    test modules passed:44 tests failed:0
+2019-09-09 11:04:17,112 - tests.cloud_tests - INFO - leaving data in /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-b-lxd/cloud-init/results
+___________________________________ summary ____________________________________
+  citest: commands succeeded
+  congratulations :)
++ RET=0
++ find . -name id_rsa* -delete
++ exit 0
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS
+=== End series b ===
+=== Begin series d ===
+Started by remote host 10.247.8.15
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd
+[cloud-init-integration-proposed-d-lxd] $ /bin/sh -xe /tmp/jenkins13057622440470085522.sh
++ release=disco
++ release_ver=19.04
++ platform=lxd
++ set -e
++ sudo rm -Rf cloud-init
++ git clone https://git.launchpad.net/cloud-init
+Cloning into 'cloud-init'...
++ cd cloud-init
++ git tag --list
++ grep 19.04
++ tail -1
++ tag=ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
++ echo Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
+Running with source from tag ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
++ git checkout ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1
+Note: checking out 'ubuntu/19.2-24-ge7881d5c-0ubuntu1_19.04.1'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by performing another checkout.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -b with the checkout command again. Example:
+
+  git checkout -b <new-branch-name>
+
+HEAD is now at f0141fe0 releasing cloud-init version 19.2-24-ge7881d5c-0ubuntu1~19.04.1
++ mirror=http://archive.ubuntu.com/ubuntu/
++ hostname
++ [ -z  -a torkoal = torkoal ]
++ export TMPDIR=/var/lib/jenkins/tmp/
++ set +e
++ no_proxy=launchpad.net https_proxy=http://squid.internal:3128 tox -e citest -- run --os-name=disco --platform=lxd --repo='deb http://archive.ubuntu.com/ubuntu/ disco-proposed main' --preserve-data --data-dir=./results --verbose
+GLOB sdist-make: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/setup.py
+citest create: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest
+citest installdeps: -r/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/integration-requirements.txt
+citest inst: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/dist/cloud-init-19.2.zip
+citest installed: asn1crypto==0.24.0,attrs==19.1.0,bcrypt==3.1.7,boto3==1.5.9,botocore==1.8.50,certifi==2019.6.16,cffi==1.12.3,chardet==3.0.4,cloud-init==19.2,configobj==5.0.6,cryptography==2.4.2,docutils==0.15.2,idna==2.8,Jinja2==2.10.1,jmespath==0.9.4,jsonpatch==1.24,jsonpointer==2.0,jsonschema==3.0.2,linecache2==1.0.0,MarkupSafe==1.1.1,oauthlib==3.1.0,paramiko==2.4.2,pbr==5.4.3,pkg-resources==0.0.0,pyasn1==0.4.7,pycparser==2.19,pylxd==2.2.7,PyNaCl==1.3.0,pyrsistent==0.15.4,python-dateutil==2.8.0,python-simplestreams==0.1.0,PyYAML==5.1.2,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,s3transfer==0.1.13,six==1.12.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.3,ws4py==0.5.1
+citest runtests: PYTHONHASHSEED='3385583481'
+citest runtests: commands[0] | /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=disco --platform=lxd --repo=deb http://archive.ubuntu.com/ubuntu/ disco-proposed main --preserve-data --data-dir=./results --verbose
+2019-09-07 10:15:54,352 - tests.cloud_tests - DEBUG - running with args: Namespace(data_dir='/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results', deb=None, feature_override={}, os_name=['disco'], platform=['lxd'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo='deb http://archive.ubuntu.com/ubuntu/ disco-proposed main', result=None, rpm=None, script=None, subcmd='run', test_config=['/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1511485.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1611074.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/bugs/lp1628337.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/add_apt_repositories.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/alter_completion_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/configure_instance_trusted_ca_certificates.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/configure_instances_ssh_keys.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/including_user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/install_arbitrary_packages.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/install_run_chef_recipes.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_apt_upgrade.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_commands.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/run_commands_first_boot.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/setup_run_puppet.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/examples/writing_out_arbitrary_files.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/main/command_output_simple.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_conf.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_disable_suites.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_primary.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_proxy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_security.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_key.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_keyserver.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/apt_pipelining_os.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/bootcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/byobu.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ca_certs.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/debug_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/debug_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/final_message.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/keys_to_console.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/landscape.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/locale.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/lxd_bridge.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/lxd_dir.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_chrony.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_pools.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_servers.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ntp_timesyncd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/package_update_upgrade_install.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/runcmd.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/seed_random_command.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/seed_random_data.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_hostname.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_hostname_fqdn.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_expire.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_list.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/set_password_list_string.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/snap.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/snappy.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_enable.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_import_id.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_generate.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/ssh_keys_provided.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/timezone.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/user_groups.yaml', '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/tests/cloud_tests/testcases/modules/write_files.yaml'], upgrade=True, upgrade_full=False, verbose=True)
+2019-09-07 10:15:54,352 - tests.cloud_tests - DEBUG - using tmpdir: /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results
+2019-09-07 10:15:54,360 - tests.cloud_tests - DEBUG - platform config: {'enabled': True, 'get_image_timeout': 300, 'create_instance_timeout': 60, 'private_key': 'cloud_init_rsa', 'public_key': 'cloud_init_rsa.pub', 'template_overrides': {'/var/lib/cloud/seed/nocloud-net/meta-data': {'when': ['create', 'copy'], 'template': 'cloud-init-meta.tpl'}, '/var/lib/cloud/seed/nocloud-net/network-config': {'when': ['create', 'copy'], 'template': 'cloud-init-network.tpl'}, '/var/lib/cloud/seed/nocloud-net/user-data': {'when': ['create', 'copy'], 'template': 'cloud-init-user.tpl', 'properties': {'default': '#cloud-config\n{}\n'}}, '/var/lib/cloud/seed/nocloud-net/vendor-data': {'when': ['create', 'copy'], 'template': 'cloud-init-vendor.tpl', 'properties': {'default': '#cloud-config\n{}\n'}}}, 'template_files': {'cloud-init-meta.tpl': '#cloud-config\ninstance-id: {{ container.name }}\nlocal-hostname: {{ container.name }}\n{{ config_get("user.meta-data", "") }}\n', 'cloud-init-network.tpl': '{% if config_get("user.network-config", "") == "" %}version: 1\nconfig:\n    - type: physical\n      name: eth0\n      subnets:\n          - type: {% if config_get("user.network_mode", "") == "link-local" %}manual{% else %}dhcp{% endif %}\n            control: auto{% else %}{{ config_get("user.network-config", "") }}{% endif %}\n', 'cloud-init-user.tpl': '{{ config_get("user.user-data", properties.default) }}\n', 'cloud-init-vendor.tpl': '{{ config_get("user.vendor-data", properties.default) }}\n'}, 'data_dir': '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results'}
+2019-09-07 10:15:54,360 - tests.cloud_tests - INFO - setting up platform: lxd
+2019-09-07 10:15:55,284 - tests.cloud_tests - DEBUG - os config: {'enabled': True, 'boot_timeout': 120, 'boot_clean_script': '#!/bin/bash\nrm -rf /var/log/cloud-init.log /var/log/cloud-init-output.log \\\n    /var/lib/cloud/ /run/cloud-init/ /var/log/syslog\n', 'system_ready_script': "# permit running or degraded state as both indicate complete boot\n[ $(systemctl is-system-running) = 'running' -o\n  $(systemctl is-system-running) = 'degraded' ]\n", 'cloud_init_ready_script': "[ -f '/run/cloud-init/result.json' ]\n", 'feature_groups': ['base', 'debian_base', 'ubuntu_specific'], 'features': {'apt': True, 'byobu': True, 'landscape': True, 'lxd': True, 'ppa': True, 'rpm': None, 'snap': True, 'hostname': True, 'apt_src_cont': True, 'apt_hist_fmt': True, 'daylight_time': True, 'apt_up_out': True, 'engb_locale': True, 'locale_gen': True, 'no_ntpdate': True, 'no_file_fmt_e': True, 'ppa_file_name': True, 'sshd': True, 'ssh_key_fmt': True, 'syslog': True, 'ubuntu_ntp': True, 'ubuntu_repos': True, 'ubuntu_user': True, 'lsb_release': True, 'sudo': True}, 'mirror_url': 'https://cloud-images.ubuntu.com/daily', 'mirror_dir': '/srv/citest/images', 'keyring': '/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg', 'version': 19.04, 'sstreams_server': 'https://cloud-images.ubuntu.com/daily', 'cache_base_image': True, 'override_templates': False, 'setup_overrides': None, 'release': 'disco', 'os': 'ubuntu', 'alias': 'disco', 'arch': 'amd64'}
+2019-09-07 10:15:55,284 - tests.cloud_tests - INFO - acquiring image for os: disco
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:15:56,678 - tests.cloud_tests - DEBUG - updating args for setup with: None
+2019-09-07 10:15:58,017 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:15:58,018 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:16:03,501 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:16:28,607 - tests.cloud_tests - INFO - setting up ubuntu-disco (build_name=server serial=20190904)
+2019-09-07 10:16:28,633 - tests.cloud_tests - DEBUG - enable repo: "deb http://archive.ubuntu.com/ubuntu/ disco-proposed main" in target
+2019-09-07 10:16:28,633 - tests.cloud_tests - DEBUG - executing "enable repo: "deb http://archive.ubuntu.com/ubuntu/ disco-proposed main" in target"
+2019-09-07 10:16:37,967 - tests.cloud_tests - DEBUG - upgrading cloud-init
+2019-09-07 10:16:37,967 - tests.cloud_tests - DEBUG - executing "upgrading cloud-init"
+2019-09-07 10:16:45,009 - tests.cloud_tests - DEBUG - creating snapshot for disco
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:16:45,765 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:16:45,766 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:16:47,289 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:16:52,601 - tests.cloud_tests - DEBUG - executing command: sh -c 'set -e; s="$1"; shift; cat > "$s"; trap "rm -f $s" EXIT; chmod +x "$s"; "$s" "$@"' runscript /tmp/LXDInstance-0000
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:16:52,888 - tests.cloud_tests - INFO - collecting test data for os: disco
+2019-09-07 10:16:52,893 - tests.cloud_tests - WARNING - test config bugs/lp1511485 is not enabled, skipping
+2019-09-07 10:16:52,897 - tests.cloud_tests - WARNING - test config bugs/lp1611074 is not enabled, skipping
+2019-09-07 10:16:52,934 - tests.cloud_tests - INFO - collecting test data for test: bugs/lp1628337
+2019-09-07 10:16:53,590 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:16:53,590 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:16:54,398 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:16:59,774 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:16:59,774 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:17:00,011 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:17:00,012 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:17:00,175 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:17:00,175 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:17:00,334 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:17:00,334 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:17:00,482 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:17:00,482 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:17:00,630 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:17:00,630 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:17:00,786 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:17:00,786 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:17:00,970 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:17:00,971 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:17:01,246 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:17:01,246 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:17:01,649 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-bugs-lp1628337-zpkybdpbg0rs1p4fppdvd3pi) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:06,085 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-bugs-lp1628337-zpkybdpbg0rs1p4fppdvd3pi to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/bugs/lp1628337/console.log
+2019-09-07 10:17:06,085 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-bugs-lp1628337-zpkybdpbg0rs1p4fppdvd3pi) status=Stopped: deleting container.
+2019-09-07 10:17:06,400 - tests.cloud_tests - WARNING - test config examples/add_apt_repositories is not enabled, skipping
+2019-09-07 10:17:06,404 - tests.cloud_tests - WARNING - test config examples/alter_completion_message is not enabled, skipping
+2019-09-07 10:17:06,409 - tests.cloud_tests - WARNING - test config examples/configure_instance_trusted_ca_certificates is not enabled, skipping
+2019-09-07 10:17:06,417 - tests.cloud_tests - WARNING - test config examples/configure_instances_ssh_keys is not enabled, skipping
+2019-09-07 10:17:06,423 - tests.cloud_tests - WARNING - test config examples/including_user_groups is not enabled, skipping
+2019-09-07 10:17:06,427 - tests.cloud_tests - WARNING - test config examples/install_arbitrary_packages is not enabled, skipping
+2019-09-07 10:17:06,435 - tests.cloud_tests - WARNING - test config examples/install_run_chef_recipes is not enabled, skipping
+2019-09-07 10:17:06,439 - tests.cloud_tests - WARNING - test config examples/run_apt_upgrade is not enabled, skipping
+2019-09-07 10:17:06,443 - tests.cloud_tests - WARNING - test config examples/run_commands is not enabled, skipping
+2019-09-07 10:17:06,448 - tests.cloud_tests - WARNING - test config examples/run_commands_first_boot is not enabled, skipping
+2019-09-07 10:17:06,454 - tests.cloud_tests - WARNING - test config examples/setup_run_puppet is not enabled, skipping
+2019-09-07 10:17:06,460 - tests.cloud_tests - WARNING - test config examples/writing_out_arbitrary_files is not enabled, skipping
+2019-09-07 10:17:06,498 - tests.cloud_tests - INFO - collecting test data for test: main/command_output_simple
+2019-09-07 10:17:07,429 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:17:07,430 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:08,598 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:17:13,957 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:17:13,958 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:17:14,194 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:17:14,195 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:17:14,434 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:17:14,434 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:17:14,646 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:17:14,646 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:17:14,922 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:17:14,923 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:17:15,110 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:17:15,110 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:17:16,266 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:17:16,267 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:17:16,486 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:17:16,487 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:17:16,670 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:17:16,671 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:17:16,902 - tests.cloud_tests - DEBUG - running collect script: cloud-init-test-output
+2019-09-07 10:17:16,902 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-test-output"
+2019-09-07 10:17:17,071 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-main-command-output-simple-8hp09vmra58d) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:19,733 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-main-command-output-simple-8hp09vmra58d to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/main/command_output_simple/console.log
+2019-09-07 10:17:19,733 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-main-command-output-simple-8hp09vmra58d) status=Stopped: deleting container.
+2019-09-07 10:17:20,009 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_conf
+2019-09-07 10:17:20,721 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:17:20,722 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:21,748 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:17:27,073 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:17:27,074 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:17:27,271 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:17:27,271 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:17:27,566 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:17:27,566 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:17:27,802 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:17:27,802 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:17:28,034 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:17:28,034 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:17:28,195 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:17:28,195 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:17:28,350 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:17:28,350 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:17:28,534 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:17:28,534 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:17:28,710 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:17:28,710 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:17:28,950 - tests.cloud_tests - DEBUG - running collect script: 94cloud-init-config
+2019-09-07 10:17:28,950 - tests.cloud_tests - DEBUG - executing "collect: 94cloud-init-config"
+2019-09-07 10:17:29,111 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-conf-s4uzxibil2hn) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:32,804 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-conf-s4uzxibil2hn to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_conf/console.log
+2019-09-07 10:17:32,804 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-conf-s4uzxibil2hn) status=Stopped: deleting container.
+2019-09-07 10:17:33,118 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_disable_suites
+2019-09-07 10:17:33,773 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:17:33,774 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:34,783 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:17:43,746 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:17:43,746 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:17:44,015 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:17:44,015 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:17:44,290 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:17:44,290 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:17:44,566 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:17:44,566 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:17:44,882 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:17:44,882 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:17:45,086 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:17:45,086 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:17:45,294 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:17:45,294 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:17:45,566 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:17:45,566 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:17:45,759 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:17:45,759 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:17:46,070 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:17:46,070 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:17:46,283 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-disable--xkujj8t3) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:51,002 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-disable--xkujj8t3 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_disable_suites/console.log
+2019-09-07 10:17:51,002 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-disable--xkujj8t3) status=Stopped: deleting container.
+2019-09-07 10:17:51,282 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_primary
+2019-09-07 10:17:52,185 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:17:52,186 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:17:53,615 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:17:58,981 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:17:58,982 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:17:59,154 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:17:59,155 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:17:59,342 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:17:59,342 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:17:59,606 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:17:59,606 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:17:59,958 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:17:59,958 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:18:00,254 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:18:00,254 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:18:00,502 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:18:00,502 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:18:00,694 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:18:00,694 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:18:00,926 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:18:00,926 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:18:01,218 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:18:01,219 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:18:01,403 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-primary-wf13syqpu) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:04,801 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-primary-wf13syqpu to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_primary/console.log
+2019-09-07 10:18:04,801 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-primary-wf13syqpu) status=Stopped: deleting container.
+2019-09-07 10:18:05,126 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_proxy
+2019-09-07 10:18:05,929 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:18:05,930 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:07,973 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:18:14,353 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:18:14,354 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:18:14,646 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:18:14,647 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:18:14,883 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:18:14,883 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:18:15,087 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:18:15,087 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:18:15,474 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:18:15,474 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:18:15,730 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:18:15,731 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:18:16,038 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:18:16,038 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:18:16,239 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:18:16,239 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:18:16,574 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:18:16,574 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:18:16,986 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-aptproxy
+2019-09-07 10:18:16,986 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-aptproxy"
+2019-09-07 10:18:17,355 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-proxy-8062sftus0z) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:19,178 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-proxy-8062sftus0z to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_proxy/console.log
+2019-09-07 10:18:19,178 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-proxy-8062sftus0z) status=Stopped: deleting container.
+2019-09-07 10:18:19,451 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_security
+2019-09-07 10:18:20,694 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:18:20,694 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:21,705 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:18:27,046 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:18:27,046 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:18:27,254 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:18:27,255 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:18:27,426 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:18:27,426 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:18:27,602 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:18:27,602 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:18:27,770 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:18:27,770 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:18:28,550 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:18:28,550 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:18:28,826 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:18:28,826 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:18:29,082 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:18:29,082 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:18:29,286 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:18:29,286 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:18:29,558 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:18:29,558 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:18:29,743 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-security-s3e11oft) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:32,709 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-security-s3e11oft to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_security/console.log
+2019-09-07 10:18:32,710 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-security-s3e11oft) status=Stopped: deleting container.
+2019-09-07 10:18:32,971 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_key
+2019-09-07 10:18:33,761 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:18:33,762 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:34,974 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:18:46,385 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:18:46,386 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:18:46,554 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:18:46,554 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:18:46,750 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:18:46,750 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:18:46,958 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:18:46,958 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:18:47,162 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:18:47,162 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:18:47,358 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:18:47,358 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:18:47,590 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:18:47,590 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:18:47,763 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:18:47,763 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:18:48,862 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:18:48,862 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:18:49,198 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:18:49,198 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:18:49,386 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-07 10:18:49,386 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-07 10:18:49,733 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-07 10:18:49,739 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--wbrleu3d) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:55,745 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--wbrleu3d to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_sources_key/console.log
+2019-09-07 10:18:55,746 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--wbrleu3d) status=Stopped: deleting container.
+2019-09-07 10:18:56,019 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_keyserver
+2019-09-07 10:18:56,605 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:18:56,606 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:18:57,425 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:19:08,769 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:19:08,770 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:19:08,950 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:19:08,951 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:19:09,114 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:19:09,114 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:19:09,266 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:19:09,267 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:19:09,426 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:19:09,426 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:19:09,586 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:19:09,586 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:19:09,806 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:19:09,806 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:19:09,962 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:19:09,962 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:19:10,154 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:19:10,154 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:19:10,419 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:19:10,419 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:19:10,598 - tests.cloud_tests - DEBUG - running collect script: apt_key_list
+2019-09-07 10:19:10,598 - tests.cloud_tests - DEBUG - executing "collect: apt_key_list"
+2019-09-07 10:19:10,885 - tests.cloud_tests - DEBUG - collect script apt_key_list exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-07 10:19:10,892 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--ivsavx83) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:19:17,769 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--ivsavx83 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_sources_keyserver/console.log
+2019-09-07 10:19:17,770 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--ivsavx83) status=Stopped: deleting container.
+2019-09-07 10:19:18,045 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_list
+2019-09-07 10:19:18,817 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:19:18,818 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:19:19,667 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:19:24,985 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:19:24,986 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:19:25,191 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:19:25,191 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:19:25,390 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:19:25,390 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:19:25,538 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:19:25,538 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:19:25,710 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:19:25,710 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:19:25,906 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:19:25,906 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:19:26,166 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:19:26,166 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:19:26,470 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:19:26,470 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:19:26,631 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:19:26,631 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:19:26,898 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:19:26,898 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:19:27,087 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--yg6ojrpp) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:19:30,815 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--yg6ojrpp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_sources_list/console.log
+2019-09-07 10:19:30,815 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--yg6ojrpp) status=Stopped: deleting container.
+2019-09-07 10:19:31,087 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_configure_sources_ppa
+2019-09-07 10:19:31,829 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:19:31,830 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:19:32,791 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:19:48,297 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:19:48,298 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:19:48,551 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:19:48,551 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:19:48,750 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:19:48,750 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:19:48,987 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:19:48,987 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:19:49,294 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:19:49,294 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:19:49,494 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:19:49,494 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:19:49,638 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:19:49,638 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:19:49,874 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:19:49,874 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:19:50,150 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:19:50,150 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:19:50,458 - tests.cloud_tests - DEBUG - running collect script: sources.list
+2019-09-07 10:19:50,458 - tests.cloud_tests - DEBUG - executing "collect: sources.list"
+2019-09-07 10:19:51,038 - tests.cloud_tests - DEBUG - running collect script: apt-key
+2019-09-07 10:19:51,038 - tests.cloud_tests - DEBUG - executing "collect: apt-key"
+2019-09-07 10:19:51,327 - tests.cloud_tests - DEBUG - collect script apt-key exited 'b'Warning: apt-key output should not be parsed (stdout is not a terminal)\n'' and had stderr: 0
+2019-09-07 10:19:51,328 - tests.cloud_tests - DEBUG - running collect script: sources_full
+2019-09-07 10:19:51,328 - tests.cloud_tests - DEBUG - executing "collect: sources_full"
+2019-09-07 10:19:51,539 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--2vywsbjl) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:19:57,235 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-configure-sources--2vywsbjl to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_configure_sources_ppa/console.log
+2019-09-07 10:19:57,235 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-configure-sources--2vywsbjl) status=Stopped: deleting container.
+2019-09-07 10:19:57,536 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_disable
+2019-09-07 10:19:58,646 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:19:58,646 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:19:59,950 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:20:06,393 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:20:06,394 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:20:06,691 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:20:06,691 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:20:07,023 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:20:07,023 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:20:07,315 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:20:07,315 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:20:07,639 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:20:07,639 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:20:07,975 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:20:07,975 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:20:08,278 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:20:08,278 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:20:08,663 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:20:08,663 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:20:08,978 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:20:08,978 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:20:09,383 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining
+2019-09-07 10:20:09,383 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining"
+2019-09-07 10:20:09,591 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-pipelining-disable-62yunsn5) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:20:16,135 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-pipelining-disable-62yunsn5 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_pipelining_disable/console.log
+2019-09-07 10:20:16,135 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-pipelining-disable-62yunsn5) status=Stopped: deleting container.
+2019-09-07 10:20:16,392 - tests.cloud_tests - INFO - collecting test data for test: modules/apt_pipelining_os
+2019-09-07 10:20:18,417 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:20:18,418 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:20:19,874 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:20:25,234 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:20:25,234 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:20:25,475 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:20:25,475 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:20:25,666 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:20:25,666 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:20:25,874 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:20:25,874 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:20:26,127 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:20:26,127 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:20:26,379 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:20:26,379 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:20:26,578 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:20:26,578 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:20:26,874 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:20:26,875 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:20:27,474 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:20:27,474 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:20:27,874 - tests.cloud_tests - DEBUG - running collect script: 90cloud-init-pipelining_not_written
+2019-09-07 10:20:27,874 - tests.cloud_tests - DEBUG - executing "collect: 90cloud-init-pipelining_not_written"
+2019-09-07 10:20:28,058 - tests.cloud_tests - DEBUG - collect script 90cloud-init-pipelining_not_written exited 'b"ls: cannot access '/etc/apt/apt.conf.d/90cloud-init-pipelining': No such file or directory\n"' and had stderr: 0
+2019-09-07 10:20:28,064 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-pipelining-os-a86quob4g5cam) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:20:31,057 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-apt-pipelining-os-a86quob4g5cam to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/apt_pipelining_os/console.log
+2019-09-07 10:20:31,057 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-apt-pipelining-os-a86quob4g5cam) status=Stopped: deleting container.
+2019-09-07 10:20:31,344 - tests.cloud_tests - INFO - collecting test data for test: modules/bootcmd
+2019-09-07 10:20:31,997 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:20:31,998 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:20:32,881 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:20:42,193 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:20:42,194 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:20:42,358 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:20:42,358 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:20:42,518 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:20:42,518 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:20:42,662 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:20:42,662 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:20:42,814 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:20:42,814 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:20:42,995 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:20:42,995 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:20:43,171 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:20:43,171 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:20:43,347 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:20:43,347 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:20:44,198 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:20:44,198 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:20:44,466 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-07 10:20:44,466 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-07 10:20:44,800 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-bootcmd-xlccp7bwu3i0jvs6vs3amp1) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:20:49,146 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-bootcmd-xlccp7bwu3i0jvs6vs3amp1 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/bootcmd/console.log
+2019-09-07 10:20:49,146 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-bootcmd-xlccp7bwu3i0jvs6vs3amp1) status=Stopped: deleting container.
+2019-09-07 10:20:49,480 - tests.cloud_tests - INFO - collecting test data for test: modules/byobu
+2019-09-07 10:20:50,341 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:20:50,342 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:20:51,572 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:20:56,910 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:20:56,910 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:20:57,243 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:20:57,243 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:20:58,134 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:20:58,134 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:20:58,390 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:20:58,390 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:20:58,642 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:20:58,642 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:20:58,862 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:20:58,862 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:20:59,018 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:20:59,018 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:20:59,250 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:20:59,250 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:20:59,514 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:20:59,514 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:20:59,822 - tests.cloud_tests - DEBUG - running collect script: byobu_profile_enabled
+2019-09-07 10:20:59,822 - tests.cloud_tests - DEBUG - executing "collect: byobu_profile_enabled"
+2019-09-07 10:20:59,966 - tests.cloud_tests - DEBUG - running collect script: byobu_launch_exists
+2019-09-07 10:20:59,966 - tests.cloud_tests - DEBUG - executing "collect: byobu_launch_exists"
+2019-09-07 10:21:00,183 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-byobu-i4s9gjxz4p625049wdwpirxtv) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:02,698 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-byobu-i4s9gjxz4p625049wdwpirxtv to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/byobu/console.log
+2019-09-07 10:21:02,698 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-byobu-i4s9gjxz4p625049wdwpirxtv) status=Stopped: deleting container.
+2019-09-07 10:21:02,942 - tests.cloud_tests - INFO - collecting test data for test: modules/ca_certs
+2019-09-07 10:21:03,717 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:21:03,718 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:04,642 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:21:09,949 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:21:09,950 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:21:10,174 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:21:10,175 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:21:10,338 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:21:10,338 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:21:10,474 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:21:10,474 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:21:10,738 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:21:10,739 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:21:10,967 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:21:10,967 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:21:11,222 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:21:11,223 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:21:11,434 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:21:11,435 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:21:11,594 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:21:11,595 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:21:11,874 - tests.cloud_tests - DEBUG - running collect script: cert_links
+2019-09-07 10:21:11,874 - tests.cloud_tests - DEBUG - executing "collect: cert_links"
+2019-09-07 10:21:12,162 - tests.cloud_tests - DEBUG - running collect script: cert
+2019-09-07 10:21:12,162 - tests.cloud_tests - DEBUG - executing "collect: cert"
+2019-09-07 10:21:12,348 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ca-certs-444kc13o54zfsot25bvimq) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:15,782 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ca-certs-444kc13o54zfsot25bvimq to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ca_certs/console.log
+2019-09-07 10:21:15,783 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ca-certs-444kc13o54zfsot25bvimq) status=Stopped: deleting container.
+2019-09-07 10:21:16,031 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_disable
+2019-09-07 10:21:16,777 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:21:16,778 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:17,945 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:21:23,238 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:21:23,238 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:21:23,399 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:21:23,399 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:21:23,582 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:21:23,582 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:21:23,786 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:21:23,786 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:21:23,978 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:21:23,978 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:21:24,134 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:21:24,134 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:21:24,322 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:21:24,322 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:21:24,502 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:21:24,502 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:21:24,663 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:21:24,663 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:21:24,949 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-debug-disable-t6c4cr2k0gxcwhyf9) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:29,110 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-debug-disable-t6c4cr2k0gxcwhyf9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/debug_disable/console.log
+2019-09-07 10:21:29,110 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-debug-disable-t6c4cr2k0gxcwhyf9) status=Stopped: deleting container.
+2019-09-07 10:21:29,414 - tests.cloud_tests - INFO - collecting test data for test: modules/debug_enable
+2019-09-07 10:21:30,294 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:21:30,294 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:32,355 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:21:38,853 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:21:38,854 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:21:39,215 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:21:39,215 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:21:39,546 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:21:39,546 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:21:39,834 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:21:39,834 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:21:40,074 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:21:40,074 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:21:40,294 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:21:40,294 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:21:40,598 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:21:40,598 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:21:40,838 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:21:40,838 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:21:41,106 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:21:41,106 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:21:41,463 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-debug-enable-i1c0hm2l4nh1ezqquo) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:43,924 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-debug-enable-i1c0hm2l4nh1ezqquo to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/debug_enable/console.log
+2019-09-07 10:21:43,925 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-debug-enable-i1c0hm2l4nh1ezqquo) status=Stopped: deleting container.
+2019-09-07 10:21:44,201 - tests.cloud_tests - INFO - collecting test data for test: modules/final_message
+2019-09-07 10:21:44,945 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:21:44,946 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:21:45,872 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:21:55,193 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:21:55,194 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:21:55,387 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:21:55,387 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:21:55,538 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:21:55,538 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:21:55,698 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:21:55,698 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:21:55,982 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:21:55,982 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:21:56,202 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:21:56,202 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:21:56,407 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:21:56,407 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:21:56,787 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:21:56,787 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:21:57,003 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:21:57,003 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:21:57,331 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-final-message-vr91hhm2r24vqas4d) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:22:02,089 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-final-message-vr91hhm2r24vqas4d to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/final_message/console.log
+2019-09-07 10:22:02,089 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-final-message-vr91hhm2r24vqas4d) status=Stopped: deleting container.
+2019-09-07 10:22:02,386 - tests.cloud_tests - INFO - collecting test data for test: modules/keys_to_console
+2019-09-07 10:22:03,341 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:22:03,342 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:22:04,960 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:22:11,289 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:22:11,290 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:22:11,782 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:22:11,783 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:22:11,982 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:22:11,982 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:22:12,174 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:22:12,174 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:22:12,390 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:22:12,390 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:22:12,582 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:22:12,582 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:22:12,790 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:22:12,790 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:22:13,002 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:22:13,002 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:22:13,182 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:22:13,182 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:22:13,459 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-07 10:22:13,459 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-07 10:22:13,651 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-keys-to-console-du2n4yi5rr7kgdk) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:22:16,203 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-keys-to-console-du2n4yi5rr7kgdk to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/keys_to_console/console.log
+2019-09-07 10:22:16,204 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-keys-to-console-du2n4yi5rr7kgdk) status=Stopped: deleting container.
+2019-09-07 10:22:16,471 - tests.cloud_tests - WARNING - test config modules/landscape is not enabled, skipping
+2019-09-07 10:22:16,510 - tests.cloud_tests - INFO - collecting test data for test: modules/locale
+2019-09-07 10:22:17,377 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:22:17,378 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:22:18,820 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:22:26,245 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:22:26,246 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:22:26,447 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:22:26,447 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:22:26,615 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:22:26,615 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:22:26,878 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:22:26,878 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:22:27,170 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:22:27,170 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:22:27,378 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:22:27,378 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:22:27,562 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:22:27,562 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:22:27,758 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:22:27,758 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:22:27,930 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:22:27,930 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:22:28,278 - tests.cloud_tests - DEBUG - running collect script: locale_default
+2019-09-07 10:22:28,278 - tests.cloud_tests - DEBUG - executing "collect: locale_default"
+2019-09-07 10:22:28,490 - tests.cloud_tests - DEBUG - running collect script: locale_a
+2019-09-07 10:22:28,490 - tests.cloud_tests - DEBUG - executing "collect: locale_a"
+2019-09-07 10:22:29,430 - tests.cloud_tests - DEBUG - running collect script: locale_gen
+2019-09-07 10:22:29,430 - tests.cloud_tests - DEBUG - executing "collect: locale_gen"
+2019-09-07 10:22:29,623 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-locale-0tfc6nbqx54x3bq5slrq8q7o) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:22:31,550 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-locale-0tfc6nbqx54x3bq5slrq8q7o to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/locale/console.log
+2019-09-07 10:22:31,550 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-locale-0tfc6nbqx54x3bq5slrq8q7o) status=Stopped: deleting container.
+2019-09-07 10:22:31,846 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_bridge
+2019-09-07 10:22:32,693 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:22:32,694 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:22:34,211 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:22:54,689 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:22:54,690 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:22:54,994 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:22:54,994 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:22:55,194 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:22:55,194 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:22:55,454 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:22:55,454 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:22:55,694 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:22:55,694 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:22:55,990 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:22:55,990 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:22:56,190 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:22:56,190 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:22:56,482 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:22:56,482 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:22:56,866 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:22:56,867 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:22:57,170 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-07 10:22:57,170 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-07 10:22:57,466 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-07 10:22:57,466 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-07 10:22:58,426 - tests.cloud_tests - DEBUG - running collect script: lxc-bridge
+2019-09-07 10:22:58,426 - tests.cloud_tests - DEBUG - executing "collect: lxc-bridge"
+2019-09-07 10:22:58,791 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-lxd-bridge-73sns7n2g1pv2d498773) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:23:02,524 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-lxd-bridge-73sns7n2g1pv2d498773 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/lxd_bridge/console.log
+2019-09-07 10:23:02,524 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-lxd-bridge-73sns7n2g1pv2d498773) status=Stopped: deleting container.
+2019-09-07 10:23:02,780 - tests.cloud_tests - INFO - collecting test data for test: modules/lxd_dir
+2019-09-07 10:23:04,237 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:23:04,238 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:23:05,727 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:23:23,229 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:23:23,230 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:23:23,558 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:23:23,559 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:23:23,842 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:23:23,842 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:23:24,138 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:23:24,138 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:23:24,414 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:23:24,415 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:23:24,686 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:23:24,686 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:23:25,034 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:23:25,034 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:23:25,450 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:23:25,450 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:23:25,642 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:23:25,642 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:23:25,978 - tests.cloud_tests - DEBUG - running collect script: lxc
+2019-09-07 10:23:25,979 - tests.cloud_tests - DEBUG - executing "collect: lxc"
+2019-09-07 10:23:26,250 - tests.cloud_tests - DEBUG - running collect script: lxd
+2019-09-07 10:23:26,250 - tests.cloud_tests - DEBUG - executing "collect: lxd"
+2019-09-07 10:23:26,481 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-lxd-dir-xh2clgk7gf1llz09yh3jd3n) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:23:28,455 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-lxd-dir-xh2clgk7gf1llz09yh3jd3n to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/lxd_dir/console.log
+2019-09-07 10:23:28,455 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-lxd-dir-xh2clgk7gf1llz09yh3jd3n) status=Stopped: deleting container.
+2019-09-07 10:23:28,791 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp
+2019-09-07 10:23:29,821 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:23:29,822 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:23:32,834 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:23:49,357 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:23:49,358 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:23:49,530 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:23:49,530 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:23:49,718 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:23:49,718 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:23:49,870 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:23:49,870 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:23:50,022 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:23:50,022 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:23:50,174 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:23:50,174 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:23:50,370 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:23:50,370 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:23:50,547 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:23:50,547 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:23:50,719 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:23:50,719 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:23:50,986 - tests.cloud_tests - DEBUG - running collect script: ntp_installed
+2019-09-07 10:23:50,986 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed"
+2019-09-07 10:23:51,162 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_empty
+2019-09-07 10:23:51,162 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_empty"
+2019-09-07 10:23:51,333 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_empty exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-07 10:23:51,335 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pool_list
+2019-09-07 10:23:51,335 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pool_list"
+2019-09-07 10:23:51,503 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-mzrqrlburhntt23githgsfd2hud) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:23:57,085 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-mzrqrlburhntt23githgsfd2hud to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ntp/console.log
+2019-09-07 10:23:57,085 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-mzrqrlburhntt23githgsfd2hud) status=Stopped: deleting container.
+2019-09-07 10:23:57,415 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_chrony
+2019-09-07 10:23:58,037 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:23:58,038 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:23:58,893 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:24:14,434 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:24:14,434 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:24:14,615 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:24:14,615 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:24:14,774 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:24:14,774 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:24:14,930 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:24:14,930 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:24:15,070 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:24:15,070 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:24:15,210 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:24:15,210 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:24:15,346 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:24:15,346 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:24:15,506 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:24:15,506 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:24:15,674 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:24:15,675 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:24:16,934 - tests.cloud_tests - DEBUG - running collect script: chrony_conf
+2019-09-07 10:24:16,934 - tests.cloud_tests - DEBUG - executing "collect: chrony_conf"
+2019-09-07 10:24:17,122 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-chrony-4ij1u4zwt96su7nvgsdb) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:24:22,733 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-chrony-4ij1u4zwt96su7nvgsdb to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ntp_chrony/console.log
+2019-09-07 10:24:22,733 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-chrony-4ij1u4zwt96su7nvgsdb) status=Stopped: deleting container.
+2019-09-07 10:24:22,994 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_pools
+2019-09-07 10:24:24,129 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:24:24,130 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:24:25,188 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:24:42,825 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:24:42,826 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:24:43,183 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:24:43,183 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:24:43,415 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:24:43,415 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:24:43,610 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:24:43,610 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:24:44,738 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:24:44,738 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:24:44,951 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:24:44,951 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:24:45,122 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:24:45,122 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:24:45,326 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:24:45,326 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:24:45,491 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:24:45,491 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:24:45,806 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_pools
+2019-09-07 10:24:45,806 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_pools"
+2019-09-07 10:24:46,018 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_pools
+2019-09-07 10:24:46,018 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_pools"
+2019-09-07 10:24:46,253 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_pools exited 'b"ls: cannot access '/etc/ntp.conf.dist': No such file or directory\n"' and had stderr: 0
+2019-09-07 10:24:46,254 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_pools
+2019-09-07 10:24:46,254 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_pools"
+2019-09-07 10:24:46,451 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-07 10:24:46,451 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-07 10:24:46,652 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-pools-44akgls8g54nvhnih2pof) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:24:50,553 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-pools-44akgls8g54nvhnih2pof to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ntp_pools/console.log
+2019-09-07 10:24:50,554 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-pools-44akgls8g54nvhnih2pof) status=Stopped: deleting container.
+2019-09-07 10:24:50,848 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_servers
+2019-09-07 10:24:51,653 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:24:51,654 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:24:52,484 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:25:08,025 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:25:08,026 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:25:08,206 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:25:08,207 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:25:08,354 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:25:08,354 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:25:08,494 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:25:08,494 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:25:08,662 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:25:08,662 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:25:08,831 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:25:08,831 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:25:09,030 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:25:09,030 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:25:09,194 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:25:09,194 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:25:09,338 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:25:09,338 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:25:09,623 - tests.cloud_tests - DEBUG - running collect script: ntp_installed_servers
+2019-09-07 10:25:09,623 - tests.cloud_tests - DEBUG - executing "collect: ntp_installed_servers"
+2019-09-07 10:25:09,802 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_dist_servers
+2019-09-07 10:25:09,802 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_dist_servers"
+2019-09-07 10:25:09,949 - tests.cloud_tests - DEBUG - collect script ntp_conf_dist_servers exited 'b'cat: /etc/ntp.conf.dist: No such file or directory\n'' and had stderr: 0
+2019-09-07 10:25:09,951 - tests.cloud_tests - DEBUG - running collect script: ntp_conf_servers
+2019-09-07 10:25:09,951 - tests.cloud_tests - DEBUG - executing "collect: ntp_conf_servers"
+2019-09-07 10:25:10,150 - tests.cloud_tests - DEBUG - running collect script: ntpq_servers
+2019-09-07 10:25:10,150 - tests.cloud_tests - DEBUG - executing "collect: ntpq_servers"
+2019-09-07 10:25:10,343 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-servers-i9ygjhx3izhfuxosk97) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:25:16,182 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-servers-i9ygjhx3izhfuxosk97 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ntp_servers/console.log
+2019-09-07 10:25:16,183 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-servers-i9ygjhx3izhfuxosk97) status=Stopped: deleting container.
+2019-09-07 10:25:16,457 - tests.cloud_tests - INFO - collecting test data for test: modules/ntp_timesyncd
+2019-09-07 10:25:17,230 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:25:17,230 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:25:18,287 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:25:24,686 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:25:24,686 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:25:24,895 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:25:24,895 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:25:25,147 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:25:25,147 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:25:25,359 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:25:25,359 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:25:25,591 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:25:25,591 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:25:25,823 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:25:25,823 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:25:26,038 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:25:26,038 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:25:26,250 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:25:26,250 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:25:26,430 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:25:26,431 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:25:26,706 - tests.cloud_tests - DEBUG - running collect script: timesyncd_conf
+2019-09-07 10:25:26,706 - tests.cloud_tests - DEBUG - executing "collect: timesyncd_conf"
+2019-09-07 10:25:26,900 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-timesyncd-7nk0laqan7sgn4kk9) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:25:29,497 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ntp-timesyncd-7nk0laqan7sgn4kk9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ntp_timesyncd/console.log
+2019-09-07 10:25:29,498 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ntp-timesyncd-7nk0laqan7sgn4kk9) status=Stopped: deleting container.
+2019-09-07 10:25:29,855 - tests.cloud_tests - INFO - collecting test data for test: modules/package_update_upgrade_install
+2019-09-07 10:25:31,097 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:25:31,098 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:25:32,641 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:25:47,130 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:25:47,130 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:25:47,371 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:25:47,371 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:25:47,643 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:25:47,643 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:25:47,894 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:25:47,894 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:25:48,094 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:25:48,094 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:25:48,350 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:25:48,351 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:25:48,659 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:25:48,659 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:25:49,414 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:25:49,414 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:25:49,614 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:25:49,614 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:25:49,906 - tests.cloud_tests - DEBUG - running collect script: apt_history_cmdline
+2019-09-07 10:25:49,906 - tests.cloud_tests - DEBUG - executing "collect: apt_history_cmdline"
+2019-09-07 10:25:50,150 - tests.cloud_tests - DEBUG - running collect script: dpkg_show
+2019-09-07 10:25:50,150 - tests.cloud_tests - DEBUG - executing "collect: dpkg_show"
+2019-09-07 10:25:50,392 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-package-update-upgrade-cckn7wax) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:25:56,595 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-package-update-upgrade-cckn7wax to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/package_update_upgrade_install/console.log
+2019-09-07 10:25:56,595 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-package-update-upgrade-cckn7wax) status=Stopped: deleting container.
+2019-09-07 10:25:57,231 - tests.cloud_tests - INFO - collecting test data for test: modules/runcmd
+2019-09-07 10:25:58,122 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:25:58,122 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:25:59,276 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:26:08,702 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:26:08,702 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:26:08,994 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:26:08,995 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:26:09,334 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:26:09,335 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:26:09,606 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:26:09,606 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:26:09,835 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:26:09,835 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:26:10,078 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:26:10,078 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:26:10,286 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:26:10,286 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:26:10,558 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:26:10,558 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:26:10,726 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:26:10,727 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:26:10,962 - tests.cloud_tests - DEBUG - running collect script: run_cmd
+2019-09-07 10:26:10,962 - tests.cloud_tests - DEBUG - executing "collect: run_cmd"
+2019-09-07 10:26:12,108 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-runcmd-5ucggyynb0j8qegk846bztee) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:13,488 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-runcmd-5ucggyynb0j8qegk846bztee to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/runcmd/console.log
+2019-09-07 10:26:13,489 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-runcmd-5ucggyynb0j8qegk846bztee) status=Stopped: deleting container.
+2019-09-07 10:26:13,734 - tests.cloud_tests - WARNING - test config modules/seed_random_command is not enabled, skipping
+2019-09-07 10:26:13,773 - tests.cloud_tests - INFO - collecting test data for test: modules/seed_random_data
+2019-09-07 10:26:14,642 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:26:14,642 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:15,511 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:26:24,906 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:26:24,906 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:26:25,139 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:26:25,139 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:26:25,323 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:26:25,323 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:26:25,506 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:26:25,506 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:26:25,722 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:26:25,722 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:26:25,906 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:26:25,906 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:26:26,134 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:26:26,134 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:26:26,334 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:26:26,334 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:26:26,582 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:26:26,582 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:26:26,950 - tests.cloud_tests - DEBUG - running collect script: seed_data
+2019-09-07 10:26:26,950 - tests.cloud_tests - DEBUG - executing "collect: seed_data"
+2019-09-07 10:26:27,192 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-seed-random-data-4vx0sudspvcdhi) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:31,697 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-seed-random-data-4vx0sudspvcdhi to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/seed_random_data/console.log
+2019-09-07 10:26:31,697 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-seed-random-data-4vx0sudspvcdhi) status=Stopped: deleting container.
+2019-09-07 10:26:32,029 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname
+2019-09-07 10:26:32,745 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:26:32,746 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:33,910 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:26:40,233 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:26:40,234 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:26:40,407 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:26:40,407 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:26:40,598 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:26:40,599 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:26:40,823 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:26:40,823 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:26:41,026 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:26:41,026 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:26:41,202 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:26:41,202 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:26:41,362 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:26:41,362 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:26:41,538 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:26:41,539 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:26:41,711 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:26:41,711 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:26:41,978 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-07 10:26:41,978 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-07 10:26:42,135 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-07 10:26:42,135 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-07 10:26:42,299 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-07 10:26:42,299 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-07 10:26:42,472 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-hostname-0p3h4qmdg29xv33t1v) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:45,017 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-hostname-0p3h4qmdg29xv33t1v to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/set_hostname/console.log
+2019-09-07 10:26:45,018 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-hostname-0p3h4qmdg29xv33t1v) status=Stopped: deleting container.
+2019-09-07 10:26:45,316 - tests.cloud_tests - INFO - collecting test data for test: modules/set_hostname_fqdn
+2019-09-07 10:26:47,181 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:26:47,182 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:48,102 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:26:53,417 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:26:53,418 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:26:53,578 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:26:53,578 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:26:53,730 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:26:53,730 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:26:53,882 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:26:53,882 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:26:54,030 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:26:54,030 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:26:54,174 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:26:54,174 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:26:54,314 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:26:54,314 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:26:54,486 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:26:54,486 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:26:54,662 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:26:54,662 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:26:54,894 - tests.cloud_tests - DEBUG - running collect script: hosts
+2019-09-07 10:26:54,894 - tests.cloud_tests - DEBUG - executing "collect: hosts"
+2019-09-07 10:26:55,046 - tests.cloud_tests - DEBUG - running collect script: hostname
+2019-09-07 10:26:55,046 - tests.cloud_tests - DEBUG - executing "collect: hostname"
+2019-09-07 10:26:55,238 - tests.cloud_tests - DEBUG - running collect script: fqdn
+2019-09-07 10:26:55,238 - tests.cloud_tests - DEBUG - executing "collect: fqdn"
+2019-09-07 10:26:55,431 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-hostname-fqdn-mj70t7ki4eo55) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:26:59,333 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-hostname-fqdn-mj70t7ki4eo55 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/set_hostname_fqdn/console.log
+2019-09-07 10:26:59,333 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-hostname-fqdn-mj70t7ki4eo55) status=Stopped: deleting container.
+2019-09-07 10:26:59,604 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password
+2019-09-07 10:27:00,249 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:27:00,250 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:01,110 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:27:06,485 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:27:06,486 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:27:06,718 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:27:06,719 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:27:07,390 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:27:07,390 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:27:07,658 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:27:07,658 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:27:07,826 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:27:07,826 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:27:08,010 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:27:08,010 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:27:08,154 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:27:08,154 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:27:08,306 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:27:08,306 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:27:08,462 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:27:08,462 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:27:08,718 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-07 10:27:08,718 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-07 10:27:08,894 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-07 10:27:08,894 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-07 10:27:09,107 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-6thkbhp8607748i5ah) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:12,131 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-6thkbhp8607748i5ah to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/set_password/console.log
+2019-09-07 10:27:12,131 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-6thkbhp8607748i5ah) status=Stopped: deleting container.
+2019-09-07 10:27:12,735 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_expire
+2019-09-07 10:27:13,361 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:27:13,362 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:14,316 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:27:19,669 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:27:19,670 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:27:19,847 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:27:19,847 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:27:20,046 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:27:20,046 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:27:20,254 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:27:20,254 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:27:20,418 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:27:20,418 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:27:20,638 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:27:20,638 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:27:20,866 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:27:20,866 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:27:21,102 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:27:21,102 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:27:21,274 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:27:21,274 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:27:21,562 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-07 10:27:21,562 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-07 10:27:21,742 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-07 10:27:21,742 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-07 10:27:21,923 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-expire-a2l7n38d0ps) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:25,438 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-expire-a2l7n38d0ps to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/set_password_expire/console.log
+2019-09-07 10:27:25,438 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-expire-a2l7n38d0ps) status=Stopped: deleting container.
+2019-09-07 10:27:25,885 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list
+2019-09-07 10:27:26,645 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:27:26,646 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:27,815 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:27:37,341 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:27:37,342 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:27:37,622 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:27:37,623 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:27:37,894 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:27:37,894 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:27:38,138 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:27:38,138 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:27:38,338 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:27:38,338 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:27:38,594 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:27:38,594 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:27:38,858 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:27:38,858 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:27:39,326 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:27:39,326 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:27:40,302 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:27:40,302 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:27:40,622 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-07 10:27:40,623 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-07 10:27:40,926 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-07 10:27:40,926 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-07 10:27:41,182 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-list-47g0vy1acc7cr) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:44,135 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-list-47g0vy1acc7cr to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/set_password_list/console.log
+2019-09-07 10:27:44,135 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-list-47g0vy1acc7cr) status=Stopped: deleting container.
+2019-09-07 10:27:44,437 - tests.cloud_tests - INFO - collecting test data for test: modules/set_password_list_string
+2019-09-07 10:27:45,273 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:27:45,274 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:46,766 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:27:53,097 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:27:53,098 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:27:53,282 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:27:53,283 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:27:53,459 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:27:53,459 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:27:53,615 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:27:53,615 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:27:53,767 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:27:53,767 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:27:53,906 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:27:53,907 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:27:54,062 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:27:54,062 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:27:54,250 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:27:54,250 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:27:54,450 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:27:54,450 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:27:54,710 - tests.cloud_tests - DEBUG - running collect script: shadow
+2019-09-07 10:27:54,710 - tests.cloud_tests - DEBUG - executing "collect: shadow"
+2019-09-07 10:27:54,866 - tests.cloud_tests - DEBUG - running collect script: sshd_config
+2019-09-07 10:27:54,866 - tests.cloud_tests - DEBUG - executing "collect: sshd_config"
+2019-09-07 10:27:55,028 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-list-stri-w6437ja9) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:27:57,947 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-set-password-list-stri-w6437ja9 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/set_password_list_string/console.log
+2019-09-07 10:27:57,948 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-set-password-list-stri-w6437ja9) status=Stopped: deleting container.
+2019-09-07 10:27:58,201 - tests.cloud_tests - WARNING - test config modules/snap is not enabled, skipping
+2019-09-07 10:27:58,206 - tests.cloud_tests - WARNING - test config modules/snappy is not enabled, skipping
+2019-09-07 10:27:58,243 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_disable
+2019-09-07 10:27:59,713 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:27:59,714 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:00,625 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:28:10,969 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:28:10,970 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:28:11,191 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:28:11,191 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:28:11,407 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:28:11,407 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:28:11,642 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:28:11,642 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:28:11,871 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:28:11,871 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:28:12,074 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:28:12,075 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:28:12,238 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:28:12,238 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:28:12,471 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:28:12,471 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:28:12,670 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:28:12,670 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:28:12,974 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-07 10:28:12,974 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-07 10:28:13,260 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-w6fv1hm1) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:16,896 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-w6fv1hm1 to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ssh_auth_key_fingerprints_disable/console.log
+2019-09-07 10:28:16,896 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-w6fv1hm1) status=Stopped: deleting container.
+2019-09-07 10:28:17,199 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_auth_key_fingerprints_enable
+2019-09-07 10:28:17,953 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:28:17,954 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:19,153 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:28:29,573 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:28:29,574 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:28:29,895 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:28:29,895 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:28:30,090 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:28:30,090 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:28:30,270 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:28:30,270 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:28:30,466 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:28:30,466 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:28:30,679 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:28:30,679 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:28:30,838 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:28:30,838 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:28:31,038 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:28:31,038 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:28:31,238 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:28:31,238 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:28:31,659 - tests.cloud_tests - DEBUG - running collect script: syslog
+2019-09-07 10:28:31,659 - tests.cloud_tests - DEBUG - executing "collect: syslog"
+2019-09-07 10:28:32,475 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-nll9687t) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:35,643 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-nll9687t to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ssh_auth_key_fingerprints_enable/console.log
+2019-09-07 10:28:35,643 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-auth-key-fingerpri-nll9687t) status=Stopped: deleting container.
+2019-09-07 10:28:35,963 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_import_id
+2019-09-07 10:28:36,702 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:28:36,702 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:37,900 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:28:49,249 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:28:49,250 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:28:49,555 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:28:49,555 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:28:49,858 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:28:49,858 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:28:50,110 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:28:50,110 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:28:50,371 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:28:50,371 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:28:50,674 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:28:50,675 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:28:50,971 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:28:50,971 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:28:51,250 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:28:51,250 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:28:51,578 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:28:51,578 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:28:52,015 - tests.cloud_tests - DEBUG - running collect script: auth_keys_ubuntu
+2019-09-07 10:28:52,015 - tests.cloud_tests - DEBUG - executing "collect: auth_keys_ubuntu"
+2019-09-07 10:28:52,209 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-import-id-2ad667s8gh6aue1ho) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:54,407 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-import-id-2ad667s8gh6aue1ho to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ssh_import_id/console.log
+2019-09-07 10:28:54,407 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-import-id-2ad667s8gh6aue1ho) status=Stopped: deleting container.
+2019-09-07 10:28:54,728 - tests.cloud_tests - INFO - collecting test data for test: modules/ssh_keys_generate
+2019-09-07 10:28:55,369 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:28:55,370 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:28:56,171 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:29:05,525 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:29:05,526 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:29:05,678 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:29:05,678 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:29:05,806 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:29:05,806 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:29:05,978 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:29:05,978 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:29:06,126 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:29:06,126 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:29:06,290 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:29:06,290 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:29:06,430 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:29:06,430 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:29:06,594 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:29:06,594 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:29:06,770 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:29:06,771 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:29:07,030 - tests.cloud_tests - DEBUG - running collect script: dsa_public
+2019-09-07 10:29:07,030 - tests.cloud_tests - DEBUG - executing "collect: dsa_public"
+2019-09-07 10:29:07,222 - tests.cloud_tests - DEBUG - collect script dsa_public exited 'b'cat: /etc/ssh/ssh_host_dsa_key.pub: No such file or directory'' and had stderr: 1
+2019-09-07 10:29:07,223 - tests.cloud_tests - DEBUG - running collect script: dsa_private
+2019-09-07 10:29:07,223 - tests.cloud_tests - DEBUG - executing "collect: dsa_private"
+2019-09-07 10:29:07,405 - tests.cloud_tests - DEBUG - collect script dsa_private exited 'b'cat: /etc/ssh/ssh_host_dsa_key: No such file or directory'' and had stderr: 1
+2019-09-07 10:29:07,406 - tests.cloud_tests - DEBUG - running collect script: rsa_public
+2019-09-07 10:29:07,406 - tests.cloud_tests - DEBUG - executing "collect: rsa_public"
+2019-09-07 10:29:07,590 - tests.cloud_tests - DEBUG - collect script rsa_public exited 'b'cat: /etc/ssh/ssh_host_rsa_key.pub: No such file or directory'' and had stderr: 1
+2019-09-07 10:29:07,591 - tests.cloud_tests - DEBUG - running collect script: rsa_private
+2019-09-07 10:29:07,591 - tests.cloud_tests - DEBUG - executing "collect: rsa_private"
+2019-09-07 10:29:07,754 - tests.cloud_tests - DEBUG - collect script rsa_private exited 'b'cat: /etc/ssh/ssh_host_rsa_key: No such file or directory'' and had stderr: 1
+2019-09-07 10:29:07,755 - tests.cloud_tests - DEBUG - running collect script: ecdsa_public
+2019-09-07 10:29:07,755 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_public"
+2019-09-07 10:29:07,934 - tests.cloud_tests - DEBUG - running collect script: ecdsa_private
+2019-09-07 10:29:07,934 - tests.cloud_tests - DEBUG - executing "collect: ecdsa_private"
+2019-09-07 10:29:08,118 - tests.cloud_tests - DEBUG - running collect script: ed25519_public
+2019-09-07 10:29:08,118 - tests.cloud_tests - DEBUG - executing "collect: ed25519_public"
+2019-09-07 10:29:08,323 - tests.cloud_tests - DEBUG - running collect script: ed25519_private
+2019-09-07 10:29:08,323 - tests.cloud_tests - DEBUG - executing "collect: ed25519_private"
+2019-09-07 10:29:08,523 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-keys-generate-p2b6kq29nafbp) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:29:12,607 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-ssh-keys-generate-p2b6kq29nafbp to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/ssh_keys_generate/console.log
+2019-09-07 10:29:12,607 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-ssh-keys-generate-p2b6kq29nafbp) status=Stopped: deleting container.
+2019-09-07 10:29:12,886 - tests.cloud_tests - WARNING - test config modules/ssh_keys_provided is not enabled, skipping
+2019-09-07 10:29:12,926 - tests.cloud_tests - INFO - collecting test data for test: modules/timezone
+2019-09-07 10:29:13,793 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:29:13,794 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:29:14,780 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:29:20,089 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:29:20,090 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:29:20,354 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:29:20,355 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:29:20,586 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:29:20,586 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:29:20,831 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:29:20,831 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:29:21,551 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:29:21,551 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:29:21,755 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:29:21,755 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:29:22,042 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:29:22,042 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:29:22,351 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:29:22,351 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:29:22,538 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:29:22,538 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:29:22,878 - tests.cloud_tests - DEBUG - running collect script: timezone
+2019-09-07 10:29:22,878 - tests.cloud_tests - DEBUG - executing "collect: timezone"
+2019-09-07 10:29:23,088 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-timezone-0nuzykhiqn7u2jerz0pkyd) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:29:26,041 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-timezone-0nuzykhiqn7u2jerz0pkyd to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/timezone/console.log
+2019-09-07 10:29:26,042 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-timezone-0nuzykhiqn7u2jerz0pkyd) status=Stopped: deleting container.
+2019-09-07 10:29:26,293 - tests.cloud_tests - INFO - collecting test data for test: modules/user_groups
+2019-09-07 10:29:27,809 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:29:27,810 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:29:29,011 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:29:35,487 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:29:35,487 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:29:35,931 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:29:35,931 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:29:36,451 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:29:36,451 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:29:36,663 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:29:36,663 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:29:36,926 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:29:36,927 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:29:37,138 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:29:37,139 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:29:37,359 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:29:37,359 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:29:37,551 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:29:37,551 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:29:37,862 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:29:37,862 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:29:38,291 - tests.cloud_tests - DEBUG - running collect script: group_ubuntu
+2019-09-07 10:29:38,291 - tests.cloud_tests - DEBUG - executing "collect: group_ubuntu"
+2019-09-07 10:29:38,878 - tests.cloud_tests - DEBUG - running collect script: group_cloud_users
+2019-09-07 10:29:38,879 - tests.cloud_tests - DEBUG - executing "collect: group_cloud_users"
+2019-09-07 10:29:39,223 - tests.cloud_tests - DEBUG - running collect script: user_ubuntu
+2019-09-07 10:29:39,223 - tests.cloud_tests - DEBUG - executing "collect: user_ubuntu"
+2019-09-07 10:29:39,518 - tests.cloud_tests - DEBUG - running collect script: user_foobar
+2019-09-07 10:29:39,519 - tests.cloud_tests - DEBUG - executing "collect: user_foobar"
+2019-09-07 10:29:39,755 - tests.cloud_tests - DEBUG - running collect script: user_barfoo
+2019-09-07 10:29:39,755 - tests.cloud_tests - DEBUG - executing "collect: user_barfoo"
+2019-09-07 10:29:39,999 - tests.cloud_tests - DEBUG - running collect script: user_cloudy
+2019-09-07 10:29:39,999 - tests.cloud_tests - DEBUG - executing "collect: user_cloudy"
+2019-09-07 10:29:40,183 - tests.cloud_tests - DEBUG - running collect script: root_groups
+2019-09-07 10:29:40,183 - tests.cloud_tests - DEBUG - executing "collect: root_groups"
+2019-09-07 10:29:40,628 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-user-groups-4zx6zl9tkp6lo2mfsme) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:29:43,305 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-user-groups-4zx6zl9tkp6lo2mfsme to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/user_groups/console.log
+2019-09-07 10:29:43,306 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-user-groups-4zx6zl9tkp6lo2mfsme) status=Stopped: deleting container.
+2019-09-07 10:29:44,646 - tests.cloud_tests - INFO - collecting test data for test: modules/write_files
+2019-09-07 10:29:45,849 - tests.cloud_tests - DEBUG - no console-support: no '--log' in lxc console --help
+2019-09-07 10:29:45,850 - tests.cloud_tests - DEBUG - Set console log method to logfile-snap
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:29:47,869 - tests.cloud_tests - DEBUG - executing "wait for instance start"
+2019-09-07 10:29:54,429 - tests.cloud_tests - DEBUG - running collect script: cloud-init.log
+2019-09-07 10:29:54,430 - tests.cloud_tests - DEBUG - executing "collect: cloud-init.log"
+2019-09-07 10:29:55,419 - tests.cloud_tests - DEBUG - running collect script: cloud-init-output.log
+2019-09-07 10:29:55,419 - tests.cloud_tests - DEBUG - executing "collect: cloud-init-output.log"
+2019-09-07 10:29:55,779 - tests.cloud_tests - DEBUG - running collect script: instance-id
+2019-09-07 10:29:55,779 - tests.cloud_tests - DEBUG - executing "collect: instance-id"
+2019-09-07 10:29:56,210 - tests.cloud_tests - DEBUG - running collect script: instance-data.json
+2019-09-07 10:29:56,210 - tests.cloud_tests - DEBUG - executing "collect: instance-data.json"
+2019-09-07 10:29:56,630 - tests.cloud_tests - DEBUG - running collect script: result.json
+2019-09-07 10:29:56,630 - tests.cloud_tests - DEBUG - executing "collect: result.json"
+2019-09-07 10:29:56,935 - tests.cloud_tests - DEBUG - running collect script: status.json
+2019-09-07 10:29:56,935 - tests.cloud_tests - DEBUG - executing "collect: status.json"
+2019-09-07 10:29:57,110 - tests.cloud_tests - DEBUG - running collect script: package-versions
+2019-09-07 10:29:57,110 - tests.cloud_tests - DEBUG - executing "collect: package-versions"
+2019-09-07 10:29:57,278 - tests.cloud_tests - DEBUG - running collect script: build.info
+2019-09-07 10:29:57,278 - tests.cloud_tests - DEBUG - executing "collect: build.info"
+2019-09-07 10:29:57,458 - tests.cloud_tests - DEBUG - running collect script: system.journal.gz
+2019-09-07 10:29:57,458 - tests.cloud_tests - DEBUG - executing "collect: system.journal.gz"
+2019-09-07 10:29:57,698 - tests.cloud_tests - DEBUG - running collect script: file_b64
+2019-09-07 10:29:57,699 - tests.cloud_tests - DEBUG - executing "collect: file_b64"
+2019-09-07 10:29:57,874 - tests.cloud_tests - DEBUG - running collect script: file_text
+2019-09-07 10:29:57,874 - tests.cloud_tests - DEBUG - executing "collect: file_text"
+2019-09-07 10:29:58,046 - tests.cloud_tests - DEBUG - running collect script: file_binary
+2019-09-07 10:29:58,046 - tests.cloud_tests - DEBUG - executing "collect: file_binary"
+2019-09-07 10:29:58,226 - tests.cloud_tests - DEBUG - running collect script: file_gzip
+2019-09-07 10:29:58,226 - tests.cloud_tests - DEBUG - executing "collect: file_gzip"
+2019-09-07 10:29:58,391 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-write-files-m066pr04or5ai5lywlv) status=Running: shutting down (wait=True)
+/var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/.tox/citest/lib/python3.6/site-packages/pylxd/models/operation.py:54: UserWarning: Attempted to set unknown attribute "location" on instance of "Operation"
+  .format(key, self.__class__.__name__))
+2019-09-07 10:30:03,969 - tests.cloud_tests - DEBUG - getting console log for cloud-test-ubuntu-disco-modules-write-files-m066pr04or5ai5lywlv to /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results/lxd/disco/modules/write_files/console.log
+2019-09-07 10:30:03,969 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-modules-write-files-m066pr04or5ai5lywlv) status=Stopped: deleting container.
+2019-09-07 10:30:04,225 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-snapshot-xkt5oarubna27mzimwuc40rll3fywg) status=Frozen: deleting container.
+2019-09-07 10:30:04,292 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-snapshot-xkt5oarubna27mzimwuc40rll3fywg) status=Running: shutting down (wait=True)
+2019-09-07 10:30:09,911 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-image-modification-vk7whtj3n5ry105cr00e) status=Running: deleting container.
+2019-09-07 10:30:09,924 - tests.cloud_tests - DEBUG - LXDInstance(name=cloud-test-ubuntu-disco-image-modification-vk7whtj3n5ry105cr00e) status=Running: shutting down (wait=True)
+2019-09-07 10:30:11,793 - tests.cloud_tests - DEBUG - collect stages: {'name': 'collect data', 'time': 857.4402980804443, 'errors': [], 'stages': [{'name': 'collect for platform: lxd', 'time': 856.5632128715515, 'errors': [], 'stages': [{'name': 'set up and collect data for os: disco', 'time': 853.2330555915833, 'errors': [], 'stages': [{'name': 'set up for ubuntu-disco', 'time': 16.381539583206177, 'errors': [], 'stages': [{'name': 'setup func for --repo, enable repo', 'time': 9.33365273475647, 'errors': [], 'success': True}, {'name': 'setup func for --upgrade, upgrade cloud-init', 'time': 7.047856569290161, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect test data for disco', 'time': 791.3369281291962, 'errors': [], 'stages': [{}, {}, {'name': 'collect for test: bugs/lp1628337', 'time': 7.996543645858765, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.1274919509887695, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.23776578903198242, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16307711601257324, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15953660011291504, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1479325294494629, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.14806079864501953, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15602707862854004, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1843576431274414, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2756481170654297, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3965270519256592, 'errors': [], 'success': True}], 'success': True}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {'name': 'collect for test: main/command_output_simple', 'time': 9.59416127204895, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.485389471054077, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.23691439628601074, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2396678924560547, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2119758129119873, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.27628612518310547, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18770289421081543, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 1.1562819480895996, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.22009825706481934, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1839742660522461, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.23164868354797363, 'errors': [], 'success': True}, {'name': 'script cloud-init-test-output', 'time': 0.1640911102294922, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_conf', 'time': 8.349609613418579, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.316941022872925, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.19736051559448242, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.295393705368042, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.23604321479797363, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.23186349868774414, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16050958633422852, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1555006504058838, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.18396782875061035, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17593955993652344, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24003839492797852, 'errors': [], 'success': True}, {'name': 'script 94cloud-init-config', 'time': 0.15590214729309082, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_disable_suites', 'time': 12.45946979522705, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 9.926870822906494, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2694587707519531, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2752368450164795, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.27583956718444824, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.3161747455596924, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.20403218269348145, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20804286003112793, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2717459201812744, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.19246912002563477, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.311506986618042, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.2079639434814453, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_primary', 'time': 9.141756534576416, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.724970817565918, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17314434051513672, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1876049041748047, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.26407480239868164, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.3520801067352295, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.29589176177978516, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.24804949760437012, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19183945655822754, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.23198771476745605, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.29228734970092773, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.17970061302185059, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_proxy', 'time': 11.370908260345459, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 8.374096393585205, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.29303812980651855, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.23608064651489258, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20398473739624023, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.3875703811645508, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2563669681549072, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.3076484203338623, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.20052242279052734, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.33537983894348145, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.41204142570495605, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-aptproxy', 'time': 0.3640449047088623, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_security', 'time': 9.005783557891846, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.313174247741699, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2088637351989746, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17196273803710938, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17579388618469238, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16794395446777344, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.7799623012542725, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2760436534881592, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.25595569610595703, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.20397520065307617, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2720928192138672, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.17988872528076172, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_key', 'time': 15.937421321868896, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 12.588458776473999, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1689925193786621, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19594287872314453, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20775461196899414, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20401453971862793, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19598078727722168, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.23204398155212402, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17239642143249512, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 1.0995278358459473, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3360438346862793, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.1879422664642334, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.3481900691986084, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_keyserver', 'time': 14.235060691833496, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 12.118115186691284, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18099212646484375, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16392731666564941, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15215539932250977, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15954971313476562, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16007590293884277, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22018170356750488, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15565776824951172, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.19235754013061523, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2642216682434082, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.17939543724060059, 'errors': [], 'success': True}, {'name': 'script apt_key_list', 'time': 0.2883148193359375, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_list', 'time': 8.215142250061035, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.118380069732666, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20554566383361816, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19918274879455566, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14805173873901367, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.17192316055297852, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19600248336791992, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2599904537200928, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.3040807247161865, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16040635108947754, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.267549991607666, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.183882474899292, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_configure_sources_ppa', 'time': 19.627721786499023, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 16.390923500061035, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.25377607345581055, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1990337371826172, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.23650074005126953, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.30741119384765625, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19999909400939941, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1440417766571045, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23592066764831543, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.27601122856140137, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.30815601348876953, 'errors': [], 'success': True}, {'name': 'script sources.list', 'time': 0.5797226428985596, 'errors': [], 'success': True}, {'name': 'script apt-key', 'time': 0.2898261547088623, 'errors': [], 'success': True}, {'name': 'script sources_full', 'time': 0.206251859664917, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_disable', 'time': 10.884562015533447, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.691893100738525, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.29770970344543457, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.3315563201904297, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.29202961921691895, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.32378554344177246, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.33605360984802246, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.3035290241241455, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.3844590187072754, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.3155660629272461, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.4043402671813965, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining', 'time': 0.20346593856811523, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/apt_pipelining_os', 'time': 9.586844682693481, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.761866331100464, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.24100613594055176, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19154834747314453, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20797157287597656, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2523772716522217, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2520637512207031, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19956588745117188, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2963135242462158, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.5996997356414795, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.4000117778778076, 'errors': [], 'success': True}, {'name': 'script 90cloud-init-pipelining_not_written', 'time': 0.18428683280944824, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/bootcmd', 'time': 12.757245302200317, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.156430959701538, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1650230884552002, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1597766876220703, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14389300346374512, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15208125114440918, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.18066954612731934, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17579340934753418, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1760547161102295, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.8513154983520508, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2682173252105713, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.3278508186340332, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/byobu', 'time': 9.765444040298462, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.496878623962402, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.3331420421600342, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.8913764953613281, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2559852600097656, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.25206661224365234, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21987509727478027, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15601134300231934, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23206591606140137, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2639334201812744, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.30799317359924316, 'errors': [], 'success': True}, {'name': 'script byobu_profile_enabled', 'time': 0.14387130737304688, 'errors': [], 'success': True}, {'name': 'script byobu_launch_exists', 'time': 0.21209120750427246, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ca_certs', 'time': 8.583106279373169, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.189977169036865, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.22505807876586914, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16374564170837402, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.13585710525512695, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.26437854766845703, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.22811150550842285, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2558252811431885, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.21206998825073242, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15982866287231445, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.27987194061279297, 'errors': [], 'success': True}, {'name': 'script cert_links', 'time': 0.2880392074584961, 'errors': [], 'success': True}, {'name': 'script cert', 'time': 0.18018245697021484, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_disable', 'time': 8.095152854919434, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.390444993972778, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.1613459587097168, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.18337559700012207, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2038881778717041, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1918022632598877, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15615630149841309, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.18780136108398438, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1800556182861328, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16040802001953125, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.27974414825439453, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/debug_enable', 'time': 11.132935523986816, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 8.528218269348145, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.36124372482299805, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.3314220905303955, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2879445552825928, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.23999714851379395, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.22001314163208008, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.3039836883544922, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2401127815246582, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.2679123878479004, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.351978063583374, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/final_message', 'time': 12.290988445281982, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.158021211624146, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.19321084022521973, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1514129638671875, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.16007614135742188, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2839851379394531, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2200307846069336, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20439958572387695, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.3802480697631836, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.21582579612731934, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.32363271713256836, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/keys_to_console', 'time': 10.256557941436768, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.8998847007751465, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.49307942390441895, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19958138465881348, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.19201445579528809, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.21594977378845215, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.19221782684326172, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20774388313293457, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2120225429534912, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18012499809265137, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2764103412628174, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.18741559982299805, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/locale', 'time': 12.211732387542725, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 8.838932752609253, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.20138192176818848, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.16800642013549805, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.26343226432800293, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.29184865951538086, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.20803070068359375, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.18406128883361816, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19591474533081055, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17199039459228516, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3481435775756836, 'errors': [], 'success': True}, {'name': 'script locale_default', 'time': 0.2118391990661621, 'errors': [], 'success': True}, {'name': 'script locale_a', 'time': 0.9399447441101074, 'errors': [], 'success': True}, {'name': 'script locale_gen', 'time': 0.1880478858947754, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_bridge', 'time': 26.036065816879272, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 21.939282178878784, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.30499744415283203, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19977688789367676, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.25994253158569336, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2400500774383545, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.29607295989990234, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19983983039855957, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.29204630851745605, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.3841855525970459, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3039219379425049, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.29584813117980957, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.9599487781524658, 'errors': [], 'success': True}, {'name': 'script lxc-bridge', 'time': 0.360001802444458, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/lxd_dir', 'time': 22.158867597579956, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 18.91356110572815, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.3291008472442627, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.28371381759643555, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.29592227935791016, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2762322425842285, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2717101573944092, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.34794163703918457, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.41606688499450684, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1920311450958252, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.33611559867858887, 'errors': [], 'success': True}, {'name': 'script lxc', 'time': 0.2717435359954834, 'errors': [], 'success': True}, {'name': 'script lxd', 'time': 0.2245464324951172, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp', 'time': 21.599478721618652, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 19.45873236656189, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17299103736877441, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1877291202545166, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15198993682861328, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15199589729309082, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.15195965766906738, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.19617128372192383, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17646265029907227, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17187261581420898, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2675623893737793, 'errors': [], 'success': True}, {'name': 'script ntp_installed', 'time': 0.17598843574523926, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_empty', 'time': 0.17276287078857422, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pool_list', 'time': 0.1630995273590088, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_chrony', 'time': 19.025277853012085, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 16.344069242477417, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18158698081970215, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1589183807373047, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15591788291931152, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14013361930847168, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13979125022888184, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.13626313209533691, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.160109281539917, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16819500923156738, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 1.2597897052764893, 'errors': [], 'success': True}, {'name': 'script chrony_conf', 'time': 0.18036484718322754, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_pools', 'time': 22.42280602455139, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 18.602133989334106, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.35746145248413086, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2316122055053711, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.195556640625, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 1.1280906200408936, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21228432655334473, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17165136337280273, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.20406794548034668, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16451263427734375, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.31539392471313477, 'errors': [], 'success': True}, {'name': 'script ntp_installed_pools', 'time': 0.2120509147644043, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_pools', 'time': 0.23605632781982422, 'errors': [], 'success': True}, {'name': 'script ntp_conf_pools', 'time': 0.19618844985961914, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.19555997848510742, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_servers', 'time': 18.640000820159912, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 16.32713294029236, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18105459213256836, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.14767813682556152, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.14001083374023438, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16820788383483887, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16828656196594238, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.199479341506958, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.1641216278076172, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.14378142356872559, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.28459978103637695, 'errors': [], 'success': True}, {'name': 'script ntp_installed_servers', 'time': 0.17947173118591309, 'errors': [], 'success': True}, {'name': 'script ntp_conf_dist_servers', 'time': 0.14856243133544922, 'errors': [], 'success': True}, {'name': 'script ntp_conf_servers', 'time': 0.19949078559875488, 'errors': [], 'success': True}, {'name': 'script ntpq_servers', 'time': 0.18794512748718262, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ntp_timesyncd', 'time': 9.613937139511108, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.40520977973938, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2091834545135498, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2523932456970215, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.21140646934509277, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.2320854663848877, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.23194026947021484, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.21551108360290527, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.21212196350097656, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18022871017456055, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2756495475769043, 'errors': [], 'success': True}, {'name': 'script timesyncd_conf', 'time': 0.18802499771118164, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/package_update_upgrade_install', 'time': 19.236571550369263, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 15.9799063205719, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.24158740043640137, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.27155470848083496, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.25141215324401855, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.19999003410339355, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2561624050140381, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.3081953525543213, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.7555720806121826, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.20003724098205566, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2920072078704834, 'errors': [], 'success': True}, {'name': 'script apt_history_cmdline', 'time': 0.24396705627441406, 'errors': [], 'success': True}, {'name': 'script dpkg_show', 'time': 0.23597502708435059, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/runcmd', 'time': 13.945422410964966, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.544774055480957, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2930290699005127, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.3399333953857422, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.27178382873535156, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.22848749160766602, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.24344968795776367, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.20790863037109375, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2720608711242676, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.16811704635620117, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2357933521270752, 'errors': [], 'success': True}, {'name': 'script run_cmd', 'time': 1.139960765838623, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/seed_random_data', 'time': 12.503326654434204, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.222682237625122, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.23319697380065918, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1838061809539795, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.1836409568786621, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.21593976020812988, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1839601993560791, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22796392440795898, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2000422477722168, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.24793553352355957, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3680894374847412, 'errors': [], 'success': True}, {'name': 'script seed_data', 'time': 0.2359304428100586, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname', 'time': 9.679589748382568, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.446704626083374, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17368149757385254, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19131731986999512, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.22420096397399902, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.20361757278442383, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.17593717575073242, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1600053310394287, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17616057395935059, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17231011390686035, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.26753735542297363, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.1565380096435547, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.16378521919250488, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.16759181022644043, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_hostname_fqdn', 'time': 8.201204776763916, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.192302465438843, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.16095423698425293, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.15170693397521973, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15202975273132324, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14793086051940918, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1441199779510498, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.13994216918945312, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.17192912101745605, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1759791374206543, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.23206496238708496, 'errors': [], 'success': True}, {'name': 'script hosts', 'time': 0.1521444320678711, 'errors': [], 'success': True}, {'name': 'script hostname', 'time': 0.19193482398986816, 'errors': [], 'success': True}, {'name': 'script fqdn', 'time': 0.18802928924560547, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password', 'time': 8.80878758430481, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.192059516906738, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2330329418182373, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.6716635227203369, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.267977237701416, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16808056831359863, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.1839306354522705, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.14402294158935547, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.15192961692810059, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.15601468086242676, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2560250759124756, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.17610669136047363, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.2077949047088623, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_expire', 'time': 8.513674020767212, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.264994144439697, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.17775654792785645, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19899773597717285, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.20803046226501465, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.16386079788208008, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2198808193206787, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22813987731933594, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23609137535095215, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17189288139343262, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.28798985481262207, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.17992568016052246, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.17597699165344238, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list', 'time': 14.491803169250488, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.658459663391113, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.28110671043395996, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.27176761627197266, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.24402403831481934, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.1998584270477295, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.25597071647644043, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.2640390396118164, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.46801185607910156, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.9758355617523193, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.32027173042297363, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.3037440776824951, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.24855709075927734, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/set_password_list_string', 'time': 9.67754602432251, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.752731800079346, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.18498516082763672, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.17625856399536133, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.15595650672912598, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.15191268920898438, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.13984012603759766, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15575528144836426, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.18790245056152344, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.20001459121704102, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.26005053520202637, 'errors': [], 'success': True}, {'name': 'script shadow', 'time': 0.15587115287780762, 'errors': [], 'success': True}, {'name': 'script sshd_config', 'time': 0.1561112403869629, 'errors': [], 'success': True}], 'success': True}, {}, {}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_disable', 'time': 13.508180379867554, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 11.223219871520996, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.22115421295166016, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2159717082977295, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.23575091361999512, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.22824501991271973, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.2037670612335205, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.16385841369628906, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.23252248764038086, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.1994478702545166, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.304079532623291, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.28000783920288086, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_auth_key_fingerprints_enable', 'time': 14.472371339797974, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 11.575672626495361, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.32167673110961914, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.19499802589416504, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.18000388145446777, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.19601202011108398, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21244287490844727, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.15953421592712402, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.20006895065307617, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.19993185997009277, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.42060327529907227, 'errors': [], 'success': True}, {'name': 'script syslog', 'time': 0.8112897872924805, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_import_id', 'time': 15.46313214302063, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 12.509769439697266, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.30582761764526367, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.3030824661254883, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.25185203552246094, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.260495662689209, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.30380749702453613, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.29609107971191406, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.2797236442565918, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.3279151916503906, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.436443567276001, 'errors': [], 'success': True}, {'name': 'script auth_keys_ubuntu', 'time': 0.1879575252532959, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/ssh_keys_generate', 'time': 13.105538129806519, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 10.116232872009277, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.15272760391235352, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.1277768611907959, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.17208600044250488, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.14798402786254883, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.16411280632019043, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.1399376392364502, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16406774520874023, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.17612528800964355, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.2598836421966553, 'errors': [], 'success': True}, {'name': 'script dsa_public', 'time': 0.1924116611480713, 'errors': [], 'success': True}, {'name': 'script dsa_private', 'time': 0.18369436264038086, 'errors': [], 'success': True}, {'name': 'script rsa_public', 'time': 0.18449640274047852, 'errors': [], 'success': True}, {'name': 'script rsa_private', 'time': 0.1637873649597168, 'errors': [], 'success': True}, {'name': 'script ecdsa_public', 'time': 0.1794121265411377, 'errors': [], 'success': True}, {'name': 'script ecdsa_private', 'time': 0.18409466743469238, 'errors': [], 'success': True}, {'name': 'script ed25519_public', 'time': 0.20435571670532227, 'errors': [], 'success': True}, {'name': 'script ed25519_private', 'time': 0.19215011596679688, 'errors': [], 'success': True}], 'success': True}, {}, {'name': 'collect for test: modules/timezone', 'time': 9.252891778945923, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 6.260031700134277, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.2650291919708252, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.2317821979522705, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.24456477165222168, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.719865083694458, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.20392441749572754, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.28761839866638184, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.30832552909851074, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18757867813110352, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.3400533199310303, 'errors': [], 'success': True}, {'name': 'script timezone', 'time': 0.20396208763122559, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/user_groups', 'time': 12.766932010650635, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 7.631622791290283, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.44414687156677246, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.5196471214294434, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.2118535041809082, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.26380300521850586, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.21179723739624023, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.22031474113464355, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.19209647178649902, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.3114798069000244, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.428361177444458, 'errors': [], 'success': True}, {'name': 'script group_ubuntu', 'time': 0.5878753662109375, 'errors': [], 'success': True}, {'name': 'script group_cloud_users', 'time': 0.34423279762268066, 'errors': [], 'success': True}, {'name': 'script user_ubuntu', 'time': 0.29575586318969727, 'errors': [], 'success': True}, {'name': 'script user_foobar', 'time': 0.236741304397583, 'errors': [], 'success': True}, {'name': 'script user_barfoo', 'time': 0.24351954460144043, 'errors': [], 'success': True}, {'name': 'script user_cloudy', 'time': 0.18379497528076172, 'errors': [], 'success': True}, {'name': 'script root_groups', 'time': 0.43964099884033203, 'errors': [], 'success': True}], 'success': True}, {'name': 'collect for test: modules/write_files', 'time': 12.48458743095398, 'errors': [], 'stages': [{'name': 'boot instance', 'time': 8.527742385864258, 'errors': [], 'success': True}, {'name': 'script cloud-init.log', 'time': 0.9898231029510498, 'errors': [], 'success': True}, {'name': 'script cloud-init-output.log', 'time': 0.35944509506225586, 'errors': [], 'success': True}, {'name': 'script instance-id', 'time': 0.4315934181213379, 'errors': [], 'success': True}, {'name': 'script instance-data.json', 'time': 0.41980528831481934, 'errors': [], 'success': True}, {'name': 'script result.json', 'time': 0.3051412105560303, 'errors': [], 'success': True}, {'name': 'script status.json', 'time': 0.17487716674804688, 'errors': [], 'success': True}, {'name': 'script package-versions', 'time': 0.16801953315734863, 'errors': [], 'success': True}, {'name': 'script build.info', 'time': 0.18002104759216309, 'errors': [], 'success': True}, {'name': 'script system.journal.gz', 'time': 0.24017930030822754, 'errors': [], 'success': True}, {'name': 'script file_b64', 'time': 0.17582917213439941, 'errors': [], 'success': True}, {'name': 'script file_text', 'time': 0.1719832420349121, 'errors': [], 'success': True}, {'name': 'script file_binary', 'time': 0.17998123168945312, 'errors': [], 'success': True}, {'name': 'script file_gzip', 'time': 0.1599571704864502, 'errors': [], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}], 'success': True}
+2019-09-07 10:30:11,797 - tests.cloud_tests - DEBUG - found test data: {'lxd': {'disco': ['bugs/lp1628337', 'modules/apt_configure_sources_list', 'modules/locale', 'modules/apt_configure_primary', 'modules/lxd_bridge', 'modules/apt_configure_security', 'modules/apt_pipelining_os', 'modules/ssh_import_id', 'modules/ntp_pools', 'modules/ssh_keys_generate', 'modules/ssh_auth_key_fingerprints_enable', 'modules/apt_configure_sources_keyserver', 'modules/bootcmd', 'modules/set_hostname_fqdn', 'modules/ssh_auth_key_fingerprints_disable', 'modules/final_message', 'modules/apt_configure_sources_key', 'modules/ntp_servers', 'modules/ntp_chrony', 'modules/write_files', 'modules/set_password', 'modules/ntp', 'modules/timezone', 'modules/keys_to_console', 'modules/debug_enable', 'modules/seed_random_data', 'modules/set_password_list', 'modules/user_groups', 'modules/debug_disable', 'modules/byobu', 'modules/apt_configure_proxy', 'modules/apt_configure_sources_ppa', 'modules/package_update_upgrade_install', 'modules/ntp_timesyncd', 'modules/lxd_dir', 'modules/apt_pipelining_disable', 'modules/runcmd', 'modules/set_hostname', 'modules/apt_configure_conf', 'modules/apt_configure_disable_suites', 'modules/set_password_list_string', 'modules/set_password_expire', 'modules/ca_certs', 'main/command_output_simple']}}
+
+2019-09-07 10:30:11,797 - tests.cloud_tests - INFO - test: platform='lxd', os='disco' verifying test data
+2019-09-07 10:30:11,797 - tests.cloud_tests - DEBUG - verifying test data for bugs/lp1628337
+test_fetch_indices (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify no apt errors. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp (tests.cloud_tests.testcases.bugs.lp1628337.TestLP1628337)
+Verify can find ntp and install it. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:11,860 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Unexpected warnings should not be found in the log. ... ok
+test_sources_list (tests.cloud_tests.testcases.modules.apt_configure_sources_list.TestAptconfigureSourcesList)
+Test sources.list includes sources. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-07 10:30:11,907 - tests.cloud_tests - DEBUG - verifying test data for modules/locale
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Validate instance-data.json content by lxd platform. ... ok
+test_locale (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale is set properly. ... ok
+test_locale_a (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test locale -a has both options. ... ok
+test_locale_gen (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Test local.gen file has all entries. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.locale.TestLocale)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:11,952 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_primary
+test_gatech_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test GaTech entries exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Unexpected warnings should not be found in the log. ... ok
+test_ubuntu_sources (tests.cloud_tests.testcases.modules.apt_configure_primary.TestAptconfigurePrimary)
+Test no default Ubuntu entries exist. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:11,995 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_bridge
+test_bridge (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test bridge config. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Validate instance-data.json content by lxd platform. ... ok
+test_lxc (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_bridge.TestLxdBridge)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,037 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_security
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Unexpected warnings should not be found in the log. ... ok
+test_security_mirror (tests.cloud_tests.testcases.modules.apt_configure_security.TestAptconfigureSecurity)
+Test security lines added and uncommented in source.list. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,079 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_os
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+Unexpected warnings should not be found in the log. ... ok
+test_os_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_os.TestAptPipeliningOS)
+test 'os' settings does not write apt config file. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,121 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_import_id
+test_authorized_keys (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Test that ssh keys were imported. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_import_id.TestSshImportId)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,162 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_pools
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test dist config file is empty ... ok
+test_ntp_entires (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_pools.TestNtpPools)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.004s
+
+OK (skipped=2)
+2019-09-07 10:30:12,208 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_keys_generate
+test_dsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa private key not generated. ... ok
+test_dsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test dsa public key not generated. ... ok
+test_ecdsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ecdsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ecdsa public key generated. ... ok
+test_ed25519_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_ed25519_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test ed25519 public key generated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Unexpected warnings should not be found in the log. ... ok
+test_rsa_private (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+test_rsa_public (tests.cloud_tests.testcases.modules.ssh_keys_generate.TestSshKeysGenerate)
+Test rsa public key not generated. ... ok
+
+----------------------------------------------------------------------
+Ran 13 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,251 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_enable
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Unexpected warnings should not be found in the log. ... ok
+test_syslog (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_enable.TestSshKeyFingerprintsEnable)
+Verify output of syslog. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,294 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_keyserver
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test specific key added. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_keyserver.TestAptconfigureSourcesKeyserver)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,335 - tests.cloud_tests - DEBUG - verifying test data for modules/bootcmd
+test_bootcmd_host (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Test boot cmd worked. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.bootcmd.TestBootCmd)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,396 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname_fqdn
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname output. ... ok
+test_hostname_fqdn (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test hostname fqdn output. ... ok
+test_hosts (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Test /etc/hosts file. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname_fqdn.TestHostnameFqdn)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,442 - tests.cloud_tests - DEBUG - verifying test data for modules/ssh_auth_key_fingerprints_disable
+test_cloud_init_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Verify disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ssh_auth_key_fingerprints_disable.TestSshKeyFingerprintsDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,484 - tests.cloud_tests - DEBUG - verifying test data for modules/final_message
+test_final_message_string (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure final handles regular strings. ... ok
+test_final_message_subs (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Test variable substitution in final message. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.final_message.TestFinalMessage)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.002s
+
+OK (skipped=2)
+2019-09-07 10:30:12,526 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_key
+test_apt_key_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test key list updated. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Unexpected warnings should not be found in the log. ... ok
+test_source_list (tests.cloud_tests.testcases.modules.apt_configure_sources_key.TestAptconfigureSourcesKey)
+Test source.list updated. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,571 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_servers
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test config server entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntp installed ... ok
+test_ntpq_servers (tests.cloud_tests.testcases.modules.ntp_servers.TestNtpServers)
+Test ntpq output has configured servers ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-07 10:30:12,618 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_chrony
+test_chrony_entries (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Test chrony config entries ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_chrony.TestNtpChrony)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,661 - tests.cloud_tests - DEBUG - verifying test data for modules/write_files
+test_b64 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test b64 encoded file reads as ascii. ... ok
+test_binary (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test binary file reads as executable. ... ok
+test_gzip (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test gzip file shows up as a shell script. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Unexpected warnings should not be found in the log. ... ok
+test_text (tests.cloud_tests.testcases.modules.write_files.TestWriteFiles)
+Test text shows up as ASCII text. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,703 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test ubuntu user in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password.TestPassword)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,748 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Unexpected warnings should not be found in the log. ... ok
+test_ntp_dist_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test dist config file is empty ... ok
+test_ntp_entries (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test config entries ... ok
+test_ntp_installed (tests.cloud_tests.testcases.modules.ntp.TestNtp)
+Test ntp installed ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,818 - tests.cloud_tests - DEBUG - verifying test data for modules/timezone
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Unexpected warnings should not be found in the log. ... ok
+test_timezone (tests.cloud_tests.testcases.modules.timezone.TestTimezone)
+Test date prints correct timezone. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,872 - tests.cloud_tests - DEBUG - verifying test data for modules/keys_to_console
+test_excluded_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test excluded keys missing. ... ok
+test_expected_keys (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Test expected keys exist. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.keys_to_console.TestKeysToConsole)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,916 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_enable
+test_debug_enable (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Test debug messages in cloud-init log. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_enable.TestDebugEnable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:12,962 - tests.cloud_tests - DEBUG - verifying test data for modules/seed_random_data
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Unexpected warnings should not be found in the log. ... ok
+test_random_seed_data (tests.cloud_tests.testcases.modules.seed_random_data.TestSeedRandom)
+Test random data passed in exists. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,007 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list.TestPasswordList)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.030s
+
+OK (skipped=2)
+2019-09-07 10:30:13,083 - tests.cloud_tests - DEBUG - verifying test data for modules/user_groups
+test_group_cloud_users (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloud users group exists. ... ok
+test_group_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu group exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Unexpected warnings should not be found in the log. ... ok
+test_user_barfoo (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test barfoo user exists. ... ok
+test_user_cloudy (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test cloudy user exists. ... ok
+test_user_foobar (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test foobar user exists. ... ok
+test_user_root_in_secret (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test root user is in 'secret' group. ... ok
+test_user_ubuntu (tests.cloud_tests.testcases.modules.user_groups.TestUserGroups)
+Test ubuntu user exists. ... ok
+
+----------------------------------------------------------------------
+Ran 12 tests in 0.002s
+
+OK (skipped=2)
+2019-09-07 10:30:13,128 - tests.cloud_tests - DEBUG - verifying test data for modules/debug_disable
+test_debug_disable (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Test verbose output missing from logs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.debug_disable.TestDebugDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,172 - tests.cloud_tests - DEBUG - verifying test data for modules/byobu
+test_byobu_installed (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu installed. ... ok
+test_byobu_launch_exists (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu-launch exists. ... ok
+test_byobu_profile_enabled (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Test byobu profile.d file exists. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.byobu.TestByobu)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,218 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_proxy
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Unexpected warnings should not be found in the log. ... ok
+test_proxy_config (tests.cloud_tests.testcases.modules.apt_configure_proxy.TestAptconfigureProxy)
+Test proxy options added to apt config. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,262 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_sources_ppa
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Unexpected warnings should not be found in the log. ... ok
+test_ppa (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test specific ppa added. ... ok
+test_ppa_key (tests.cloud_tests.testcases.modules.apt_configure_sources_ppa.TestAptconfigureSourcesPPA)
+Test ppa key added. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,305 - tests.cloud_tests - DEBUG - verifying test data for modules/package_update_upgrade_install
+test_apt_history (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test apt history for update command. ... ok
+test_cloud_init_output (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test cloud-init-output for install & upgrade stuff. ... ok
+test_installed_sl (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test sl got installed. ... ok
+test_installed_tree (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Test tree got installed. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.package_update_upgrade_install.TestPackageInstallUpdateUpgrade)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 9 tests in 0.002s
+
+OK (skipped=2)
+2019-09-07 10:30:13,356 - tests.cloud_tests - DEBUG - verifying test data for modules/ntp_timesyncd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Unexpected warnings should not be found in the log. ... ok
+test_timesyncd_entries (tests.cloud_tests.testcases.modules.ntp_timesyncd.TestNtpTimesyncd)
+Test timesyncd config entries ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,417 - tests.cloud_tests - DEBUG - verifying test data for modules/lxd_dir
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Validate instance-data.json content by lxd platform. ... ok
+test_lxc (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxc installed. ... ok
+test_lxd (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Test lxd installed. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.lxd_dir.TestLxdDir)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,470 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_pipelining_disable
+test_disable_pipelining (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Test pipelining disabled. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_pipelining_disable.TestAptPipeliningDisable)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,512 - tests.cloud_tests - DEBUG - verifying test data for modules/runcmd
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Unexpected warnings should not be found in the log. ... ok
+test_run_cmd (tests.cloud_tests.testcases.modules.runcmd.TestRunCmd)
+Test run command worked. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,554 - tests.cloud_tests - DEBUG - verifying test data for modules/set_hostname
+test_hostname (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Test hostname command shows correct output. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_hostname.TestHostname)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,598 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_conf
+test_apt_conf_assumeyes (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config assumes true. ... ok
+test_apt_conf_fixbroken (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Test config fixes broken. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_conf.TestAptconfigureConf)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,640 - tests.cloud_tests - DEBUG - verifying test data for modules/apt_configure_disable_suites
+test_empty_sourcelist (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Test source list is empty. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.apt_configure_disable_suites.TestAptconfigureDisableSuites)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,683 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_list_string
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow_expected_users (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test every tom, dick, and harry user in shadow. ... ok
+test_shadow_passwords (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test shadow passwords. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_list_string.TestPasswordListString)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.004s
+
+OK (skipped=2)
+2019-09-07 10:30:13,730 - tests.cloud_tests - DEBUG - verifying test data for modules/set_password_expire
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Unexpected warnings should not be found in the log. ... ok
+test_shadow (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test user frozen in shadow. ... ok
+test_sshd_config (tests.cloud_tests.testcases.modules.set_password_expire.TestPasswordExpire)
+Test sshd config allows passwords. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,774 - tests.cloud_tests - DEBUG - verifying test data for modules/ca_certs
+test_cert_installed (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test line from our cert exists. ... ok
+test_certs_updated (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Test certs have been updated in /etc/ssl/certs. ... ok
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.modules.ca_certs.TestCaCerts)
+Unexpected warnings should not be found in the log. ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK (skipped=2)
+2019-09-07 10:30:13,820 - tests.cloud_tests - DEBUG - verifying test data for main/command_output_simple
+test_instance_data_json_ec2 (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by ec2 platform. ... skipped 'Skipping ec2 instance-data.json on lxd'
+test_instance_data_json_kvm (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by nocloud-kvm platform. ... skipped 'Skipping nocloud-kvm instance-data.json on lxd'
+test_instance_data_json_lxd (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Validate instance-data.json content by lxd platform. ... ok
+test_no_stages_errors (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that there were no errors in any stage. ... ok
+test_no_warnings_in_log (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Unexpected warnings should not be found in the log. ... ok
+test_output_file (tests.cloud_tests.testcases.main.command_output_simple.TestCommandOutputSimple)
+Ensure that the output file is not empty and has all stages. ... ok
+
+----------------------------------------------------------------------
+Ran 6 tests in 0.002s
+
+OK (skipped=2)
+2019-09-07 10:30:13,863 - tests.cloud_tests - INFO - test: platform='lxd', os='disco' passed all tests
+2019-09-07 10:30:13,863 - tests.cloud_tests - DEBUG - 
+---- Verify summarized results:
+
+Platform: lxd
+  Distro: disco
+    test modules passed:44 tests failed:0
+2019-09-07 10:30:13,863 - tests.cloud_tests - INFO - leaving data in /var/lib/jenkins/servers/server/workspace/cloud-init-integration-proposed-d-lxd/cloud-init/results
+___________________________________ summary ____________________________________
+  citest: commands succeeded
+  congratulations :)
++ RET=0
++ find . -name id_rsa* -delete
++ exit 0
+Sending e-mails to: server-crew-qa@lists.canonical.com
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in 0 seconds
+Finished: SUCCESS
+=== End series d ===


### PR DESCRIPTION
added script update to bin/sru-get-jenkins-logs to only query x b and d series as well as passing a '-s' to uss-tableflip/scripts/jenkins-get-job to return the last successful job run