### PR TITLE
Fix commented command in gh-364 report

### DIFF
--- a/bugs/gh-364.txt
+++ b/bugs/gh-364.txt
@@ -48,8 +48,7 @@ apt-get update -qq;
 apt-get install -qqy cloud-init;
 EOF
 
-#for SERIES in bionic eoan focal xenial; do
-for SERIES in xenial; do
+for SERIES in bionic eoan focal xenial; do
    echo '=== BEGIN ' $SERIES
    ref=$SERIES-proposed
    name=test-$SERIES


### PR DESCRIPTION
In `gh-364`, the correct for command is commented out. This PR fix that.