### PR TITLE
sru: add azure byteswapped manual test

### DIFF
--- a/bugs/sru-19.4.33-manual-1.txt
+++ b/bugs/sru-19.4.33-manual-1.txt
@@ -1,0 +1,141 @@
+=== Begin SRU Template ===
+[Impact] 
+Azure Gen2 VMs which migrate from one Azure backend server to another
+will run into a scenario where dmi data reports byte-swapped DMI product_uuid.
+
+In this scenario, cloud-init should not reprovision the system due to 
+New Instance first boot event as cloud-init will have already configured the
+VM appropriately.
+
+This fix should avoid re-provisioning when DMI product_uuid on Azure VMs
+happen to have byte-swapped ordering for the first 3 segments of the product
+UUID.
+
+[Test Case]
+
+#!/bin/sh
+set -x
+# Manually deploy on Azure using Azure CLI client.
+# Fake a byte-swapped cached instance-id and validate that old cloud-init
+# fails to return the previous instance-id.  Validate that -proposed cloud-init
+# does return the previous IID (to avoid triggering the New instance ID boot
+# event
+ 
+# To be adapted to the SRU to test
+SRU_SERIES="xenial bionic eoan"
+
+# local values
+# find region with az account list-locations -o table
+REGION="eastus2"
+VNET_NAME="sruVnet"
+NETWORK_SECURITY_GROUP="sruNetSecGroup"
+NIC_NAME="sruNic"
+RESOURCE_GROUP="srugroup"
+BOOT_DIAG="storeitsru"
+SSH_KEY="$HOME/.ssh/id_rsa.pub"
+
+
+cat > sethostname.yaml <<EOF
+## template: jinja
+#cloud-config
+ssh_import_id : [chad.smith]
+hostname: SRU-worked-{{v1.cloud_name}}
+EOF
+
+cat > setup_proposed.sh <<EOF
+#/bin/bash
+mirror=http://archive.ubuntu.com/ubuntu
+echo deb \$mirror \$(lsb_release -sc)-proposed main | tee /etc/apt/sources.list.d/proposed.list
+apt-get update -q
+apt-get install -qy cloud-init
+EOF
+
+cat > byteswap_test.sh <<EOF
+#!/usr/bin/python3
+
+from cloudinit.stages import _pkl_load, _pkl_store
+
+import textwrap
+def swap_bytestring(s, width=2):
+        dd = [byte for byte in textwrap.wrap(s, 2)]
+        dd.reverse()
+        return ''.join(dd)
+
+def swapped_iid(iid):
+    parts = iid.split('-')
+    return '-'.join([
+        swap_bytestring(parts[0]),
+        swap_bytestring(parts[1]),
+        swap_bytestring(parts[2]),
+        parts[3],
+        parts[4]
+    ])
+
+# Cache a swapped instance-id so it looks like real product-uuid has swapped
+with open('/sys/class/dmi/id/product_uuid', 'r') as stream:
+    real_iid = stream.read().strip()
+ds =_pkl_load("/var/lib/cloud/instance/obj.pkl")
+fake_prev_iid = swapped_iid(ds.get_instance_id())
+# persist byte-swapped in /run/cloud-init/.instance-id as stages reads it
+with open('/var/lib/cloud/data/instance-id', 'w') as stream:
+    stream.write(fake_prev_iid)
+ds.metadata['instance-id'] = fake_prev_iid
+_pkl_store(ds, "/var/lib/cloud/instance/obj.pkl")
+
+assert ds.get_instance_id() == fake_prev_iid, "Did not swap cached instance-id"
+crawled_metadata = ds.crawl_metadata()
+assert crawled_metadata['metadata']['instance-id'] == fake_prev_iid, "Crawled metadata didn't return previous IID"
+print("SUCCESS")
+EOF
+chmod 755 byteswap_test.sh
+
+
+az group create --name $RESOURCE_GROUP --location $REGION
+
+sshopts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+for series in $SRU_SERIES; do
+    echo "### BEGIN $series"
+    netcfg="/etc/netplan/50-cloud-init.yaml"
+    case $series in
+        xenial) image_version=16.04-DAILY-LTS
+                netcfg="/etc/network/interfaces.d/50-cloud-init.cfg";;
+        bionic) image_version=18.04-DAILY-LTS;;
+        disco) image_version=19.04-DAILY;;
+        eoan) image_version=19.10-DAILY;;
+        *) echo "!! UPDATE FAMILY CASE STATEMENT !!"; exit 1;;
+    esac
+    # Note: Gen2 instance types (--size) exhibit byte-swapped values
+    name=test-sru-$series
+    az vm create --name=$name \
+        --image=Canonical:UbuntuServer:$image_version:latest \
+        --admin-username=root --admin-username=ubuntu \
+        -g $RESOURCE_GROUP --ssh-key-value $SSH_KEY \
+        --custom-data sethostname.yaml --size Standard_B1s
+    IP=$(az vm list-ip-addresses --name $name | jq -r '.[] | .virtualMachine.network.publicIpAddresses[].ipAddress'| awk '{printf "ubuntu@%s", $1}')
+
+    echo "Created $name: ubuntu@$IP"
+
+    ssh $sshopts $IP -- cloud-init status --wait --long
+    scp $sshopts setup_proposed.sh byteswap_test.sh $IP:.
+    echo '--- Expect assert byteswap error for current release'
+    ssh $sshopts $IP -- sudo ./byteswap_test.sh
+    ssh $sshopts $IP -- sudo bash ./setup_proposed.sh 2>&1 | egrep 'cloud-init'
+    ssh $sshopts $IP -- dpkg-query --show cloud-init
+    ssh $sshopts $IP -- sudo cloud-init clean --logs
+    # Setup cached datasource pkl with real product_uuid saved as intance-id
+    ssh $sshopts $IP -- sudo cloud-init init --local
+    echo '--- Expect SUCCESS byteswap -proposed release'
+    ssh $sshopts $IP -- sudo ./byteswap_test.sh
+    echo "### END $series"
+done
+
+[Regression Potential]
+On Azure only, if new _iid logic was broken we could see tracebacks resulting
+in failure for cloud-init to initially provision (or upgrade) on Azure.
+
+[Other Info]
+Upstream commit at 
+https://git.launchpad.net/cloud-init/commit/?id=129b1c4e
+
+
+

