### PR TITLE
Add code to terminate ec2 instance

### DIFF
--- a/sru-templates/manual/ec2-sru
+++ b/sru-templates/manual/ec2-sru
@@ -32,7 +32,7 @@ get_ec2_instance_id() {
     aws ec2 describe-instances --filter "Name=dns-name,Values=${dns_name}" --query $query | jq -r .[]
 }
 
-terminate_instances() {
+terminate_instance() {
     ec2_inst=$1
     if [ "$PRESERVE_INSTANCE" = false ]; then
         echo "deleting instance"
@@ -78,7 +78,7 @@ for series in $SRU_SERIES; do
     [ -n "$EC2_INST" ] || { echo "Failed to launch ec2 instance!"; exit 1; }
     sleep 60
 
-    trap "terminate_instances ${EC2_INST}" ERR
+    trap "terminate_instance ${EC2_INST}" ERR
     ssh $sshopts $EC2_INST -- cloud-init status --wait --long
     ssh $sshopts $EC2_INST -- cat /run/cloud-init/result.json
     ssh $sshopts $EC2_INST -- ! grep Trace "/var/log/cloud-init.*"
@@ -120,6 +120,6 @@ for series in $SRU_SERIES; do
     sleep 60
     echo 'After reboot'
     ssh $sshopts $EC2_INST "grep 'Update datasource' /var/log/cloud-init.log"
-    terminate_instances $EC2_INST
+    terminate_instance $EC2_INST
     echo "### END $series"
 done

--- a/sru-templates/manual/ec2-sru
+++ b/sru-templates/manual/ec2-sru
@@ -3,6 +3,7 @@
 set -e
 
 SRU_SERIES="%SRU_SERIES%"
+PRESERVE_INSTANCE=false
 
 # local values
 LP_USER=${LP_USER:-"%SRU_LP_USER%"}
@@ -15,6 +16,32 @@ else
     PROPOSED_SCRIPT=setup_dev_proposed.sh
 fi
 
+while [ $# -ne 0 ]; do
+	case "$1" in
+		# any flag pass through.
+		--preserve-instance) PRESERVE_INSTANCE=true;;
+		--) shift; break;;
+	esac
+	shift;
+done
+
+get_ec2_instance_id() {
+    dns_name=$1
+    dns_name="${dns_name#"ubuntu@"}"
+    query='Reservations[].Instances[].InstanceId'
+    aws ec2 describe-instances --filter "Name=dns-name,Values=${dns_name}" --query $query | jq .[]
+}
+
+terminate_instances() {
+    ec2_inst=$1
+    if [ "$PRESERVE_INSTANCE" = false ]; then
+        echo "deleting instance"
+        ec2_inst_id=`get_ec2_instance_id $ec2_inst | tr -d '"'`
+        aws ec2 terminate-instances --instance-ids $ec2_inst_id
+    else
+        echo "Keeping instance active"
+    fi
+}
 
 # Manual EC2 upgrade and clean install validation
 cat > sethostname.yaml <<EOF
@@ -50,6 +77,8 @@ for series in $SRU_SERIES; do
     EC2_INST=`launch-ec2 --series $series -u sethostname.yaml | awk '/Found/{print $5}'`
     [ -n "$EC2_INST" ] || { echo "Failed to launch ec2 instance!"; exit 1; }
     sleep 60
+
+    trap "terminate_instances ${EC2_INST}" ERR
     ssh $sshopts $EC2_INST -- cloud-init status --wait --long
     ssh $sshopts $EC2_INST -- cat /run/cloud-init/result.json
     ssh $sshopts $EC2_INST -- ! grep Trace "/var/log/cloud-init.*"
@@ -91,5 +120,6 @@ for series in $SRU_SERIES; do
     sleep 60
     echo 'After reboot'
     ssh $sshopts $EC2_INST "grep 'Update datasource' /var/log/cloud-init.log"
+    terminate_instances $EC2_INST
     echo "### END $series"
 done

--- a/sru-templates/manual/ec2-sru
+++ b/sru-templates/manual/ec2-sru
@@ -29,14 +29,14 @@ get_ec2_instance_id() {
     dns_name=$1
     dns_name="${dns_name#"ubuntu@"}"
     query='Reservations[].Instances[].InstanceId'
-    aws ec2 describe-instances --filter "Name=dns-name,Values=${dns_name}" --query $query | jq .[]
+    aws ec2 describe-instances --filter "Name=dns-name,Values=${dns_name}" --query $query | jq -r .[]
 }
 
 terminate_instances() {
     ec2_inst=$1
     if [ "$PRESERVE_INSTANCE" = false ]; then
         echo "deleting instance"
-        ec2_inst_id=`get_ec2_instance_id $ec2_inst | tr -d '"'`
+        ec2_inst_id=`get_ec2_instance_id ${ec2_inst}`
         aws ec2 terminate-instances --instance-ids $ec2_inst_id
     else
         echo "Keeping instance active"


### PR DESCRIPTION
By default, our ec2 instances are not terminated after the tests are run. We are now adding to the ec2-sru template the code necessary to terminate an instance after executing or failing the tests. If the user wants to preserve the instance, it must run the script with `--preserve-instance`