--- a/bugs/sru-19.4.33-manual-1.txt
+++ b/bugs/sru-19.4.33-manual-1.txt
@@ -138,4 +138,201 @@ Upstream commit at
 https://git.launchpad.net/cloud-init/commit/?id=129b1c4e
 
 
+====== BEGIN SRU verification logs =======
+root@publishing:~# ./azure-byteswap.txt | tee byte.log
++ SRU_SERIES=xenial bionic eoan
++ REGION=eastus2
++ VNET_NAME=sruVnet
++ NETWORK_SECURITY_GROUP=sruNetSecGroup
++ NIC_NAME=sruNic
++ RESOURCE_GROUP=srugroup
++ BOOT_DIAG=storeitsru
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ cat
++ cat
++ cat
++ chmod 755 byteswap_test.sh
++ az group create --name srugroup --location eastus2
+{
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroup",
+  "location": "eastus2",
+  "managedBy": null,
+  "name": "srugroup",
+  "properties": {
+    "provisioningState": "Succeeded"
+  },
+  "tags": null,
+  "type": "Microsoft.Resources/resourceGroups"
+}
++ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ echo ### BEGIN xenial
++ netcfg=/etc/netplan/50-cloud-init.yaml
+### BEGIN xenial
++ image_version=16.04-DAILY-LTS
++ netcfg=/etc/network/interfaces.d/50-cloud-init.cfg
++ name=test-sru-xenial
++ az vm create --name=test-sru-xenial --image=Canonical:UbuntuServer:16.04-DAILY-LTS:latest --admin-username=root --admin-username=ubuntu -g srugroup --ssh-key-value /root/.ssh/id_rsa.pub --custom-data sethostname.yaml --size Standard_B1s
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroup/providers/Microsoft.Compute/virtualMachines/test-sru-xenial",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-7A-AC-77",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.4",
+  "publicIpAddress": "104.209.184.57",
+  "resourceGroup": "srugroup",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-xenial
++ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
++ awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@104.209.184.57
++ echo Created test-sru-xenial: ubuntu@ubuntu@104.209.184.57
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.184.57 -- cloud-init status --wait --long
+Created test-sru-xenial: ubuntu@ubuntu@104.209.184.57
 
+status: done
+time: Sat, 25 Jan 2020 04:12:40 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR setup_proposed.sh byteswap_test.sh ubuntu@104.209.184.57:.
++ echo --- Expect assert byteswap error for current release
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o--- Expect assert byteswap error for current release
+ LogLevel=ERROR ubuntu@104.209.184.57 -- sudo ./byteswap_test.sh
+sudo: unable to resolve host SRU-worked-azure
+Traceback (most recent call last):
+  File "./byteswap_test.sh", line 34, in <module>
+    assert crawled_metadata['metadata']['instance-id'] == fake_prev_iid, "Crawled metadata didn't return previous IID"
+AssertionError: Crawled metadata didn't return previous IID
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.184.57 -- sudo bash ./setup_proposed.sh
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 cloud-init all 19.4-33-gbb4131a2-0ubuntu1~16.04.1 [413 kB]
+Preparing to unpack .../cloud-init_19.4-33-gbb4131a2-0ubuntu1~16.04.1_all.deb ...
+Unpacking cloud-init (19.4-33-gbb4131a2-0ubuntu1~16.04.1) over (19.3-41-gc4735dd3-0ubuntu1~16.04.1) ...
+Setting up cloud-init (19.4-33-gbb4131a2-0ubuntu1~16.04.1) ...
+Leaving 'diversion of /etc/init/ureadahead.conf to /etc/init/ureadahead.conf.disabled by cloud-init'
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.184.57 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~16.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.184.57 -- sudo cloud-init clean --logs
+sudo: unable to resolve host SRU-worked-azure
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.184.57 -- sudo cloud-init init --local
+sudo: unable to resolve host SRU-worked-azure
+Cloud-init v. 19.4-33-gbb4131a2-0ubuntu1~16.04.1 running 'init-local' at Sat, 25 Jan 2020 04:13:31 +0000. Up 87.53 seconds.
++ echo --- Expect SUCCESS byteswap -proposed release
++ ssh -o--- Expect SUCCESS byteswap -proposed release
+ StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.184.57 -- sudo ./byteswap_test.sh
+SUCCESS
++ echo ### END xenial
++ echo ### BEGIN bionic
+### END xenial
++ netcfg=/etc/netplan/50-cloud-init.yaml
++ image_version=18.04-DAILY-LTS
++ name=test-sru-bionic
+### BEGIN bionic
++ az vm create --name=test-sru-bionic --image=Canonical:UbuntuServer:18.04-DAILY-LTS:latest --admin-username=root --admin-username=ubuntu -g srugroup --ssh-key-value /root/.ssh/id_rsa.pub --custom-data sethostname.yaml --size Standard_B1s
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroup/providers/Microsoft.Compute/virtualMachines/test-sru-bionic",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-7D-5D-8E",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.5",
+  "publicIpAddress": "104.46.7.95",
+  "resourceGroup": "srugroup",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-bionic
++ jq+  -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
+awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@104.46.7.95
++ echo Created test-sru-bionic: ubuntu@ubuntu@104.46.7.95
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.46.7.95 -- cloud-init status --wait --long
+Created test-sru-bionic: ubuntu@ubuntu@104.46.7.95
+
+status: done
+time: Sat, 25 Jan 2020 04:16:13 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR setup_proposed.sh byteswap_test.sh ubuntu@104.46.7.95:.
++ echo --- Expect assert byteswap error for current release
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.46.7.95 -- sudo--- Expect assert byteswap error for current release
+ ./byteswap_test.sh
+Traceback (most recent call last):
+  File "./byteswap_test.sh", line 34, in <module>
+    assert crawled_metadata['metadata']['instance-id'] == fake_prev_iid, "Crawled metadata didn't return previous IID"
+AssertionError: Crawled metadata didn't return previous IID
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null+  -o LogLevel=ERROR ubuntu@104.46.7.95 --egrep sudo bash cloud-init ./setup_proposed.sh
+
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 19.4-33-gbb4131a2-0ubuntu1~18.04.1 [409 kB]
+Preparing to unpack .../cloud-init_19.4-33-gbb4131a2-0ubuntu1~18.04.1_all.deb ...
+Unpacking cloud-init (19.4-33-gbb4131a2-0ubuntu1~18.04.1) over (19.3-41-gc4735dd3-0ubuntu1~18.04.1) ...
+Setting up cloud-init (19.4-33-gbb4131a2-0ubuntu1~18.04.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.46.7.95 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~18.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.46.7.95 -- sudo cloud-init clean --logs
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.46.7.95 -- sudo cloud-init init --local
+Cloud-init v. 19.4-33-gbb4131a2-0ubuntu1~18.04.1 running 'init-local' at Sat, 25 Jan 2020 04:17:10 +0000. Up 8018.91 seconds.
++ echo --- Expect SUCCESS byteswap -proposed release
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR--- Expect SUCCESS byteswap -proposed release
+ ubuntu@104.46.7.95 -- sudo ./byteswap_test.sh
+SUCCESS
++ echo ### END bionic
++ echo ### BEGIN eoan
++ ### END bionic
+netcfg=/etc/netplan/50-cloud-init.yaml
++ image_version=19.10-DAILY
+### BEGIN eoan
++ name=test-sru-eoan
++ az vm create --name=test-sru-eoan --image=Canonical:UbuntuServer:19.10-DAILY:latest --admin-username=root --admin-username=ubuntu -g srugroup --ssh-key-value /root/.ssh/id_rsa.pub --custom-data sethostname.yaml --size Standard_B1s
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroup/providers/Microsoft.Compute/virtualMachines/test-sru-eoan",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-7D-A8-17",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.6",
+  "publicIpAddress": "104.209.141.174",
+  "resourceGroup": "srugroup",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-eoan
++ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
++ awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@104.209.141.174
++ echo Created test-sru-eoan: ubuntu@ubuntu@104.209.141.174
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERRORCreated test-sru-eoan: ubuntu@ubuntu@104.209.141.174
+ ubuntu@104.209.141.174 -- cloud-init status --wait --long
+
+status: done
+time: Sat, 25 Jan 2020 04:21:23 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR setup_proposed.sh byteswap_test.sh ubuntu@104.209.141.174:.
++ echo --- Expect assert byteswap error for current release
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR--- Expect assert byteswap error for current release
+ ubuntu@104.209.141.174 -- sudo ./byteswap_test.sh
+Traceback (most recent call last):
+  File "./byteswap_test.sh", line 34, in <module>
+    assert crawled_metadata['metadata']['instance-id'] == fake_prev_iid, "Crawled metadata didn't return previous IID"
+AssertionError: Crawled metadata didn't return previous IID
++ ssh -o StrictHostKeyChecking=no -o+  UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.141.174 -- sudo bashegrep ./setup_proposed.sh cloud-init
+
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 cloud-init all 19.4-33-gbb4131a2-0ubuntu1~19.10.1 [405 kB]
+Preparing to unpack .../cloud-init_19.4-33-gbb4131a2-0ubuntu1~19.10.1_all.deb ...
+Unpacking cloud-init (19.4-33-gbb4131a2-0ubuntu1~19.10.1) over (19.3-41-gc4735dd3-0ubuntu1~19.10.1) ...
+Setting up cloud-init (19.4-33-gbb4131a2-0ubuntu1~19.10.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.141.174 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~19.10.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.141.174 -- sudo cloud-init clean --logs
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.141.174 -- sudo cloud-init init --local
+Cloud-init v. 19.4-33-gbb4131a2-0ubuntu1~19.10.1 running 'init-local' at Sat, 25 Jan 2020 04:22:23 +0000. Up 8331.96 seconds.
++ echo --- Expect SUCCESS byteswap -proposed release
++ ssh -o StrictHostKeyChecking=no -o--- Expect SUCCESS byteswap -proposed release
+ UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.141.174 -- sudo ./byteswap_test.sh
+SUCCESS
++ echo ### END eoan
+### END eoan
+====== END SRU verification logs =======


### PR DESCRIPTION
SRU Test  on Azure gen2 instances which *should* exhibit byte swapped dmi system-uuid  which doesn't match IMDS instance-id