### PR TITLE
sru: 20.2.45 get maas latest success proposed SRU logs

### DIFF
--- a/bin/sru-get-jenkins-logs
+++ b/bin/sru-get-jenkins-logs
@@ -35,7 +35,7 @@ for platform in lxd kvm; do
   echo "Wrote $manuallog. Upload with lp-attach-file $SRU_BUG $manuallog"
 done
 echo "=== Downloading MAAS SRU -proposed results"
-jenkins-get-job --url http://10.245.136.4:8080 --username $SRU_MAAS_JENKINS_USER --password $SRU_MAAS_JENKINS_PASSWORD SRU-proposed-cloudinit-sru-manual -v -s;
+jenkins-get-job --url http://maas-integration-ci.internal:8080 --username $SRU_MAAS_JENKINS_USER --password $SRU_MAAS_JENKINS_PASSWORD SRU-proposed-cloudinit-sru-manual -v -s;
 maas_sru_log=`ls ./jenkins/SRU-proposed-cloudinit-sru-manual/*/console.log`
 cp $maas_sru_log manual/maas-sru-$SRU_VERSION.txt
 echo "Upload with lp-attach-file manual/maas-sru-$SRU_VERSION.txt"

--- a/manual/maas-sru-20.2.45.txt
+++ b/manual/maas-sru-20.2.45.txt
@@ -1,0 +1,8947 @@
+Started by user Cloud Init
+Running as SYSTEM
+Building remotely on HP-DL360-Gen9 (ci-lab) in workspace /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual
+[SRU-proposed-cloudinit-sru-manual] $ /bin/bash -ex /tmp/jenkins386310300377690392.sh
++ rm -Rf bootloaders maas maas-ci-config maas-images results
++ export http_proxy=http://squid.internal:3128
++ http_proxy=http://squid.internal:3128
++ export https_proxy=http://squid.internal:3128
++ https_proxy=http://squid.internal:3128
++ UPDATES=-U
++ '[' '!' ']'
++ VM_RAM_SIZE=3072
++ '[' '!' ']'
++ TEST_PERFORMANCE=0
++ '[' '!' 1 ']'
++ TEST_CUSTOM_IMAGES=0
++ '[' http://git.launchpad.net/maas-images ']'
++ TEST_CUSTOM_IMAGES=1
++ git clone http://git.launchpad.net/maas-images maas-images
+Cloning into 'maas-images'...
+warning: redirecting to https://git.launchpad.net/maas-images/
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:./maas-images/bin
++ STREAM_ARCHES=amd64
++ '[' 0 -ge 1 ']'
++ '[' 0 -ge 1 ']'
++ STREAM_RELEASES='xenial|bionic'
++ '[' '!' ']'
++ DEPLOYMENT_RELEASE=bionic
+++ dirname /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual
++ workspace_root=/home/ubuntu/workspace
++ rm -Rf /home/ubuntu/workspace/www/html/images/bionic /home/ubuntu/workspace/www/html/images/bootloaders /home/ubuntu/workspace/www/html/images/streams /home/ubuntu/workspace/www/html/images/xenial
++ '[' '!' -d /home/ubuntu/workspace/www/html/images ']'
++ '[' 1 -eq 0 ']'
++ meph2-cloudimg-sync --config ./maas-images/conf/meph-v3.yaml --target=force --proposed --arches=amd64 --max=1 /home/ubuntu/workspace/www/html/images/ 'release~(xenial|bionic)'
+Tue, 16 Jun 2020 02:52:47 +0000: getting source http://cloud-images.ubuntu.com/daily/server/xenial/20200611/xenial-server-cloudimg-amd64.squashfs
+--2020-06-16 02:52:47--  http://cloud-images.ubuntu.com/daily/server/xenial/20200611/xenial-server-cloudimg-amd64.squashfs
+Resolving squid.internal (squid.internal)... 91.189.89.11
+Connecting to squid.internal (squid.internal)|91.189.89.11|:3128... connected.
+Proxy request sent, awaiting response... 200 OK
+Length: 167608320 (160M)
+Saving to: â/tmp/maas-cloudimg2eph2.UPUhFi/xenial-server-cloudimg-amd64.squashfsâ
+
+     0K ........ ........ ........ ........ ........ ........  1% 6.54M 24s
+  3072K ........ ........ ........ ........ ........ ........  3% 24.7M 15s
+  6144K ........ ........ ........ ........ ........ ........  5% 40.9M 11s
+  9216K ........ ........ ........ ........ ........ ........  7% 38.5M 9s
+ 12288K ........ ........ ........ ........ ........ ........  9% 29.1M 8s
+ 15360K ........ ........ ........ ........ ........ ........ 11% 43.7M 7s
+ 18432K ........ ........ ........ ........ ........ ........ 13% 41.3M 6s
+ 21504K ........ ........ ........ ........ ........ ........ 15% 26.0M 6s
+ 24576K ........ ........ ........ ........ ........ ........ 16% 39.9M 6s
+ 27648K ........ ........ ........ ........ ........ ........ 18% 26.2M 6s
+ 30720K ........ ........ ........ ........ ........ ........ 20% 39.5M 5s
+ 33792K ........ ........ ........ ........ ........ ........ 22% 26.3M 5s
+ 36864K ........ ........ ........ ........ ........ ........ 24% 39.3M 5s
+ 39936K ........ ........ ........ ........ ........ ........ 26% 36.9M 5s
+ 43008K ........ ........ ........ ........ ........ ........ 28% 17.4M 5s
+ 46080K ........ ........ ........ ........ ........ ........ 30% 33.6M 4s
+ 49152K ........ ........ ........ ........ ........ ........ 31% 29.9M 4s
+ 52224K ........ ........ ........ ........ ........ ........ 33% 33.4M 4s
+ 55296K ........ ........ ........ ........ ........ ........ 35% 29.9M 4s
+ 58368K ........ ........ ........ ........ ........ ........ 37% 33.2M 4s
+ 61440K ........ ........ ........ ........ ........ ........ 39% 30.2M 4s
+ 64512K ........ ........ ........ ........ ........ ........ 41% 33.0M 4s
+ 67584K ........ ........ ........ ........ ........ ........ 43% 30.1M 3s
+ 70656K ........ ........ ........ ........ ........ ........ 45% 33.4M 3s
+ 73728K ........ ........ ........ ........ ........ ........ 46% 29.8M 3s
+ 76800K ........ ........ ........ ........ ........ ........ 48% 33.4M 3s
+ 79872K ........ ........ ........ ........ ........ ........ 50% 29.3M 3s
+ 82944K ........ ........ ........ ........ ........ ........ 52% 34.5M 3s
+ 86016K ........ ........ ........ ........ ........ ........ 54% 28.7M 3s
+ 89088K ........ ........ ........ ........ ........ ........ 56% 35.8M 2s
+ 92160K ........ ........ ........ ........ ........ ........ 58% 29.3M 2s
+ 95232K ........ ........ ........ ........ ........ ........ 60% 33.9M 2s
+ 98304K ........ ........ ........ ........ ........ ........ 61% 35.2M 2s
+101376K ........ ........ ........ ........ ........ ........ 63% 28.7M 2s
+104448K ........ ........ ........ ........ ........ ........ 65% 35.2M 2s
+107520K ........ ........ ........ ........ ........ ........ 67% 29.1M 2s
+110592K ........ ........ ........ ........ ........ ........ 69% 34.3M 2s
+113664K ........ ........ ........ ........ ........ ........ 71% 29.4M 2s
+116736K ........ ........ ........ ........ ........ ........ 73% 34.5M 1s
+119808K ........ ........ ........ ........ ........ ........ 75% 29.7M 1s
+122880K ........ ........ ........ ........ ........ ........ 76% 33.9M 1s
+125952K ........ ........ ........ ........ ........ ........ 78% 29.7M 1s
+129024K ........ ........ ........ ........ ........ ........ 80% 34.1M 1s
+132096K ........ ........ ........ ........ ........ ........ 82% 29.7M 1s
+135168K ........ ........ ........ ........ ........ ........ 84% 34.3M 1s
+138240K ........ ........ ........ ........ ........ ........ 86% 29.3M 1s
+141312K ........ ........ ........ ........ ........ ........ 88% 35.3M 1s
+144384K ........ ........ ........ ........ ........ ........ 90% 28.6M 1s
+147456K ........ ........ ........ ........ ........ ........ 91% 35.5M 0s
+150528K ........ ........ ........ ........ ........ ........ 93% 29.4M 0s
+153600K ........ ........ ........ ........ ........ ........ 95% 34.4M 0s
+156672K ........ ........ ........ ........ ........ ........ 97% 34.0M 0s
+159744K ........ ........ ........ ........ ........ ........ 99% 29.4M 0s
+162816K ........ .....                                       100% 35.6M=5.4s
+
+2020-06-16 02:52:52 (29.5 MB/s) - â/tmp/maas-cloudimg2eph2.UPUhFi/xenial-server-cloudimg-amd64.squashfsâ saved [167608320/167608320]
+
+Tue, 16 Jun 2020 02:52:52 +0000: getting .img from /tmp/maas-cloudimg2eph2.UPUhFi/xenial-server-cloudimg-amd64.squashfs fmt=auto
+determined format is squashfs-image
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.UPUhFi/root.img'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+turning squahsfs image in /tmp/maas-cloudimg2eph2.UPUhFi/xenial-server-cloudimg-amd64.squashfs to ext4 image in /tmp/maas-cloudimg2eph2.UPUhFi/root.img
+Parallel unsquashfs: Using 28 processors
+28889 inodes (31712 blocks) to write
+
+[===========================================================-] 31712/31712 100%
+
+created 24462 files
+created 2932 directories
+created 4341 symlinks
+created 79 devices
+created 0 fifos
+Tue, 16 Jun 2020 02:53:17 +0000: getting '1024M' in /tmp/maas-cloudimg2eph2.UPUhFi/root.img
+Tue, 16 Jun 2020 02:53:18 +0000: targetting 5368709120 (1310720*4096) bytes.
+Tue, 16 Jun 2020 02:53:18 +0000: fs is currently 1048576 * 4096.
+Tue, 16 Jun 2020 02:53:18 +0000: resize to 1310720. minblocks=225472. target=1310720
+Tue, 16 Jun 2020 02:53:20 +0000: starting maas-cloudimg2ephemeral --arch=amd64 --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img none /tmp/maas-cloudimg2eph2.UPUhFi/none-kernel /tmp/maas-cloudimg2eph2.UPUhFi/none-initrd /tmp/maas-cloudimg2eph2.UPUhFi/manifest
+NO_CHANGE: add additional repos.
+NO_CHANGE: images ppa for cloud-init and maas-enlist (LP: #1511482, 1515733)
+CHANGE: enable proposed [amd64 http://archive.ubuntu.com/ubuntu/]
+NO_CHANGE: ensure mellanox mlx4_en gets loaded (LP: #1115710)
+NO_CHANGE: build-only: divert newaliases (LP: #1531299)
+nothing to remove: nothing match '^linux-.*' and not '^linux-base$'.
+NO_CHANGE: removing linux kernel packages.
+CHANGE: apt-get dist-upgrade
+CHANGE: run apt-update [dist-upgrade].
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
+Get:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease [260 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7532 kB]
+Get:7 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [883 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial/universe Translation-en [4354 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [144 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/multiverse Translation-en [106 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1161 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [799 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [334 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [17.1 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [8632 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7280 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [4456 B]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8064 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [4328 B]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 Packages [52.7 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-proposed/main Translation-en [20.8 kB]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-proposed/universe amd64 Packages [9216 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-proposed/universe Translation-en [6572 B]
+Get:24 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [331 kB]
+Get:25 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [494 kB]
+Get:26 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [202 kB]
+Get:27 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6084 B]
+Get:28 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [2888 B]
+Fetched 17.1 MB in 3s (4765 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'sudo apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init libpam-modules libpam-modules-bin libpam-runtime libpam0g
+  libseccomp2 login openssh-client openssh-server openssh-sftp-server passwd
+  ubuntu-keyring uidmap
+13 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+Need to get 2971 kB of archives.
+After this operation, 88.1 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 login amd64 1:4.2-3.1ubuntu5.5 [304 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 libpam0g amd64 1.1.8-3.2ubuntu2.2 [55.6 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 libpam-modules-bin amd64 1.1.8-3.2ubuntu2.2 [36.8 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 libpam-modules amd64 1.1.8-3.2ubuntu2.2 [244 kB]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 libpam-runtime all 1.1.8-3.2ubuntu2.2 [37.7 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 libseccomp2 amd64 2.4.3-1ubuntu3.16.04.2 [39.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 passwd amd64 1:4.2-3.1ubuntu5.5 [782 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 ubuntu-keyring all 2012.05.19.1 [18.4 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 openssh-sftp-server amd64 1:7.2p2-4ubuntu2.10 [38.8 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 openssh-server amd64 1:7.2p2-4ubuntu2.10 [335 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 openssh-client amd64 1:7.2p2-4ubuntu2.10 [590 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 uidmap amd64 1:4.2-3.1ubuntu5.5 [64.4 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~16.04.1 [425 kB]
+Preconfiguring packages ...
+Fetched 2971 kB in 0s (4446 kB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../login_1%3a4.2-3.1ubuntu5.5_amd64.deb ...
+Unpacking login (1:4.2-3.1ubuntu5.5) over (1:4.2-3.1ubuntu5.4) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up login (1:4.2-3.1ubuntu5.5) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../libpam0g_1.1.8-3.2ubuntu2.2_amd64.deb ...
+Unpacking libpam0g:amd64 (1.1.8-3.2ubuntu2.2) over (1.1.8-3.2ubuntu2.1) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Setting up libpam0g:amd64 (1.1.8-3.2ubuntu2.2) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../libpam-modules-bin_1.1.8-3.2ubuntu2.2_amd64.deb ...
+Unpacking libpam-modules-bin (1.1.8-3.2ubuntu2.2) over (1.1.8-3.2ubuntu2.1) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up libpam-modules-bin (1.1.8-3.2ubuntu2.2) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../libpam-modules_1.1.8-3.2ubuntu2.2_amd64.deb ...
+Unpacking libpam-modules:amd64 (1.1.8-3.2ubuntu2.2) over (1.1.8-3.2ubuntu2.1) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up libpam-modules:amd64 (1.1.8-3.2ubuntu2.2) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../libpam-runtime_1.1.8-3.2ubuntu2.2_all.deb ...
+Unpacking libpam-runtime (1.1.8-3.2ubuntu2.2) over (1.1.8-3.2ubuntu2.1) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up libpam-runtime (1.1.8-3.2ubuntu2.2) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../libseccomp2_2.4.3-1ubuntu3.16.04.2_amd64.deb ...
+Unpacking libseccomp2:amd64 (2.4.3-1ubuntu3.16.04.2) over (2.4.1-0ubuntu0.16.04.2) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Setting up libseccomp2:amd64 (2.4.3-1ubuntu3.16.04.2) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../passwd_1%3a4.2-3.1ubuntu5.5_amd64.deb ...
+Unpacking passwd (1:4.2-3.1ubuntu5.5) over (1:4.2-3.1ubuntu5.4) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Setting up passwd (1:4.2-3.1ubuntu5.5) ...
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../ubuntu-keyring_2012.05.19.1_all.deb ...
+Unpacking ubuntu-keyring (2012.05.19.1) over (2012.05.19) ...
+Setting up ubuntu-keyring (2012.05.19.1) ...
+gpg: key 437D05B5: "Ubuntu Archive Automatic Signing Key <ftpmaster@ubuntu.com>" not changed
+gpg: key FBB75451: "Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>" not changed
+gpg: key C0B21F32: "Ubuntu Archive Automatic Signing Key (2012) <ftpmaster@ubuntu.com>" not changed
+gpg: key EFE21092: "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" not changed
+gpg: key 991BC93C: public key "Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>" imported
+gpg: Total number processed: 5
+gpg:               imported: 1  (RSA: 1)
+gpg:              unchanged: 4
+(Reading database ... 25763 files and directories currently installed.)
+Preparing to unpack .../openssh-sftp-server_1%3a7.2p2-4ubuntu2.10_amd64.deb ...
+Unpacking openssh-sftp-server (1:7.2p2-4ubuntu2.10) over (1:7.2p2-4ubuntu2.8) ...
+Preparing to unpack .../openssh-server_1%3a7.2p2-4ubuntu2.10_amd64.deb ...
+Unpacking openssh-server (1:7.2p2-4ubuntu2.10) over (1:7.2p2-4ubuntu2.8) ...
+Preparing to unpack .../openssh-client_1%3a7.2p2-4ubuntu2.10_amd64.deb ...
+Unpacking openssh-client (1:7.2p2-4ubuntu2.10) over (1:7.2p2-4ubuntu2.8) ...
+Preparing to unpack .../uidmap_1%3a4.2-3.1ubuntu5.5_amd64.deb ...
+Unpacking uidmap (1:4.2-3.1ubuntu5.5) over (1:4.2-3.1ubuntu5.4) ...
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~16.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) over (19.4-33-gbb4131a2-0ubuntu1~16.04.1) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for ufw (0.35-0ubuntu2) ...
+WARN: Couldn't find pid (is /proc mounted?)
+Setting up openssh-client (1:7.2p2-4ubuntu2.10) ...
+Setting up openssh-sftp-server (1:7.2p2-4ubuntu2.10) ...
+Setting up openssh-server (1:7.2p2-4ubuntu2.10) ...
+Creating SSH2 RSA key; this may take some time ...
+2048 SHA256:iZXEMYq+8mdkhyZvUnGfBFDXRbE3LANq/ZO1+RdPcxg root@jenkins-slave-2 (RSA)
+Creating SSH2 DSA key; this may take some time ...
+1024 SHA256:fB5lrx9TmnY9qNoRqLuzFxkuFcvMimhQDsJcXUG7kCw root@jenkins-slave-2 (DSA)
+Creating SSH2 ECDSA key; this may take some time ...
+256 SHA256:h2JGn6iD1fKrtdxrOB1bEX2kWPxivvk4Jx3tN4aAHC4 root@jenkins-slave-2 (ECDSA)
+Creating SSH2 ED25519 key; this may take some time ...
+256 SHA256:NjegmAJU9kO/BsaRVaSXg3sdCvj5B+qfja3jT6qIWps root@jenkins-slave-2 (ED25519)
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of restart.
+Setting up uidmap (1:4.2-3.1ubuntu5.5) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) ...
+Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl ...
+Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Leaving 'diversion of /etc/init/ureadahead.conf to /etc/init/ureadahead.conf.disabled by cloud-init'
+NO_CHANGE: install missing packages
+NO_CHANGE: remove dpkg foreign architectures
+NO_CHANGE: run autoremove
+CHANGE: apt-get clean
+CHANGE: symlink ENI for cloud-initramfs-dyn-netconf (LP: #1534205)
+NO_CHANGE: touch /etc/iscsi/iscsi.initramfs for iscsi root shutdown (LP: #1536707) [systemd]
+NO_CHANGE: create /lib/modules (LP: #1543204)
+NO_CHANGE: set CRYPTSETUP=y in /etc/cryptsetup-initramfs/conf-hook (LP: #1818876)
+NO_CHANGE: update-initramfs
+NO_CHANGE: disable rescuevol (LP: #1034116)
+NO_CHANGE: package changes: add='' remove=''
+Tue, 16 Jun 2020 02:53:52 +0000: starting kpacks: linux-generic,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/ga-16.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/ga-16.04/generic/boot-initrd linux-lowlatency,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/ga-16.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/ga-16.04/lowlatency/boot-initrd linux-generic-hwe-16.04,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04/generic/boot-initrd linux-lowlatency-hwe-16.04,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04/lowlatency/boot-initrd linux-generic-hwe-16.04-edge,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04-edge/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04-edge/generic/boot-initrd linux-lowlatency-hwe-16.04-edge,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04-edge/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/hwe-16.04-edge/lowlatency/boot-initrd
+Tue, 16 Jun 2020 02:53:52 +0000: Tue, 16 Jun 2020 02:53:52 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img linux-generic /tmp/maas-cloudimg2eph2.UPUhFi/linux-generic
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libnl-3-200 libnl-genl-3-200
+  linux-firmware linux-headers-4.4.0-185 linux-headers-4.4.0-185-generic
+  linux-headers-generic linux-image-4.4.0-185-generic linux-image-generic
+  linux-modules-4.4.0-185-generic linux-modules-extra-4.4.0-185-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.4.0
+  | linux-source-4.4.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libnl-3-200 libnl-genl-3-200 linux-firmware linux-generic
+  linux-headers-4.4.0-185 linux-headers-4.4.0-185-generic
+  linux-headers-generic linux-image-4.4.0-185-generic linux-image-generic
+  linux-modules-4.4.0-185-generic linux-modules-extra-4.4.0-185-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 563 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.23 [1704 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.23 [511 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.23 [891 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.23 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~16.04.1 [11.7 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-4.4.0-185-generic amd64 4.4.0-185.215 [12.0 MB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-4.4.0-185-generic amd64 4.4.0-185.215 [6943 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-extra-4.4.0-185-generic amd64 4.4.0-185.215 [36.6 MB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.16.04.1 [2528 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-generic amd64 4.4.0.185.191 [2518 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.4.0-185 all 4.4.0-185.215 [10.1 MB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.4.0-185-generic amd64 4.4.0-185.215 [804 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-generic amd64 4.4.0.185.191 [2350 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-generic amd64 4.4.0.185.191 [1790 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 4s (27.7 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25773 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package libnl-3-200:amd64.
+Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../wireless-regdb_2018.05.09-0ubuntu1~16.04.1_all.deb ...
+Unpacking wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
+Unpacking iw (3.17-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
+Unpacking crda (3.13-1) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-modules-4.4.0-185-generic.
+Preparing to unpack .../linux-modules-4.4.0-185-generic_4.4.0-185.215_amd64.deb ...
+Unpacking linux-modules-4.4.0-185-generic (4.4.0-185.215) ...
+Selecting previously unselected package linux-image-4.4.0-185-generic.
+Preparing to unpack .../linux-image-4.4.0-185-generic_4.4.0-185.215_amd64.deb ...
+Unpacking linux-image-4.4.0-185-generic (4.4.0-185.215) ...
+Selecting previously unselected package linux-modules-extra-4.4.0-185-generic.
+Preparing to unpack .../linux-modules-extra-4.4.0-185-generic_4.4.0-185.215_amd64.deb ...
+Unpacking linux-modules-extra-4.4.0-185-generic (4.4.0-185.215) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20200609.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-generic.
+Preparing to unpack .../linux-image-generic_4.4.0.185.191_amd64.deb ...
+Unpacking linux-image-generic (4.4.0.185.191) ...
+Selecting previously unselected package linux-headers-4.4.0-185.
+Preparing to unpack .../linux-headers-4.4.0-185_4.4.0-185.215_all.deb ...
+Unpacking linux-headers-4.4.0-185 (4.4.0-185.215) ...
+Selecting previously unselected package linux-headers-4.4.0-185-generic.
+Preparing to unpack .../linux-headers-4.4.0-185-generic_4.4.0-185.215_amd64.deb ...
+Unpacking linux-headers-4.4.0-185-generic (4.4.0-185.215) ...
+Selecting previously unselected package linux-headers-generic.
+Preparing to unpack .../linux-headers-generic_4.4.0.185.191_amd64.deb ...
+Unpacking linux-headers-generic (4.4.0.185.191) ...
+Selecting previously unselected package linux-generic.
+Preparing to unpack .../linux-generic_4.4.0.185.191_amd64.deb ...
+Unpacking linux-generic (4.4.0.185.191) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.23) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
+Setting up iw (3.17-1) ...
+Setting up crda (3.13-1) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-modules-4.4.0-185-generic (4.4.0-185.215) ...
+Setting up linux-image-4.4.0-185-generic (4.4.0-185.215) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.4.0-185-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.4.0-185-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.4.0-185-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.4.0-185-generic
+Setting up linux-modules-extra-4.4.0-185-generic (4.4.0-185.215) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-generic (4.4.0.185.191) ...
+Setting up linux-headers-4.4.0-185 (4.4.0-185.215) ...
+Setting up linux-headers-4.4.0-185-generic (4.4.0-185.215) ...
+Setting up linux-headers-generic (4.4.0.185.191) ...
+Setting up linux-generic (4.4.0.185.191) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Processing triggers for linux-image-4.4.0-185-generic (4.4.0-185.215) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.4.0-185-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.16) ...
+update-initramfs: Generating /boot/initrd.img-4.4.0-185-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.UPUhFi/linux-generic
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 02:55:44 +0000: Tue, 16 Jun 2020 02:55:44 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img linux-lowlatency /tmp/maas-cloudimg2eph2.UPUhFi/linux-lowlatency
+Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.4.0-185 linux-headers-4.4.0-185-lowlatency
+  linux-headers-lowlatency linux-image-4.4.0-185-lowlatency
+  linux-image-lowlatency linux-modules-4.4.0-185-lowlatency os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.4.0
+  | linux-source-4.4.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.4.0-185 linux-headers-4.4.0-185-lowlatency
+  linux-headers-lowlatency linux-image-4.4.0-185-lowlatency
+  linux-image-lowlatency linux-lowlatency linux-modules-4.4.0-185-lowlatency
+  os-prober thermald
+0 upgraded, 19 newly installed, 0 to remove and 0 not upgraded.
+Need to get 116 MB of archives.
+After this operation, 561 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.23 [1704 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.23 [511 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.23 [891 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.23 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.4.0-185 all 4.4.0-185.215 [10.1 MB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.4.0-185-lowlatency amd64 4.4.0-185.215 [805 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-lowlatency amd64 4.4.0.185.191 [2358 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-4.4.0-185-lowlatency amd64 4.4.0-185.215 [41.0 MB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-4.4.0-185-lowlatency amd64 4.4.0-185.215 [6968 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.16.04.1 [2528 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-lowlatency amd64 4.4.0.185.191 [2506 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-lowlatency amd64 4.4.0.185.191 [1792 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 116 MB in 4s (28.5 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25773 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-headers-4.4.0-185.
+Preparing to unpack .../linux-headers-4.4.0-185_4.4.0-185.215_all.deb ...
+Unpacking linux-headers-4.4.0-185 (4.4.0-185.215) ...
+Selecting previously unselected package linux-headers-4.4.0-185-lowlatency.
+Preparing to unpack .../linux-headers-4.4.0-185-lowlatency_4.4.0-185.215_amd64.deb ...
+Unpacking linux-headers-4.4.0-185-lowlatency (4.4.0-185.215) ...
+Selecting previously unselected package linux-headers-lowlatency.
+Preparing to unpack .../linux-headers-lowlatency_4.4.0.185.191_amd64.deb ...
+Unpacking linux-headers-lowlatency (4.4.0.185.191) ...
+Selecting previously unselected package linux-modules-4.4.0-185-lowlatency.
+Preparing to unpack .../linux-modules-4.4.0-185-lowlatency_4.4.0-185.215_amd64.deb ...
+Unpacking linux-modules-4.4.0-185-lowlatency (4.4.0-185.215) ...
+Selecting previously unselected package linux-image-4.4.0-185-lowlatency.
+Preparing to unpack .../linux-image-4.4.0-185-lowlatency_4.4.0-185.215_amd64.deb ...
+Unpacking linux-image-4.4.0-185-lowlatency (4.4.0-185.215) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20200609.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-lowlatency.
+Preparing to unpack .../linux-image-lowlatency_4.4.0.185.191_amd64.deb ...
+Unpacking linux-image-lowlatency (4.4.0.185.191) ...
+Selecting previously unselected package linux-lowlatency.
+Preparing to unpack .../linux-lowlatency_4.4.0.185.191_amd64.deb ...
+Unpacking linux-lowlatency (4.4.0.185.191) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.23) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-headers-4.4.0-185 (4.4.0-185.215) ...
+Setting up linux-headers-4.4.0-185-lowlatency (4.4.0-185.215) ...
+Setting up linux-headers-lowlatency (4.4.0.185.191) ...
+Setting up linux-modules-4.4.0-185-lowlatency (4.4.0-185.215) ...
+Setting up linux-image-4.4.0-185-lowlatency (4.4.0-185.215) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.4.0-185-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.4.0-185-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.4.0-185-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.4.0-185-lowlatency
+Setting up intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-lowlatency (4.4.0.185.191) ...
+Setting up linux-lowlatency (4.4.0.185.191) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for linux-image-4.4.0-185-lowlatency (4.4.0-185.215) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.4.0-185-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.16) ...
+update-initramfs: Generating /boot/initrd.img-4.4.0-185-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.UPUhFi/linux-lowlatency
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 02:57:31 +0000: Tue, 16 Jun 2020 02:57:31 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img linux-generic-hwe-16.04 /tmp/maas-cloudimg2eph2.UPUhFi/linux-generic-hwe-16.04
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libnl-3-200 libnl-genl-3-200
+  linux-firmware linux-headers-4.15.0-107 linux-headers-4.15.0-107-generic
+  linux-headers-generic-hwe-16.04 linux-image-4.15.0-107-generic
+  linux-image-generic-hwe-16.04 linux-modules-4.15.0-107-generic
+  linux-modules-extra-4.15.0-107-generic os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-16.04 linux-headers-4.15.0-107
+  linux-headers-4.15.0-107-generic linux-headers-generic-hwe-16.04
+  linux-image-4.15.0-107-generic linux-image-generic-hwe-16.04
+  linux-modules-4.15.0-107-generic linux-modules-extra-4.15.0-107-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 594 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.23 [1704 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.23 [511 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.23 [891 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.23 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~16.04.1 [11.7 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [13.0 MB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [7991 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-extra-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [32.7 MB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.16.04.1 [2528 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-generic-hwe-16.04 amd64 4.15.0.107.112 [2410 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107 all 4.15.0-107.108~16.04.1 [10.9 MB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [1104 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-generic-hwe-16.04 amd64 4.15.0.107.112 [2368 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-generic-hwe-16.04 amd64 4.15.0.107.112 [1806 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 4s (25.1 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25773 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package libnl-3-200:amd64.
+Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../wireless-regdb_2018.05.09-0ubuntu1~16.04.1_all.deb ...
+Unpacking wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
+Unpacking iw (3.17-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
+Unpacking crda (3.13-1) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-modules-4.15.0-107-generic.
+Preparing to unpack .../linux-modules-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-107-generic.
+Preparing to unpack .../linux-image-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-107-generic.
+Preparing to unpack .../linux-modules-extra-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20200609.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-generic-hwe-16.04.
+Preparing to unpack .../linux-image-generic-hwe-16.04_4.15.0.107.112_amd64.deb ...
+Unpacking linux-image-generic-hwe-16.04 (4.15.0.107.112) ...
+Selecting previously unselected package linux-headers-4.15.0-107.
+Preparing to unpack .../linux-headers-4.15.0-107_4.15.0-107.108~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-107-generic.
+Preparing to unpack .../linux-headers-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-16.04.
+Preparing to unpack .../linux-headers-generic-hwe-16.04_4.15.0.107.112_amd64.deb ...
+Unpacking linux-headers-generic-hwe-16.04 (4.15.0.107.112) ...
+Selecting previously unselected package linux-generic-hwe-16.04.
+Preparing to unpack .../linux-generic-hwe-16.04_4.15.0.107.112_amd64.deb ...
+Unpacking linux-generic-hwe-16.04 (4.15.0.107.112) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.23) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
+Setting up iw (3.17-1) ...
+Setting up crda (3.13-1) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-modules-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Setting up linux-image-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-107-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-107-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-107-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-107-generic
+Setting up linux-modules-extra-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-generic-hwe-16.04 (4.15.0.107.112) ...
+Setting up linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-generic-hwe-16.04 (4.15.0.107.112) ...
+Setting up linux-generic-hwe-16.04 (4.15.0.107.112) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Processing triggers for linux-image-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.16) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.UPUhFi/linux-generic-hwe-16.04
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 02:59:29 +0000: Tue, 16 Jun 2020 02:59:29 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img linux-lowlatency-hwe-16.04 /tmp/maas-cloudimg2eph2.UPUhFi/linux-lowlatency-hwe-16.04
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:5 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-107 linux-headers-4.15.0-107-lowlatency
+  linux-headers-lowlatency-hwe-16.04 linux-image-4.15.0-107-lowlatency
+  linux-image-lowlatency-hwe-16.04 linux-modules-4.15.0-107-lowlatency
+  os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-107 linux-headers-4.15.0-107-lowlatency
+  linux-headers-lowlatency-hwe-16.04 linux-image-4.15.0-107-lowlatency
+  linux-image-lowlatency-hwe-16.04 linux-lowlatency-hwe-16.04
+  linux-modules-4.15.0-107-lowlatency os-prober thermald
+0 upgraded, 19 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 593 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.23 [1704 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.23 [511 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.23 [891 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.23 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107 all 4.15.0-107.108~16.04.1 [10.9 MB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107-lowlatency amd64 4.15.0-107.108~16.04.1 [1107 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-lowlatency-hwe-16.04 amd64 4.15.0.107.112 [2370 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-4.15.0-107-lowlatency amd64 4.15.0-107.108~16.04.1 [45.7 MB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-4.15.0-107-lowlatency amd64 4.15.0-107.108~16.04.1 [8044 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.16.04.1 [2528 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-lowlatency-hwe-16.04 amd64 4.15.0.107.112 [2408 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-lowlatency-hwe-16.04 amd64 4.15.0.107.112 [1804 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 4s (27.0 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25773 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-headers-4.15.0-107.
+Preparing to unpack .../linux-headers-4.15.0-107_4.15.0-107.108~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-107-lowlatency.
+Preparing to unpack .../linux-headers-4.15.0-107-lowlatency_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-16.04.
+Preparing to unpack .../linux-headers-lowlatency-hwe-16.04_4.15.0.107.112_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-16.04 (4.15.0.107.112) ...
+Selecting previously unselected package linux-modules-4.15.0-107-lowlatency.
+Preparing to unpack .../linux-modules-4.15.0-107-lowlatency_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-107-lowlatency.
+Preparing to unpack .../linux-image-4.15.0-107-lowlatency_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20200609.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-16.04.
+Preparing to unpack .../linux-image-lowlatency-hwe-16.04_4.15.0.107.112_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-16.04 (4.15.0.107.112) ...
+Selecting previously unselected package linux-lowlatency-hwe-16.04.
+Preparing to unpack .../linux-lowlatency-hwe-16.04_4.15.0.107.112_amd64.deb ...
+Unpacking linux-lowlatency-hwe-16.04 (4.15.0.107.112) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.23) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-lowlatency-hwe-16.04 (4.15.0.107.112) ...
+Setting up linux-modules-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Setting up linux-image-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-107-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-107-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-107-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-107-lowlatency
+Setting up intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-lowlatency-hwe-16.04 (4.15.0.107.112) ...
+Setting up linux-lowlatency-hwe-16.04 (4.15.0.107.112) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for linux-image-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.16) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.UPUhFi/linux-lowlatency-hwe-16.04
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:01:31 +0000: Tue, 16 Jun 2020 03:01:31 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img linux-generic-hwe-16.04-edge /tmp/maas-cloudimg2eph2.UPUhFi/linux-generic-hwe-16.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libnl-3-200 libnl-genl-3-200
+  linux-firmware linux-headers-4.15.0-107 linux-headers-4.15.0-107-generic
+  linux-headers-generic-hwe-16.04-edge linux-image-4.15.0-107-generic
+  linux-image-generic-hwe-16.04-edge linux-modules-4.15.0-107-generic
+  linux-modules-extra-4.15.0-107-generic os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-16.04-edge linux-headers-4.15.0-107
+  linux-headers-4.15.0-107-generic linux-headers-generic-hwe-16.04-edge
+  linux-image-4.15.0-107-generic linux-image-generic-hwe-16.04-edge
+  linux-modules-4.15.0-107-generic linux-modules-extra-4.15.0-107-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 25 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 594 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.23 [1704 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.23 [511 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.23 [891 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.23 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [52.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnl-genl-3-200 amd64 3.2.27-1ubuntu0.16.04.1 [11.2 kB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~16.04.1 [11.7 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/main amd64 iw amd64 3.17-1 [63.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial/main amd64 crda amd64 3.13-1 [60.5 kB]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [13.0 MB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [7991 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-extra-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [32.7 MB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.16.04.1 [2528 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-generic-hwe-16.04-edge amd64 4.15.0.107.112 [2426 B]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107 all 4.15.0-107.108~16.04.1 [10.9 MB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107-generic amd64 4.15.0-107.108~16.04.1 [1104 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-generic-hwe-16.04-edge amd64 4.15.0.107.112 [2372 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-generic-hwe-16.04-edge amd64 4.15.0.107.112 [1812 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 4s (28.2 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25773 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package libnl-3-200:amd64.
+Preparing to unpack .../libnl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../libnl-genl-3-200_3.2.27-1ubuntu0.16.04.1_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../wireless-regdb_2018.05.09-0ubuntu1~16.04.1_all.deb ...
+Unpacking wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../archives/iw_3.17-1_amd64.deb ...
+Unpacking iw (3.17-1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../archives/crda_3.13-1_amd64.deb ...
+Unpacking crda (3.13-1) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-modules-4.15.0-107-generic.
+Preparing to unpack .../linux-modules-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-107-generic.
+Preparing to unpack .../linux-image-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-107-generic.
+Preparing to unpack .../linux-modules-extra-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20200609.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-generic-hwe-16.04-edge.
+Preparing to unpack .../linux-image-generic-hwe-16.04-edge_4.15.0.107.112_amd64.deb ...
+Unpacking linux-image-generic-hwe-16.04-edge (4.15.0.107.112) ...
+Selecting previously unselected package linux-headers-4.15.0-107.
+Preparing to unpack .../linux-headers-4.15.0-107_4.15.0-107.108~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-107-generic.
+Preparing to unpack .../linux-headers-4.15.0-107-generic_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-16.04-edge.
+Preparing to unpack .../linux-headers-generic-hwe-16.04-edge_4.15.0.107.112_amd64.deb ...
+Unpacking linux-headers-generic-hwe-16.04-edge (4.15.0.107.112) ...
+Selecting previously unselected package linux-generic-hwe-16.04-edge.
+Preparing to unpack .../linux-generic-hwe-16.04-edge_4.15.0.107.112_amd64.deb ...
+Unpacking linux-generic-hwe-16.04-edge (4.15.0.107.112) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.23) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Setting up libnl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up libnl-genl-3-200:amd64 (3.2.27-1ubuntu0.16.04.1) ...
+Setting up wireless-regdb (2018.05.09-0ubuntu1~16.04.1) ...
+Setting up iw (3.17-1) ...
+Setting up crda (3.13-1) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-modules-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Setting up linux-image-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-107-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-107-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-107-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-107-generic
+Setting up linux-modules-extra-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-generic-hwe-16.04-edge (4.15.0.107.112) ...
+Setting up linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-generic-hwe-16.04-edge (4.15.0.107.112) ...
+Setting up linux-generic-hwe-16.04-edge (4.15.0.107.112) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for libc-bin (2.23-0ubuntu11) ...
+Processing triggers for linux-image-4.15.0-107-generic (4.15.0-107.108~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.16) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-generic
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.UPUhFi/linux-generic-hwe-16.04-edge
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:03:34 +0000: Tue, 16 Jun 2020 03:03:34 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.UPUhFi/root.img linux-lowlatency-hwe-16.04-edge /tmp/maas-cloudimg2eph2.UPUhFi/linux-lowlatency-hwe-16.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease
+Hit:5 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-107 linux-headers-4.15.0-107-lowlatency
+  linux-headers-lowlatency-hwe-16.04-edge linux-image-4.15.0-107-lowlatency
+  linux-image-lowlatency-hwe-16.04-edge linux-modules-4.15.0-107-lowlatency
+  os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool linux-firmware
+  linux-headers-4.15.0-107 linux-headers-4.15.0-107-lowlatency
+  linux-headers-lowlatency-hwe-16.04-edge linux-image-4.15.0-107-lowlatency
+  linux-image-lowlatency-hwe-16.04-edge linux-lowlatency-hwe-16.04-edge
+  linux-modules-4.15.0-107-lowlatency os-prober thermald
+0 upgraded, 19 newly installed, 0 to remove and 0 not upgraded.
+Need to get 123 MB of archives.
+After this operation, 593 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-common amd64 2.02~beta2-36ubuntu3.23 [1704 kB]
+Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub2-common amd64 2.02~beta2-36ubuntu3.23 [511 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc-bin amd64 2.02~beta2-36ubuntu3.23 [891 kB]
+Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 grub-pc amd64 2.02~beta2-36ubuntu3.23 [197 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iucode-tool amd64 1.5.1-1ubuntu0.1 [33.8 kB]
+Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 linux-firmware all 1.157.23 [50.6 MB]
+Get:8 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107 all 4.15.0-107.108~16.04.1 [10.9 MB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-4.15.0-107-lowlatency amd64 4.15.0-107.108~16.04.1 [1107 kB]
+Get:10 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-headers-lowlatency-hwe-16.04-edge amd64 4.15.0.107.112 [2378 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-modules-4.15.0-107-lowlatency amd64 4.15.0-107.108~16.04.1 [45.7 MB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-4.15.0-107-lowlatency amd64 4.15.0-107.108~16.04.1 [8044 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.16.04.1 [2528 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20180524.1~ubuntu0.16.04.2 [30.8 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-image-lowlatency-hwe-16.04-edge amd64 4.15.0.107.112 [2416 B]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 linux-lowlatency-hwe-16.04-edge amd64 4.15.0.107.112 [1812 B]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 os-prober amd64 1.70ubuntu3.3 [19.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 thermald amd64 1.5-2ubuntu4 [187 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 cloud-initramfs-rooturl all 0.27ubuntu1.6 [4770 B]
+Preconfiguring packages ...
+Fetched 123 MB in 4s (28.5 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 25773 files and directories currently installed.)
+Preparing to unpack .../grub-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../grub2-common_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub2-common (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../grub-pc-bin_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../grub-pc_2.02~beta2-36ubuntu3.23_amd64.deb ...
+Unpacking grub-pc (2.02~beta2-36ubuntu3.23) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../iucode-tool_1.5.1-1ubuntu0.1_amd64.deb ...
+Unpacking iucode-tool (1.5.1-1ubuntu0.1) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../linux-firmware_1.157.23_all.deb ...
+Unpacking linux-firmware (1.157.23) ...
+Selecting previously unselected package linux-headers-4.15.0-107.
+Preparing to unpack .../linux-headers-4.15.0-107_4.15.0-107.108~16.04.1_all.deb ...
+Unpacking linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-4.15.0-107-lowlatency.
+Preparing to unpack .../linux-headers-4.15.0-107-lowlatency_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-headers-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-16.04-edge.
+Preparing to unpack .../linux-headers-lowlatency-hwe-16.04-edge_4.15.0.107.112_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-16.04-edge (4.15.0.107.112) ...
+Selecting previously unselected package linux-modules-4.15.0-107-lowlatency.
+Preparing to unpack .../linux-modules-4.15.0-107-lowlatency_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-modules-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package linux-image-4.15.0-107-lowlatency.
+Preparing to unpack .../linux-image-4.15.0-107-lowlatency_4.15.0-107.108~16.04.1_amd64.deb ...
+Unpacking linux-image-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../intel-microcode_3.20200609.0ubuntu0.16.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../amd64-microcode_3.20191021.1+really3.20180524.1~ubuntu0.16.04.2_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-16.04-edge.
+Preparing to unpack .../linux-image-lowlatency-hwe-16.04-edge_4.15.0.107.112_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-16.04-edge (4.15.0.107.112) ...
+Selecting previously unselected package linux-lowlatency-hwe-16.04-edge.
+Preparing to unpack .../linux-lowlatency-hwe-16.04-edge_4.15.0.107.112_amd64.deb ...
+Unpacking linux-lowlatency-hwe-16.04-edge (4.15.0.107.112) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../os-prober_1.70ubuntu3.3_amd64.deb ...
+Unpacking os-prober (1.70ubuntu3.3) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../thermald_1.5-2ubuntu4_amd64.deb ...
+Unpacking thermald (1.5-2ubuntu4) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../cloud-initramfs-rooturl_0.27ubuntu1.6_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for man-db (2.7.5-1) ...
+Processing triggers for install-info (6.1.0.dfsg.1-5) ...
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Setting up grub-common (2.02~beta2-36ubuntu3.23) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up grub2-common (2.02~beta2-36ubuntu3.23) ...
+Setting up grub-pc-bin (2.02~beta2-36ubuntu3.23) ...
+Setting up iucode-tool (1.5.1-1ubuntu0.1) ...
+Setting up linux-firmware (1.157.23) ...
+Setting up linux-headers-4.15.0-107 (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Setting up linux-headers-lowlatency-hwe-16.04-edge (4.15.0.107.112) ...
+Setting up linux-modules-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+Setting up linux-image-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-107-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-107-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-107-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-107-lowlatency
+Setting up intel-microcode (3.20200609.0ubuntu0.16.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up amd64-microcode (3.20191021.1+really3.20180524.1~ubuntu0.16.04.2) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-image-lowlatency-hwe-16.04-edge (4.15.0.107.112) ...
+Setting up linux-lowlatency-hwe-16.04-edge (4.15.0.107.112) ...
+Setting up os-prober (1.70ubuntu3.3) ...
+Setting up thermald (1.5-2ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.27ubuntu1.6) ...
+Setting up grub-pc (2.02~beta2-36ubuntu3.23) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Processing triggers for systemd (229-4ubuntu21.28) ...
+Processing triggers for linux-image-4.15.0-107-lowlatency (4.15.0-107.108~16.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for initramfs-tools (0.122ubuntu8.16) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-lowlatency
+W: mdadm: /etc/mdadm/mdadm.conf defines no arrays.
+Processing triggers for dbus (1.10.6-1ubuntu3.5) ...
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.UPUhFi/linux-lowlatency-hwe-16.04-edge
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:05:32 +0000: kpacks done
+Tue, 16 Jun 2020 03:05:32 +0000: copying working img into new fs of 1400M (pad=)
+src image uuid=fd187d95-c5ac-43ef-b1f9-07c643622052 label=cloudimg-rootfs fstype=ext4
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.UPUhFi/root.img.fs_img_size'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+Tue, 16 Jun 2020 03:05:57 +0000: zeroing img
+e2fsck 1.44.1 (24-Mar-2018)
+Pass 1: Checking inodes, blocks, and sizes
+Pass 2: Checking directory structure
+Pass 3: Checking directory connectivity
+Pass 4: Checking reference counts
+Pass 5: Checking group summary information
+cloudimg-rootfs: 31875/327680 files (0.1% non-contiguous), 220631/1310720 blocks
+creating a new squash image in /home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/squashfs with ./maas-images/bin/img2squashfs from /tmp/maas-cloudimg2eph2.UPUhFi/root.img
+format of '/tmp/maas-cloudimg2eph2.UPUhFi/root.img' is 'root-image'
+got format 'fs-image' at temp path '/tmp/img2squashfs.toD7Ri/fs-image'
+calling mount-image-callback /tmp/img2squashfs.toD7Ri/fs-image -- ./maas-images/bin/img2squashfs dir2squashfs _MOUNTPOINT_ /home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/squashfs
+Tue, 16 Jun 2020 03:06:05 +0000: starting: mksquashfs /tmp/mount-image-callback.3YVshN/mp /home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/squashfs.img2squashfs.16161 -xattrs -comp xz
+Parallel mksquashfs: Using 28 processors
+Creating 4.0 filesystem on /home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/squashfs.img2squashfs.16161, block size 131072.
+[===========================================================\] 27949/27949 100%
+
+Exportable Squashfs 4.0 filesystem, xz compressed, data block size 131072
+	compressed data, compressed metadata, compressed fragments, compressed xattrs
+	duplicates are removed
+Filesystem size 179922.28 Kbytes (175.71 Mbytes)
+	27.77% of uncompressed filesystem size (647910.96 Kbytes)
+Inode table size 274652 bytes (268.21 Kbytes)
+	25.52% of uncompressed inode table size (1076388 bytes)
+Directory table size 271296 bytes (264.94 Kbytes)
+	39.43% of uncompressed directory table size (688119 bytes)
+Xattr table size 78 bytes (0.08 Kbytes)
+	97.50% of uncompressed xattr table size (80 bytes)
+Number of duplicate files found 1203
+Number of inodes 31866
+Number of files 24512
+Number of fragments 1461
+Number of symbolic links  4342
+Number of device nodes 79
+Number of fifo nodes 0
+Number of socket nodes 0
+Number of directories 2933
+Number of ids (unique uids + gids) 21
+Number of uids 7
+	root (0)
+	man (6)
+	daemon (1)
+	pollinate (111)
+	_apt (105)
+	lxd (106)
+	syslog (104)
+Number of gids 18
+	root (0)
+	video (44)
+	audio (29)
+	tty (5)
+	kmem (15)
+	disk (6)
+	daemon (1)
+	shadow (42)
+	crontab (107)
+	ssh (114)
+	utmp (43)
+	mlocate (113)
+	messagebus (111)
+	staff (50)
+	nogroup (65534)
+	adm (4)
+	syslog (108)
+	mail (8)
+Tue, 16 Jun 2020 03:06:18 +0000: finished: returned 0
+output in /home/ubuntu/workspace/www/html/images/xenial/amd64/20200611/squashfs. took 15s.
+Tue, 16 Jun 2020 03:06:20 +0000: finished
+Tue, 16 Jun 2020 03:06:22 +0000: getting source http://cloud-images.ubuntu.com/daily/server/bionic/20200610.1/bionic-server-cloudimg-amd64.squashfs
+--2020-06-16 03:06:22--  http://cloud-images.ubuntu.com/daily/server/bionic/20200610.1/bionic-server-cloudimg-amd64.squashfs
+Resolving squid.internal (squid.internal)... 91.189.89.11
+Connecting to squid.internal (squid.internal)|91.189.89.11|:3128... connected.
+Proxy request sent, awaiting response... 200 OK
+Length: 187985920 (179M)
+Saving to: â/tmp/maas-cloudimg2eph2.8QbeQ3/bionic-server-cloudimg-amd64.squashfsâ
+
+     0K ........ ........ ........ ........ ........ ........  1% 6.50M 27s
+  3072K ........ ........ ........ ........ ........ ........  3% 25.3M 17s
+  6144K ........ ........ ........ ........ ........ ........  5% 33.7M 13s
+  9216K ........ ........ ........ ........ ........ ........  6% 29.5M 11s
+ 12288K ........ ........ ........ ........ ........ ........  8% 32.7M 9s
+ 15360K ........ ........ ........ ........ ........ ........ 10% 30.1M 9s
+ 18432K ........ ........ ........ ........ ........ ........ 11% 30.4M 8s
+ 21504K ........ ........ ........ ........ ........ ........ 13% 32.3M 7s
+ 24576K ........ ........ ........ ........ ........ ........ 15% 30.4M 7s
+ 27648K ........ ........ ........ ........ ........ ........ 16% 32.7M 7s
+ 30720K ........ ........ ........ ........ ........ ........ 18% 30.3M 6s
+ 33792K ........ ........ ........ ........ ........ ........ 20% 34.8M 6s
+ 36864K ........ ........ ........ ........ ........ ........ 21% 27.8M 6s
+ 39936K ........ ........ ........ ........ ........ ........ 23% 35.8M 6s
+ 43008K ........ ........ ........ ........ ........ ........ 25% 27.6M 5s
+ 46080K ........ ........ ........ ........ ........ ........ 26% 7.07M 6s
+ 49152K ........ ........ ........ ........ ........ ........ 28%  334M 6s
+ 52224K ........ ........ ........ ........ ........ ........ 30% 18.3M 6s
+ 55296K ........ ........ ........ ........ ........ ........ 31% 38.3M 5s
+ 58368K ........ ........ ........ ........ ........ ........ 33% 24.1M 5s
+ 61440K ........ ........ ........ ........ ........ ........ 35% 37.7M 5s
+ 64512K ........ ........ ........ ........ ........ ........ 36% 26.6M 5s
+ 67584K ........ ........ ........ ........ ........ ........ 38% 36.2M 5s
+ 70656K ........ ........ ........ ........ ........ ........ 40% 27.0M 4s
+ 73728K ........ ........ ........ ........ ........ ........ 41% 37.2M 4s
+ 76800K ........ ........ ........ ........ ........ ........ 43% 27.2M 4s
+ 79872K ........ ........ ........ ........ ........ ........ 45% 37.3M 4s
+ 82944K ........ ........ ........ ........ ........ ........ 46% 27.3M 4s
+ 86016K ........ ........ ........ ........ ........ ........ 48% 37.9M 4s
+ 89088K ........ ........ ........ ........ ........ ........ 50% 27.1M 4s
+ 92160K ........ ........ ........ ........ ........ ........ 51% 38.0M 3s
+ 95232K ........ ........ ........ ........ ........ ........ 53% 36.7M 3s
+ 98304K ........ ........ ........ ........ ........ ........ 55% 27.7M 3s
+101376K ........ ........ ........ ........ ........ ........ 56% 36.9M 3s
+104448K ........ ........ ........ ........ ........ ........ 58% 27.7M 3s
+107520K ........ ........ ........ ........ ........ ........ 60% 37.0M 3s
+110592K ........ ........ ........ ........ ........ ........ 61% 27.5M 3s
+113664K ........ ........ ........ ........ ........ ........ 63% 37.0M 2s
+116736K ........ ........ ........ ........ ........ ........ 65% 27.4M 2s
+119808K ........ ........ ........ ........ ........ ........ 66% 37.7M 2s
+122880K ........ ........ ........ ........ ........ ........ 68% 27.2M 2s
+125952K ........ ........ ........ ........ ........ ........ 70% 37.5M 2s
+129024K ........ ........ ........ ........ ........ ........ 71% 27.1M 2s
+132096K ........ ........ ........ ........ ........ ........ 73% 38.3M 2s
+135168K ........ ........ ........ ........ ........ ........ 75% 26.8M 2s
+138240K ........ ........ ........ ........ ........ ........ 76% 38.4M 2s
+141312K ........ ........ ........ ........ ........ ........ 78% 27.1M 1s
+144384K ........ ........ ........ ........ ........ ........ 80% 37.8M 1s
+147456K ........ ........ ........ ........ ........ ........ 81% 27.2M 1s
+150528K ........ ........ ........ ........ ........ ........ 83% 37.1M 1s
+153600K ........ ........ ........ ........ ........ ........ 85% 37.4M 1s
+156672K ........ ........ ........ ........ ........ ........ 87% 27.4M 1s
+159744K ........ ........ ........ ........ ........ ........ 88% 37.5M 1s
+162816K ........ ........ ........ ........ ........ ........ 90% 27.2M 1s
+165888K ........ ........ ........ ........ ........ ........ 92% 38.1M 1s
+168960K ........ ........ ........ ........ ........ ........ 93% 26.7M 0s
+172032K ........ ........ ........ ........ ........ ........ 95% 38.9M 0s
+175104K ........ ........ ........ ........ ........ ........ 97% 26.7M 0s
+178176K ........ ........ ........ ........ ........ ........ 98% 38.6M 0s
+181248K ........ ........ ........ ........ ....             100% 33.3M=6.4s
+
+2020-06-16 03:06:29 (28.2 MB/s) - â/tmp/maas-cloudimg2eph2.8QbeQ3/bionic-server-cloudimg-amd64.squashfsâ saved [187985920/187985920]
+
+Tue, 16 Jun 2020 03:06:29 +0000: getting .img from /tmp/maas-cloudimg2eph2.8QbeQ3/bionic-server-cloudimg-amd64.squashfs fmt=auto
+determined format is squashfs-image
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.8QbeQ3/root.img'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+turning squahsfs image in /tmp/maas-cloudimg2eph2.8QbeQ3/bionic-server-cloudimg-amd64.squashfs to ext4 image in /tmp/maas-cloudimg2eph2.8QbeQ3/root.img
+Parallel unsquashfs: Using 28 processors
+32504 inodes (35576 blocks) to write
+
+[===========================================================\] 35576/35576 100%
+
+created 27812 files
+created 3264 directories
+created 4679 symlinks
+created 7 devices
+created 0 fifos
+Tue, 16 Jun 2020 03:07:13 +0000: getting '1024M' in /tmp/maas-cloudimg2eph2.8QbeQ3/root.img
+Tue, 16 Jun 2020 03:07:14 +0000: targetting 5368709120 (1310720*4096) bytes.
+Tue, 16 Jun 2020 03:07:14 +0000: fs is currently 1048576 * 4096.
+Tue, 16 Jun 2020 03:07:14 +0000: resize to 1310720. minblocks=244333. target=1310720
+Tue, 16 Jun 2020 03:07:18 +0000: starting maas-cloudimg2ephemeral --arch=amd64 --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img none /tmp/maas-cloudimg2eph2.8QbeQ3/none-kernel /tmp/maas-cloudimg2eph2.8QbeQ3/none-initrd /tmp/maas-cloudimg2eph2.8QbeQ3/manifest
+NO_CHANGE: add additional repos.
+NO_CHANGE: images ppa for cloud-init and maas-enlist (LP: #1511482, 1515733)
+CHANGE: enable proposed [amd64 http://archive.ubuntu.com/ubuntu/]
+NO_CHANGE: ensure mellanox mlx4_en gets loaded (LP: #1115710)
+NO_CHANGE: build-only: divert newaliases (LP: #1531299)
+nothing to remove: nothing match '^linux-.*' and not '^linux-base$'.
+NO_CHANGE: removing linux kernel packages.
+CHANGE: apt-get dist-upgrade
+CHANGE: run apt-update [dist-upgrade].
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
+Get:7 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [748 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic/universe Translation-en [4941 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/multiverse Translation-en [108 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [970 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1081 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [336 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [15.9 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Translation-en [6420 B]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [7516 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [4764 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [7484 B]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [4436 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 Packages [101 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-proposed/main Translation-en [39.1 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-proposed/universe amd64 Packages [34.5 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-proposed/universe Translation-en [17.3 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-proposed/multiverse amd64 Packages [2476 B]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-proposed/multiverse Translation-en [948 B]
+Get:26 http://security.ubuntu.com/ubuntu bionic-security/main Translation-en [237 kB]
+Get:27 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [673 kB]
+Get:28 http://security.ubuntu.com/ubuntu bionic-security/universe Translation-en [223 kB]
+Get:29 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [7808 B]
+Get:30 http://security.ubuntu.com/ubuntu bionic-security/multiverse Translation-en [2856 B]
+Fetched 18.8 MB in 4s (4951 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'sudo apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init libdrm-common libdrm2 libnetplan0 libseccomp2 login netplan.io
+  nplan openssh-client openssh-server openssh-sftp-server passwd
+  python3-update-manager uidmap update-manager-core
+15 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+Need to get 2822 kB of archives.
+After this operation, 113 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 login amd64 1:4.5-1ubuntu2.1 [307 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 passwd amd64 1:4.5-1ubuntu2.1 [819 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 libseccomp2 amd64 2.4.3-1ubuntu3.18.04.2 [41.6 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnetplan0 amd64 0.99-0ubuntu3~18.04.3 [22.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 netplan.io amd64 0.99-0ubuntu3~18.04.3 [70.7 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 nplan all 0.99-0ubuntu3~18.04.3 [1800 B]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 libdrm-common all 2.4.101-2~18.04.1 [5560 B]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 libdrm2 amd64 2.4.101-2~18.04.1 [32.3 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 openssh-sftp-server amd64 1:7.6p1-4ubuntu0.4 [45.5 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 openssh-server amd64 1:7.6p1-4ubuntu0.4 [332 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 openssh-client amd64 1:7.6p1-4ubuntu0.4 [612 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 python3-update-manager all 1:18.04.11.13 [35.0 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 update-manager-core all 1:18.04.11.13 [8500 B]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 uidmap amd64 1:4.5-1ubuntu2.1 [65.6 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~18.04.1 [422 kB]
+Preconfiguring packages ...
+Fetched 2822 kB in 1s (3843 kB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+(Reading database ... 28716 files and directories currently installed.)
+Preparing to unpack .../login_1%3a4.5-1ubuntu2.1_amd64.deb ...
+Unpacking login (1:4.5-1ubuntu2.1) over (1:4.5-1ubuntu2) ...
+Setting up login (1:4.5-1ubuntu2.1) ...
+(Reading database ... 28716 files and directories currently installed.)
+Preparing to unpack .../passwd_1%3a4.5-1ubuntu2.1_amd64.deb ...
+Unpacking passwd (1:4.5-1ubuntu2.1) over (1:4.5-1ubuntu2) ...
+Setting up passwd (1:4.5-1ubuntu2.1) ...
+(Reading database ... 28716 files and directories currently installed.)
+Preparing to unpack .../libseccomp2_2.4.3-1ubuntu3.18.04.2_amd64.deb ...
+Unpacking libseccomp2:amd64 (2.4.3-1ubuntu3.18.04.2) over (2.4.1-0ubuntu0.18.04.2) ...
+Setting up libseccomp2:amd64 (2.4.3-1ubuntu3.18.04.2) ...
+(Reading database ... 28716 files and directories currently installed.)
+Preparing to unpack .../00-libnetplan0_0.99-0ubuntu3~18.04.3_amd64.deb ...
+Unpacking libnetplan0:amd64 (0.99-0ubuntu3~18.04.3) over (0.99-0ubuntu3~18.04.2) ...
+Preparing to unpack .../01-netplan.io_0.99-0ubuntu3~18.04.3_amd64.deb ...
+Unpacking netplan.io (0.99-0ubuntu3~18.04.3) over (0.99-0ubuntu3~18.04.2) ...
+Preparing to unpack .../02-nplan_0.99-0ubuntu3~18.04.3_all.deb ...
+Unpacking nplan (0.99-0ubuntu3~18.04.3) over (0.99-0ubuntu3~18.04.2) ...
+Preparing to unpack .../03-libdrm-common_2.4.101-2~18.04.1_all.deb ...
+Unpacking libdrm-common (2.4.101-2~18.04.1) over (2.4.99-1ubuntu1~18.04.2) ...
+Preparing to unpack .../04-libdrm2_2.4.101-2~18.04.1_amd64.deb ...
+Unpacking libdrm2:amd64 (2.4.101-2~18.04.1) over (2.4.99-1ubuntu1~18.04.2) ...
+Preparing to unpack .../05-openssh-sftp-server_1%3a7.6p1-4ubuntu0.4_amd64.deb ...
+Unpacking openssh-sftp-server (1:7.6p1-4ubuntu0.4) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../06-openssh-server_1%3a7.6p1-4ubuntu0.4_amd64.deb ...
+Unpacking openssh-server (1:7.6p1-4ubuntu0.4) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../07-openssh-client_1%3a7.6p1-4ubuntu0.4_amd64.deb ...
+Unpacking openssh-client (1:7.6p1-4ubuntu0.4) over (1:7.6p1-4ubuntu0.3) ...
+Preparing to unpack .../08-python3-update-manager_1%3a18.04.11.13_all.deb ...
+Unpacking python3-update-manager (1:18.04.11.13) over (1:18.04.11.12) ...
+Preparing to unpack .../09-update-manager-core_1%3a18.04.11.13_all.deb ...
+Unpacking update-manager-core (1:18.04.11.13) over (1:18.04.11.12) ...
+Preparing to unpack .../10-uidmap_1%3a4.5-1ubuntu2.1_amd64.deb ...
+Unpacking uidmap (1:4.5-1ubuntu2.1) over (1:4.5-1ubuntu2) ...
+Preparing to unpack .../11-cloud-init_20.2-45-g5f7825e2-0ubuntu1~18.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) over (19.4-33-gbb4131a2-0ubuntu1~18.04.1) ...
+Setting up python3-update-manager (1:18.04.11.13) ...
+Setting up uidmap (1:4.5-1ubuntu2.1) ...
+Setting up libdrm-common (2.4.101-2~18.04.1) ...
+Setting up libnetplan0:amd64 (0.99-0ubuntu3~18.04.3) ...
+Setting up openssh-client (1:7.6p1-4ubuntu0.4) ...
+Setting up update-manager-core (1:18.04.11.13) ...
+Setting up netplan.io (0.99-0ubuntu3~18.04.3) ...
+Setting up libdrm2:amd64 (2.4.101-2~18.04.1) ...
+Setting up openssh-sftp-server (1:7.6p1-4ubuntu0.4) ...
+Setting up nplan (0.99-0ubuntu3~18.04.3) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) ...
+Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl ...
+Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Setting up openssh-server (1:7.6p1-4ubuntu0.4) ...
+Creating SSH2 RSA key; this may take some time ...
+2048 SHA256:kxYbYNJmmkLjKOXxAhTPZCdtMpxmlxD+A7YFSyhBHxE root@jenkins-slave-2 (RSA)
+Creating SSH2 ECDSA key; this may take some time ...
+256 SHA256:30jrlRfxYyFhD4BZC0zc2GAttjVpdXEGt96L0KaNzwE root@jenkins-slave-2 (ECDSA)
+Creating SSH2 ED25519 key; this may take some time ...
+256 SHA256:hiGF/9s276LzWr0oNfSVJIlOLjVtEABQPineBexhIEU root@jenkins-slave-2 (ED25519)
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of restart.
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of try-restart.
+Processing triggers for ufw (0.36-0ubuntu0.18.04.1) ...
+WARN: Couldn't find pid (is /proc mounted?)
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+NO_CHANGE: install missing packages
+NO_CHANGE: remove dpkg foreign architectures
+NO_CHANGE: run autoremove
+CHANGE: apt-get clean
+NO_CHANGE: symlink ENI for cloud-initramfs-dyn-netconf (LP: #1534205)
+NO_CHANGE: touch /etc/iscsi/iscsi.initramfs for iscsi root shutdown (LP: #1536707) [systemd]
+NO_CHANGE: create /lib/modules (LP: #1543204)
+CHANGE: set CRYPTSETUP=y in /etc/cryptsetup-initramfs/conf-hook (LP: #1818876)
+NO_CHANGE: update-initramfs
+NO_CHANGE: disable rescuevol (LP: #1034116)
+NO_CHANGE: package changes: add='' remove=''
+Tue, 16 Jun 2020 03:07:45 +0000: starting kpacks: linux-generic,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/ga-18.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/ga-18.04/generic/boot-initrd linux-lowlatency,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/ga-18.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/ga-18.04/lowlatency/boot-initrd linux-generic-hwe-18.04,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04/generic/boot-initrd linux-lowlatency-hwe-18.04,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04/lowlatency/boot-initrd linux-generic-hwe-18.04-edge,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04-edge/generic/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04-edge/generic/boot-initrd linux-lowlatency-hwe-18.04-edge,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04-edge/lowlatency/boot-kernel,/home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/hwe-18.04-edge/lowlatency/boot-initrd
+Tue, 16 Jun 2020 03:07:45 +0000: Tue, 16 Jun 2020 03:07:45 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img linux-generic /tmp/maas-cloudimg2eph2.8QbeQ3/linux-generic
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Fetched 494 kB in 2s (230 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libnl-3-200
+  libnl-genl-3-200 linux-firmware linux-headers-4.15.0-107
+  linux-headers-4.15.0-107-generic linux-headers-generic
+  linux-image-4.15.0-107-generic linux-image-generic
+  linux-modules-4.15.0-107-generic linux-modules-extra-4.15.0-107-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.15.0
+  | linux-source-4.15.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic linux-headers-4.15.0-107 linux-headers-4.15.0-107-generic
+  linux-headers-generic linux-image-4.15.0-107-generic linux-image-generic
+  linux-modules-4.15.0-107-generic linux-modules-extra-4.15.0-107-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
+Need to get 147 MB of archives.
+After this operation, 688 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-3-200 amd64 3.2.29-0ubuntu3 [52.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-genl-3-200 amd64 3.2.29-0ubuntu3 [11.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~18.04.1 [11.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 iw amd64 4.14-0.1 [75.4 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1775 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.15 [900 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.15 [138 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-modules-4.15.0-107-generic amd64 4.15.0-107.108 [13.0 MB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-4.15.0-107-generic amd64 4.15.0-107.108 [8008 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-modules-extra-4.15.0-107-generic amd64 4.15.0-107.108 [32.8 MB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2526 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-generic amd64 4.15.0.107.95 [2468 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-107 all 4.15.0-107.108 [10.9 MB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-107-generic amd64 4.15.0-107.108 [1103 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-generic amd64 4.15.0.107.95 [2428 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-generic amd64 4.15.0.107.95 [1868 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 147 MB in 7s (20.5 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 28726 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2018.05.09-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2018.05.09-0ubuntu1~18.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_4.14-0.1_amd64.deb ...
+Unpacking iw (4.14-0.1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../12-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) ...
+Selecting previously unselected package linux-modules-4.15.0-107-generic.
+Preparing to unpack .../13-linux-modules-4.15.0-107-generic_4.15.0-107.108_amd64.deb ...
+Unpacking linux-modules-4.15.0-107-generic (4.15.0-107.108) ...
+Selecting previously unselected package linux-image-4.15.0-107-generic.
+Preparing to unpack .../14-linux-image-4.15.0-107-generic_4.15.0-107.108_amd64.deb ...
+Unpacking linux-image-4.15.0-107-generic (4.15.0-107.108) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-107-generic.
+Preparing to unpack .../15-linux-modules-extra-4.15.0-107-generic_4.15.0-107.108_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-107-generic (4.15.0-107.108) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../16-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../17-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-generic.
+Preparing to unpack .../18-linux-image-generic_4.15.0.107.95_amd64.deb ...
+Unpacking linux-image-generic (4.15.0.107.95) ...
+Selecting previously unselected package linux-headers-4.15.0-107.
+Preparing to unpack .../19-linux-headers-4.15.0-107_4.15.0-107.108_all.deb ...
+Unpacking linux-headers-4.15.0-107 (4.15.0-107.108) ...
+Selecting previously unselected package linux-headers-4.15.0-107-generic.
+Preparing to unpack .../20-linux-headers-4.15.0-107-generic_4.15.0-107.108_amd64.deb ...
+Unpacking linux-headers-4.15.0-107-generic (4.15.0-107.108) ...
+Selecting previously unselected package linux-headers-generic.
+Preparing to unpack .../21-linux-headers-generic_4.15.0.107.95_amd64.deb ...
+Unpacking linux-headers-generic (4.15.0.107.95) ...
+Selecting previously unselected package linux-generic.
+Preparing to unpack .../22-linux-generic_4.15.0.107.95_amd64.deb ...
+Unpacking linux-generic (4.15.0.107.95) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../23-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../24-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../25-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-modules-4.15.0-107-generic (4.15.0-107.108) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up linux-image-4.15.0-107-generic (4.15.0-107.108) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-107-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-107-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-107-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-107-generic
+Setting up wireless-regdb (2018.05.09-0ubuntu1~18.04.1) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+Setting up linux-headers-4.15.0-107 (4.15.0-107.108) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up iw (4.14-0.1) ...
+Setting up linux-headers-4.15.0-107-generic (4.15.0-107.108) ...
+Setting up linux-headers-generic (4.15.0.107.95) ...
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-4.15.0-107-generic (4.15.0-107.108) ...
+Setting up linux-image-generic (4.15.0.107.95) ...
+Setting up linux-generic (4.15.0.107.95) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.15) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-4.15.0-107-generic (4.15.0-107.108) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-generic
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-generic
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.8QbeQ3/linux-generic
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:10:06 +0000: Tue, 16 Jun 2020 03:10:06 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img linux-lowlatency /tmp/maas-cloudimg2eph2.8QbeQ3/linux-lowlatency
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Fetched 494 kB in 3s (185 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 linux-firmware
+  linux-headers-4.15.0-107 linux-headers-4.15.0-107-lowlatency
+  linux-headers-lowlatency linux-image-4.15.0-107-lowlatency
+  linux-image-lowlatency linux-modules-4.15.0-107-lowlatency os-prober
+  thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-doc-4.15.0
+  | linux-source-4.15.0 linux-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 linux-firmware linux-headers-4.15.0-107
+  linux-headers-4.15.0-107-lowlatency linux-headers-lowlatency
+  linux-image-4.15.0-107-lowlatency linux-image-lowlatency linux-lowlatency
+  linux-modules-4.15.0-107-lowlatency os-prober thermald
+0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
+Need to get 147 MB of archives.
+After this operation, 687 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1775 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.15 [900 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.15 [138 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-107 all 4.15.0-107.108 [10.9 MB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-4.15.0-107-lowlatency amd64 4.15.0-107.108 [1103 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-headers-lowlatency amd64 4.15.0.107.95 [2428 B]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-modules-4.15.0-107-lowlatency amd64 4.15.0-107.108 [45.9 MB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-4.15.0-107-lowlatency amd64 4.15.0-107.108 [8058 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2526 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-image-lowlatency amd64 4.15.0.107.95 [2468 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 linux-lowlatency amd64 4.15.0.107.95 [1864 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 147 MB in 6s (26.6 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 28726 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../07-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) ...
+Selecting previously unselected package linux-headers-4.15.0-107.
+Preparing to unpack .../08-linux-headers-4.15.0-107_4.15.0-107.108_all.deb ...
+Unpacking linux-headers-4.15.0-107 (4.15.0-107.108) ...
+Selecting previously unselected package linux-headers-4.15.0-107-lowlatency.
+Preparing to unpack .../09-linux-headers-4.15.0-107-lowlatency_4.15.0-107.108_amd64.deb ...
+Unpacking linux-headers-4.15.0-107-lowlatency (4.15.0-107.108) ...
+Selecting previously unselected package linux-headers-lowlatency.
+Preparing to unpack .../10-linux-headers-lowlatency_4.15.0.107.95_amd64.deb ...
+Unpacking linux-headers-lowlatency (4.15.0.107.95) ...
+Selecting previously unselected package linux-modules-4.15.0-107-lowlatency.
+Preparing to unpack .../11-linux-modules-4.15.0-107-lowlatency_4.15.0-107.108_amd64.deb ...
+Unpacking linux-modules-4.15.0-107-lowlatency (4.15.0-107.108) ...
+Selecting previously unselected package linux-image-4.15.0-107-lowlatency.
+Preparing to unpack .../12-linux-image-4.15.0-107-lowlatency_4.15.0-107.108_amd64.deb ...
+Unpacking linux-image-4.15.0-107-lowlatency (4.15.0-107.108) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../13-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../14-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-lowlatency.
+Preparing to unpack .../15-linux-image-lowlatency_4.15.0.107.95_amd64.deb ...
+Unpacking linux-image-lowlatency (4.15.0.107.95) ...
+Selecting previously unselected package linux-lowlatency.
+Preparing to unpack .../16-linux-lowlatency_4.15.0.107.95_amd64.deb ...
+Unpacking linux-lowlatency (4.15.0.107.95) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../18-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../19-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up linux-modules-4.15.0-107-lowlatency (4.15.0-107.108) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+Setting up linux-headers-4.15.0-107 (4.15.0-107.108) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up linux-image-4.15.0-107-lowlatency (4.15.0-107.108) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-107-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-107-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-107-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-107-lowlatency
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-image-lowlatency (4.15.0.107.95) ...
+Setting up linux-headers-4.15.0-107-lowlatency (4.15.0-107.108) ...
+Setting up linux-headers-lowlatency (4.15.0.107.95) ...
+Setting up linux-lowlatency (4.15.0.107.95) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.15) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+Processing triggers for linux-image-4.15.0-107-lowlatency (4.15.0-107.108) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-107-lowlatency
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.8QbeQ3/linux-lowlatency
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:12:03 +0000: Tue, 16 Jun 2020 03:12:03 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img linux-generic-hwe-18.04 /tmp/maas-cloudimg2eph2.8QbeQ3/linux-generic-hwe-18.04
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Fetched 494 kB in 3s (190 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libnl-3-200
+  libnl-genl-3-200 linux-firmware linux-headers-5.3.0-59
+  linux-headers-5.3.0-59-generic linux-headers-generic-hwe-18.04
+  linux-image-5.3.0-59-generic linux-image-generic-hwe-18.04
+  linux-modules-5.3.0-59-generic linux-modules-extra-5.3.0-59-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-doc-5.3.0
+  | linux-hwe-source-5.3.0 linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-18.04 linux-headers-5.3.0-59
+  linux-headers-5.3.0-59-generic linux-headers-generic-hwe-18.04
+  linux-image-5.3.0-59-generic linux-image-generic-hwe-18.04
+  linux-modules-5.3.0-59-generic linux-modules-extra-5.3.0-59-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
+Need to get 154 MB of archives.
+After this operation, 700 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-3-200 amd64 3.2.29-0ubuntu3 [52.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-genl-3-200 amd64 3.2.29-0ubuntu3 [11.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~18.04.1 [11.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 iw amd64 4.14-0.1 [75.4 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1775 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.15 [900 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.15 [138 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.3.0-59-generic amd64 5.3.0-59.53~18.04.1 [14.3 MB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.3.0-59-generic amd64 5.3.0-59.53~18.04.1 [8739 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-5.3.0-59-generic amd64 5.3.0-59.53~18.04.1 [37.5 MB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2526 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic-hwe-18.04 amd64 5.3.0.59.113 [2696 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.3.0-59 all 5.3.0-59.53~18.04.1 [11.0 MB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.3.0-59-generic amd64 5.3.0-59.53~18.04.1 [1176 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic-hwe-18.04 amd64 5.3.0.59.113 [2656 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic-hwe-18.04 amd64 5.3.0.59.113 [1936 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 154 MB in 6s (24.1 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 28726 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2018.05.09-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2018.05.09-0ubuntu1~18.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_4.14-0.1_amd64.deb ...
+Unpacking iw (4.14-0.1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../12-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) ...
+Selecting previously unselected package linux-modules-5.3.0-59-generic.
+Preparing to unpack .../13-linux-modules-5.3.0-59-generic_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-image-5.3.0-59-generic.
+Preparing to unpack .../14-linux-image-5.3.0-59-generic_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-image-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-modules-extra-5.3.0-59-generic.
+Preparing to unpack .../15-linux-modules-extra-5.3.0-59-generic_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-modules-extra-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../16-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../17-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-generic-hwe-18.04.
+Preparing to unpack .../18-linux-image-generic-hwe-18.04_5.3.0.59.113_amd64.deb ...
+Unpacking linux-image-generic-hwe-18.04 (5.3.0.59.113) ...
+Selecting previously unselected package linux-headers-5.3.0-59.
+Preparing to unpack .../19-linux-headers-5.3.0-59_5.3.0-59.53~18.04.1_all.deb ...
+Unpacking linux-headers-5.3.0-59 (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-headers-5.3.0-59-generic.
+Preparing to unpack .../20-linux-headers-5.3.0-59-generic_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-18.04.
+Preparing to unpack .../21-linux-headers-generic-hwe-18.04_5.3.0.59.113_amd64.deb ...
+Unpacking linux-headers-generic-hwe-18.04 (5.3.0.59.113) ...
+Selecting previously unselected package linux-generic-hwe-18.04.
+Preparing to unpack .../22-linux-generic-hwe-18.04_5.3.0.59.113_amd64.deb ...
+Unpacking linux-generic-hwe-18.04 (5.3.0.59.113) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../23-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../24-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../25-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-modules-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up wireless-regdb (2018.05.09-0ubuntu1~18.04.1) ...
+Setting up linux-image-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.3.0-59-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.3.0-59-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.3.0-59-generic
+I: /initrd.img is now a symlink to boot/initrd.img-5.3.0-59-generic
+Setting up linux-headers-5.3.0-59 (5.3.0-59.53~18.04.1) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-headers-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Setting up iw (4.14-0.1) ...
+Setting up linux-headers-generic-hwe-18.04 (5.3.0.59.113) ...
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+Setting up linux-image-generic-hwe-18.04 (5.3.0.59.113) ...
+Setting up linux-generic-hwe-18.04 (5.3.0.59.113) ...
+Setting up grub-pc (2.02-2ubuntu8.15) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-5.3.0-59-generic (5.3.0-59.53~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.3.0-59-generic
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: Generating /boot/initrd.img-5.3.0-59-generic
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.8QbeQ3/linux-generic-hwe-18.04
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:14:40 +0000: Tue, 16 Jun 2020 03:14:40 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img linux-lowlatency-hwe-18.04 /tmp/maas-cloudimg2eph2.8QbeQ3/linux-lowlatency-hwe-18.04
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Fetched 494 kB in 3s (173 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 linux-firmware
+  linux-headers-5.3.0-59 linux-headers-5.3.0-59-lowlatency
+  linux-headers-lowlatency-hwe-18.04 linux-image-5.3.0-59-lowlatency
+  linux-image-lowlatency-hwe-18.04 linux-modules-5.3.0-59-lowlatency os-prober
+  thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-doc-5.3.0
+  | linux-hwe-source-5.3.0 linux-hwe-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 linux-firmware linux-headers-5.3.0-59
+  linux-headers-5.3.0-59-lowlatency linux-headers-lowlatency-hwe-18.04
+  linux-image-5.3.0-59-lowlatency linux-image-lowlatency-hwe-18.04
+  linux-lowlatency-hwe-18.04 linux-modules-5.3.0-59-lowlatency os-prober
+  thermald
+0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
+Need to get 154 MB of archives.
+After this operation, 699 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1775 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.15 [900 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.15 [138 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.3.0-59 all 5.3.0-59.53~18.04.1 [11.0 MB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.3.0-59-lowlatency amd64 5.3.0-59.53~18.04.1 [1175 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-lowlatency-hwe-18.04 amd64 5.3.0.59.113 [2652 B]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.3.0-59-lowlatency amd64 5.3.0-59.53~18.04.1 [51.6 MB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.3.0-59-lowlatency amd64 5.3.0-59.53~18.04.1 [8807 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2526 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-lowlatency-hwe-18.04 amd64 5.3.0.59.113 [2688 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-lowlatency-hwe-18.04 amd64 5.3.0.59.113 [1920 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 154 MB in 7s (21.7 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 28726 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../07-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) ...
+Selecting previously unselected package linux-headers-5.3.0-59.
+Preparing to unpack .../08-linux-headers-5.3.0-59_5.3.0-59.53~18.04.1_all.deb ...
+Unpacking linux-headers-5.3.0-59 (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-headers-5.3.0-59-lowlatency.
+Preparing to unpack .../09-linux-headers-5.3.0-59-lowlatency_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-18.04.
+Preparing to unpack .../10-linux-headers-lowlatency-hwe-18.04_5.3.0.59.113_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-18.04 (5.3.0.59.113) ...
+Selecting previously unselected package linux-modules-5.3.0-59-lowlatency.
+Preparing to unpack .../11-linux-modules-5.3.0-59-lowlatency_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package linux-image-5.3.0-59-lowlatency.
+Preparing to unpack .../12-linux-image-5.3.0-59-lowlatency_5.3.0-59.53~18.04.1_amd64.deb ...
+Unpacking linux-image-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../13-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../14-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-18.04.
+Preparing to unpack .../15-linux-image-lowlatency-hwe-18.04_5.3.0.59.113_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-18.04 (5.3.0.59.113) ...
+Selecting previously unselected package linux-lowlatency-hwe-18.04.
+Preparing to unpack .../16-linux-lowlatency-hwe-18.04_5.3.0.59.113_amd64.deb ...
+Unpacking linux-lowlatency-hwe-18.04 (5.3.0.59.113) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../18-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../19-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-modules-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+Setting up linux-image-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.3.0-59-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.3.0-59-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.3.0-59-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-5.3.0-59-lowlatency
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up linux-headers-5.3.0-59 (5.3.0-59.53~18.04.1) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-headers-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+Setting up linux-image-lowlatency-hwe-18.04 (5.3.0.59.113) ...
+Setting up linux-headers-lowlatency-hwe-18.04 (5.3.0.59.113) ...
+Setting up linux-lowlatency-hwe-18.04 (5.3.0.59.113) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.15) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-5.3.0-59-lowlatency (5.3.0-59.53~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.3.0-59-lowlatency
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: Generating /boot/initrd.img-5.3.0-59-lowlatency
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.8QbeQ3/linux-lowlatency-hwe-18.04
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:17:13 +0000: Tue, 16 Jun 2020 03:17:13 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img linux-generic-hwe-18.04-edge /tmp/maas-cloudimg2eph2.8QbeQ3/linux-generic-hwe-18.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Fetched 494 kB in 1s (369 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode crda grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool iw libdbus-glib-1-2 libnl-3-200
+  libnl-genl-3-200 linux-firmware linux-headers-5.4.0-37-generic
+  linux-headers-generic-hwe-18.04-edge linux-hwe-5.4-headers-5.4.0-37
+  linux-image-5.4.0-37-generic linux-image-generic-hwe-18.04-edge
+  linux-modules-5.4.0-37-generic linux-modules-extra-5.4.0-37-generic
+  os-prober thermald wireless-regdb
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-5.4-doc-5.4.0
+  | linux-hwe-5.4-source-5.4.0 linux-hwe-5.4-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl crda grub-common
+  grub-gfxpayload-lists grub-pc grub-pc-bin grub2-common intel-microcode
+  iucode-tool iw libdbus-glib-1-2 libnl-3-200 libnl-genl-3-200 linux-firmware
+  linux-generic-hwe-18.04-edge linux-headers-5.4.0-37-generic
+  linux-headers-generic-hwe-18.04-edge linux-hwe-5.4-headers-5.4.0-37
+  linux-image-5.4.0-37-generic linux-image-generic-hwe-18.04-edge
+  linux-modules-5.4.0-37-generic linux-modules-extra-5.4.0-37-generic
+  os-prober thermald wireless-regdb
+0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
+Need to get 156 MB of archives.
+After this operation, 703 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-3-200 amd64 3.2.29-0ubuntu3 [52.8 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnl-genl-3-200 amd64 3.2.29-0ubuntu3 [11.2 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wireless-regdb all 2018.05.09-0ubuntu1~18.04.1 [11.1 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 iw amd64 4.14-0.1 [75.4 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 crda amd64 3.18-1build1 [63.5 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1775 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.15 [900 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.15 [138 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.4.0-37-generic amd64 5.4.0-37.41~18.04.1 [14.4 MB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.4.0-37-generic amd64 5.4.0-37.41~18.04.1 [8956 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-5.4.0-37-generic amd64 5.4.0-37.41~18.04.1 [38.2 MB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2526 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic-hwe-18.04-edge amd64 5.4.0.37.41~18.04.28 [2988 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-hwe-5.4-headers-5.4.0-37 all 5.4.0-37.41~18.04.1 [11.2 MB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.4.0-37-generic amd64 5.4.0-37.41~18.04.1 [1350 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic-hwe-18.04-edge amd64 5.4.0.37.41~18.04.28 [2876 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic-hwe-18.04-edge amd64 5.4.0.37.41~18.04.28 [1952 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 156 MB in 7s (23.5 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package libnl-3-200:amd64.
+(Reading database ... 28726 files and directories currently installed.)
+Preparing to unpack .../00-libnl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package libnl-genl-3-200:amd64.
+Preparing to unpack .../01-libnl-genl-3-200_3.2.29-0ubuntu3_amd64.deb ...
+Unpacking libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Selecting previously unselected package wireless-regdb.
+Preparing to unpack .../02-wireless-regdb_2018.05.09-0ubuntu1~18.04.1_all.deb ...
+Unpacking wireless-regdb (2018.05.09-0ubuntu1~18.04.1) ...
+Selecting previously unselected package iw.
+Preparing to unpack .../03-iw_4.14-0.1_amd64.deb ...
+Unpacking iw (4.14-0.1) ...
+Selecting previously unselected package crda.
+Preparing to unpack .../04-crda_3.18-1build1_amd64.deb ...
+Unpacking crda (3.18-1build1) ...
+Selecting previously unselected package grub-common.
+Preparing to unpack .../05-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../06-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../07-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../08-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../09-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../10-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../11-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../12-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) ...
+Selecting previously unselected package linux-modules-5.4.0-37-generic.
+Preparing to unpack .../13-linux-modules-5.4.0-37-generic_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-image-5.4.0-37-generic.
+Preparing to unpack .../14-linux-image-5.4.0-37-generic_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-image-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-modules-extra-5.4.0-37-generic.
+Preparing to unpack .../15-linux-modules-extra-5.4.0-37-generic_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-modules-extra-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../16-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../17-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-generic-hwe-18.04-edge.
+Preparing to unpack .../18-linux-image-generic-hwe-18.04-edge_5.4.0.37.41~18.04.28_amd64.deb ...
+Unpacking linux-image-generic-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Selecting previously unselected package linux-hwe-5.4-headers-5.4.0-37.
+Preparing to unpack .../19-linux-hwe-5.4-headers-5.4.0-37_5.4.0-37.41~18.04.1_all.deb ...
+Unpacking linux-hwe-5.4-headers-5.4.0-37 (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-headers-5.4.0-37-generic.
+Preparing to unpack .../20-linux-headers-5.4.0-37-generic_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-headers-generic-hwe-18.04-edge.
+Preparing to unpack .../21-linux-headers-generic-hwe-18.04-edge_5.4.0.37.41~18.04.28_amd64.deb ...
+Unpacking linux-headers-generic-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Selecting previously unselected package linux-generic-hwe-18.04-edge.
+Preparing to unpack .../22-linux-generic-hwe-18.04-edge_5.4.0.37.41~18.04.28_amd64.deb ...
+Unpacking linux-generic-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../23-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../24-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../25-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up wireless-regdb (2018.05.09-0ubuntu1~18.04.1) ...
+Setting up linux-modules-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Setting up linux-image-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.4.0-37-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.4.0-37-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.4.0-37-generic
+I: /initrd.img is now a symlink to boot/initrd.img-5.4.0-37-generic
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-hwe-5.4-headers-5.4.0-37 (5.4.0-37.41~18.04.1) ...
+Setting up libnl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+Setting up linux-headers-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up libnl-genl-3-200:amd64 (3.2.29-0ubuntu3) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up iw (4.14-0.1) ...
+Setting up linux-headers-generic-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Setting up crda (3.18-1build1) ...
+Setting up linux-modules-extra-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+Setting up linux-image-generic-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Setting up linux-generic-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Setting up grub-pc (2.02-2ubuntu8.15) ...
+
+Creating config file /etc/default/grub with new version
+Setting up grub-gfxpayload-lists (0.7) ...
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for linux-image-5.4.0-37-generic (5.4.0-37.41~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-37-generic
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: Generating /boot/initrd.img-5.4.0-37-generic
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.8QbeQ3/linux-generic-hwe-18.04-edge
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:19:58 +0000: Tue, 16 Jun 2020 03:19:58 +0000: starting env kpack-from-image --proposed /tmp/maas-cloudimg2eph2.8QbeQ3/root.img linux-lowlatency-hwe-18.04-edge /tmp/maas-cloudimg2eph2.8QbeQ3/linux-lowlatency-hwe-18.04-edge
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:4 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Fetched 494 kB in 3s (197 kB/s)
+Reading package lists...
+Adding 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following additional packages will be installed:
+  amd64-microcode grub-common grub-gfxpayload-lists grub-pc grub-pc-bin
+  grub2-common intel-microcode iucode-tool libdbus-glib-1-2 linux-firmware
+  linux-headers-5.4.0-37-lowlatency linux-headers-lowlatency-hwe-18.04-edge
+  linux-hwe-5.4-headers-5.4.0-37 linux-image-5.4.0-37-lowlatency
+  linux-image-lowlatency-hwe-18.04-edge linux-modules-5.4.0-37-lowlatency
+  os-prober thermald
+Suggested packages:
+  multiboot-doc grub-emu xorriso desktop-base fdutils linux-hwe-5.4-doc-5.4.0
+  | linux-hwe-5.4-source-5.4.0 linux-hwe-5.4-tools
+The following NEW packages will be installed:
+  amd64-microcode cloud-initramfs-rooturl grub-common grub-gfxpayload-lists
+  grub-pc grub-pc-bin grub2-common intel-microcode iucode-tool
+  libdbus-glib-1-2 linux-firmware linux-headers-5.4.0-37-lowlatency
+  linux-headers-lowlatency-hwe-18.04-edge linux-hwe-5.4-headers-5.4.0-37
+  linux-image-5.4.0-37-lowlatency linux-image-lowlatency-hwe-18.04-edge
+  linux-lowlatency-hwe-18.04-edge linux-modules-5.4.0-37-lowlatency os-prober
+  thermald
+0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
+Need to get 155 MB of archives.
+After this operation, 702 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1775 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc-bin amd64 2.02-2ubuntu8.15 [900 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-pc amd64 2.02-2ubuntu8.15 [138 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic/main amd64 grub-gfxpayload-lists amd64 0.7 [3658 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 iucode-tool amd64 2.3.1-1 [45.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbus-glib-1-2 amd64 0.110-2 [58.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-hwe-5.4-headers-5.4.0-37 all 5.4.0-37.41~18.04.1 [11.2 MB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-5.4.0-37-lowlatency amd64 5.4.0-37.41~18.04.1 [1351 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-lowlatency-hwe-18.04-edge amd64 5.4.0.37.41~18.04.28 [2880 B]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-5.4.0-37-lowlatency amd64 5.4.0-37.41~18.04.1 [52.3 MB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-5.4.0-37-lowlatency amd64 5.4.0-37.41~18.04.1 [9026 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2526 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-lowlatency-hwe-18.04-edge amd64 5.4.0.37.41~18.04.28 [2988 B]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-lowlatency-hwe-18.04-edge amd64 5.4.0.37.41~18.04.28 [1924 B]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 os-prober amd64 1.74ubuntu1 [19.8 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 thermald amd64 1.7.0-5ubuntu5 [192 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 cloud-initramfs-rooturl all 0.40ubuntu1.1 [4208 B]
+Preconfiguring packages ...
+Fetched 155 MB in 6s (24.1 MB/s)
+E: Can not write log (Is /dev/pts mounted?) - posix_openpt (2: No such file or directory)
+Selecting previously unselected package grub-common.
+(Reading database ... 28726 files and directories currently installed.)
+Preparing to unpack .../00-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub2-common.
+Preparing to unpack .../01-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc-bin.
+Preparing to unpack .../02-grub-pc-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc-bin (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-pc.
+Preparing to unpack .../03-grub-pc_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-pc (2.02-2ubuntu8.15) ...
+Selecting previously unselected package grub-gfxpayload-lists.
+Preparing to unpack .../04-grub-gfxpayload-lists_0.7_amd64.deb ...
+Unpacking grub-gfxpayload-lists (0.7) ...
+Selecting previously unselected package iucode-tool.
+Preparing to unpack .../05-iucode-tool_2.3.1-1_amd64.deb ...
+Unpacking iucode-tool (2.3.1-1) ...
+Selecting previously unselected package libdbus-glib-1-2:amd64.
+Preparing to unpack .../06-libdbus-glib-1-2_0.110-2_amd64.deb ...
+Unpacking libdbus-glib-1-2:amd64 (0.110-2) ...
+Selecting previously unselected package linux-firmware.
+Preparing to unpack .../07-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) ...
+Selecting previously unselected package linux-hwe-5.4-headers-5.4.0-37.
+Preparing to unpack .../08-linux-hwe-5.4-headers-5.4.0-37_5.4.0-37.41~18.04.1_all.deb ...
+Unpacking linux-hwe-5.4-headers-5.4.0-37 (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-headers-5.4.0-37-lowlatency.
+Preparing to unpack .../09-linux-headers-5.4.0-37-lowlatency_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-headers-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-headers-lowlatency-hwe-18.04-edge.
+Preparing to unpack .../10-linux-headers-lowlatency-hwe-18.04-edge_5.4.0.37.41~18.04.28_amd64.deb ...
+Unpacking linux-headers-lowlatency-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Selecting previously unselected package linux-modules-5.4.0-37-lowlatency.
+Preparing to unpack .../11-linux-modules-5.4.0-37-lowlatency_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-modules-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package linux-image-5.4.0-37-lowlatency.
+Preparing to unpack .../12-linux-image-5.4.0-37-lowlatency_5.4.0-37.41~18.04.1_amd64.deb ...
+Unpacking linux-image-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+Selecting previously unselected package intel-microcode.
+Preparing to unpack .../13-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+Selecting previously unselected package amd64-microcode.
+Preparing to unpack .../14-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+Selecting previously unselected package linux-image-lowlatency-hwe-18.04-edge.
+Preparing to unpack .../15-linux-image-lowlatency-hwe-18.04-edge_5.4.0.37.41~18.04.28_amd64.deb ...
+Unpacking linux-image-lowlatency-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Selecting previously unselected package linux-lowlatency-hwe-18.04-edge.
+Preparing to unpack .../16-linux-lowlatency-hwe-18.04-edge_5.4.0.37.41~18.04.28_amd64.deb ...
+Unpacking linux-lowlatency-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Selecting previously unselected package os-prober.
+Preparing to unpack .../17-os-prober_1.74ubuntu1_amd64.deb ...
+Unpacking os-prober (1.74ubuntu1) ...
+Selecting previously unselected package thermald.
+Preparing to unpack .../18-thermald_1.7.0-5ubuntu5_amd64.deb ...
+Unpacking thermald (1.7.0-5ubuntu5) ...
+Selecting previously unselected package cloud-initramfs-rooturl.
+Preparing to unpack .../19-cloud-initramfs-rooturl_0.40ubuntu1.1_all.deb ...
+Unpacking cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up libdbus-glib-1-2:amd64 (0.110-2) ...
+Setting up iucode-tool (2.3.1-1) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Running in chroot, ignoring request.
+invoke-rc.d: policy-rc.d denied execution of start.
+Setting up linux-modules-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+Setting up cloud-initramfs-rooturl (0.40ubuntu1.1) ...
+Setting up linux-hwe-5.4-headers-5.4.0-37 (5.4.0-37.41~18.04.1) ...
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up grub-pc-bin (2.02-2ubuntu8.15) ...
+Setting up thermald (1.7.0-5ubuntu5) ...
+Created symlink /etc/systemd/system/dbus-org.freedesktop.thermald.service -> /lib/systemd/system/thermald.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/thermald.service -> /lib/systemd/system/thermald.service.
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up os-prober (1.74ubuntu1) ...
+Setting up linux-image-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-5.4.0-37-lowlatency
+I: /initrd.img.old is now a symlink to boot/initrd.img-5.4.0-37-lowlatency
+I: /vmlinuz is now a symlink to boot/vmlinuz-5.4.0-37-lowlatency
+I: /initrd.img is now a symlink to boot/initrd.img-5.4.0-37-lowlatency
+Setting up linux-headers-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+Setting up linux-headers-lowlatency-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Setting up linux-image-lowlatency-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Setting up linux-lowlatency-hwe-18.04-edge (5.4.0.37.41~18.04.28) ...
+Setting up grub-gfxpayload-lists (0.7) ...
+Setting up grub-pc (2.02-2ubuntu8.15) ...
+
+Creating config file /etc/default/grub with new version
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for ureadahead (0.100.0-21) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+Processing triggers for linux-image-5.4.0-37-lowlatency (5.4.0-37.41~18.04.1) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-5.4.0-37-lowlatency
+Removing 'local diversion of /usr/bin/newaliases to /usr/bin/newaliases.distrib'
+wrote to /tmp/maas-cloudimg2eph2.8QbeQ3/linux-lowlatency-hwe-18.04-edge
+   config initrd kernel System.map verflav
+Tue, 16 Jun 2020 03:22:02 +0000: kpacks done
+Tue, 16 Jun 2020 03:22:02 +0000: copying working img into new fs of 1400M (pad=)
+src image uuid=14fc7bf9-36f3-4f50-87af-dfea05651c4c label=cloudimg-rootfs fstype=ext4
+creating ext4 fs in '/tmp/maas-cloudimg2eph2.8QbeQ3/root.img.fs_img_size'. label=cloudimg-rootfs  feature_flags='^metadata_csum'
+Tue, 16 Jun 2020 03:22:29 +0000: zeroing img
+e2fsck 1.44.1 (24-Mar-2018)
+Pass 1: Checking inodes, blocks, and sizes
+Pass 2: Checking directory structure
+Pass 3: Checking directory connectivity
+Pass 4: Checking reference counts
+Pass 5: Checking group summary information
+cloudimg-rootfs: 35821/327680 files (0.1% non-contiguous), 243691/1310720 blocks
+creating a new squash image in /home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/squashfs with ./maas-images/bin/img2squashfs from /tmp/maas-cloudimg2eph2.8QbeQ3/root.img
+format of '/tmp/maas-cloudimg2eph2.8QbeQ3/root.img' is 'root-image'
+got format 'fs-image' at temp path '/tmp/img2squashfs.JqE4RZ/fs-image'
+calling mount-image-callback /tmp/img2squashfs.JqE4RZ/fs-image -- ./maas-images/bin/img2squashfs dir2squashfs _MOUNTPOINT_ /home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/squashfs
+Tue, 16 Jun 2020 03:22:36 +0000: starting: mksquashfs /tmp/mount-image-callback.FwAeGA/mp /home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/squashfs.img2squashfs.6050 -xattrs -comp xz
+Parallel mksquashfs: Using 28 processors
+Creating 4.0 filesystem on /home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/squashfs.img2squashfs.6050, block size 131072.
+[=================-                                          ]  9300/31690  29%[===========================================================|] 31690/31690 100%
+
+Exportable Squashfs 4.0 filesystem, xz compressed, data block size 131072
+	compressed data, compressed metadata, compressed fragments, compressed xattrs
+	duplicates are removed
+Filesystem size 202501.17 Kbytes (197.76 Mbytes)
+	27.71% of uncompressed filesystem size (730822.14 Kbytes)
+Inode table size 299726 bytes (292.70 Kbytes)
+	24.88% of uncompressed inode table size (1204455 bytes)
+Directory table size 304198 bytes (297.07 Kbytes)
+	38.55% of uncompressed directory table size (789195 bytes)
+Xattr table size 40 bytes (0.04 Kbytes)
+	100.00% of uncompressed xattr table size (40 bytes)
+Number of duplicate files found 1363
+Number of inodes 35812
+Number of files 27861
+Number of fragments 1700
+Number of symbolic links  4679
+Number of device nodes 7
+Number of fifo nodes 0
+Number of socket nodes 0
+Number of directories 3265
+Number of ids (unique uids + gids) 22
+Number of uids 8
+	root (0)
+	daemon (1)
+	_apt (105)
+	syslog (104)
+	man (6)
+	sshd (110)
+	uuidd (108)
+	systemd-resolve (102)
+Number of gids 17
+	root (0)
+	daemon (1)
+	shadow (42)
+	uuidd (112)
+	tty (5)
+	rdma (105)
+	netdev (109)
+	messagebus (111)
+	crontab (107)
+	utmp (43)
+	staff (50)
+	man (12)
+	nogroup (65534)
+	adm (4)
+	systemd-journal (101)
+	input (106)
+	mail (8)
+Tue, 16 Jun 2020 03:22:51 +0000: finished: returned 0
+output in /home/ubuntu/workspace/www/html/images/bionic/amd64/20200610.1/squashfs. took 19s.
+Tue, 16 Jun 2020 03:22:55 +0000: finished
++ meph2-import --proposed --no-sign ./maas-images/conf/bootloaders.yaml ./bootloaders
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for pxelinux
+Found pxelinux-3:6.03+dfsg1-2ubuntu0.18.04.2 in bionic-proposed
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for syslinux-common
+Found syslinux-common-3:6.03+dfsg1-2ubuntu0.18.04.2 in bionic-proposed
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for pxelinux
+Found pxelinux-3:6.03+dfsg1-2ubuntu0.18.04.2 in bionic-proposed
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for syslinux-common
+Found syslinux-common-3:6.03+dfsg1-2ubuntu0.18.04.2 in bionic-proposed
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for shim-signed
+Found shim-signed-1.37~18.04.5+15+1533136590.3beb971-0ubuntu1 in bionic-proposed
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for grub-efi-amd64-signed
+Found grub-efi-amd64-signed-1.93.16+2.02-2ubuntu8.15 in bionic-updates
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for shim-signed
+Found shim-signed-1.37~18.04.5+15+1533136590.3beb971-0ubuntu1 in bionic-proposed
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for grub-efi-amd64-signed
+Found grub-efi-amd64-signed-1.93.16+2.02-2ubuntu8.15 in bionic-updates
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for grub-efi-arm64-bin
+Found grub-efi-arm64-bin-2.02-2ubuntu8.15 in bionic-updates
+Searching bionic-proposed, bionic-updates, bionic-security, bionic for grub-efi-arm64-bin
+Found grub-efi-arm64-bin-2.02-2ubuntu8.15 in bionic-updates
+Searching xenial-proposed, xenial-updates, xenial-security, xenial for grub-ieee1275-bin
+Found grub-ieee1275-bin-2.02~beta2-36ubuntu3.23 in xenial-updates
+Searching xenial-proposed, xenial-updates, xenial-security, xenial for grub-ieee1275-bin
+Found grub-ieee1275-bin-2.02~beta2-36ubuntu3.23 in xenial-updates
+Creating new product com.ubuntu.maas.daily:1:pxelinux:pxe:i386
+Downloading and creating com.ubuntu.maas.daily:1:pxelinux:pxe:i386 version 20200616.0
+Creating new product com.ubuntu.maas.daily:1:grub-efi-signed:uefi:amd64
+Downloading and creating com.ubuntu.maas.daily:1:grub-efi-signed:uefi:amd64 version 20200616.0
+Creating new product com.ubuntu.maas.daily:1:grub-efi:uefi:arm64
+Downloading and creating com.ubuntu.maas.daily:1:grub-efi:uefi:arm64 version 20200616.0
+Creating new product com.ubuntu.maas.daily:1:grub-ieee1275:open-firmware:ppc64el
+Downloading and creating com.ubuntu.maas.daily:1:grub-ieee1275:open-firmware:ppc64el version 20200616.0
++ meph2-util merge --no-sign ./bootloaders /home/ubuntu/workspace/www/html/images
++ '[' 0 -ge 1 ']'
++ bzr checkout --lightweight 'lp:~maas-maintainers/maas/qa-lab-tests' qa-lab-tests
++ '[' 0 -ge 1 ']'
++ '[' -eq 1 ']'
+/tmp/jenkins386310300377690392.sh: line 94: [: -eq: unary operator expected
++ '[' '!' ']'
++ mv qa-lab-tests/dummy maas
++ UNBUILT_MAAS_TREE=/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas
++ grep '^package-tree' /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/Makefile
+grep: /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/Makefile: No such file or directory
++ mv qa-lab-tests /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/debian/tests
+++ git -C maas rev-list --count
+fatal: not a git repository (or any of the parent directories): .git
++ export MAAS_BRANCH_REVNO_COUNT=
++ MAAS_BRANCH_REVNO_COUNT=
+++ git -C maas rev-parse --short
+fatal: not a git repository (or any of the parent directories): .git
++ export MAAS_BRANCH_REVNO=
++ MAAS_BRANCH_REVNO=
++ export VER_FOR_PKG=-g
++ VER_FOR_PKG=-g
++ git clone git+ssh://git.launchpad.net/~maas-committers/maas-ci/+git/maas-ci-config
+Cloning into 'maas-ci-config'...
++ source maas-ci-config/maas-ci-common
+++ AUTOPKGTEST_ROOT=/home/ubuntu/autopkgtest
+++ MAAS_CI_ROOT=/home/ubuntu/maas-ci
+++ ADT_IMAGES_ROOT=/home/ubuntu/images
++ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/debian/tests/update_changelog.py /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/debian/changelog -g ci
++ SETUP_COMMANDS='export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128'
++ '[' '!' -z ']'
++ '[' '!' -z ']'
++ '[' '!' -z ']'
++ SETUP_COMMANDS='export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'
++ PACKAGES_FROM_PROPOSED=
++ '[' -eq 1 ']'
+/tmp/jenkins386310300377690392.sh: line 153: [: -eq: unary operator expected
++ '[' -eq 1 ']'
+/tmp/jenkins386310300377690392.sh: line 155: [: -eq: unary operator expected
++ '[' -eq 0 ']'
+/tmp/jenkins386310300377690392.sh: line 157: [: -eq: unary operator expected
++ QEMU_CFG=/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg
++ QEMU_IMG=/home/ubuntu/images/autopkgtest-bionic-amd64.img
++ '[' ']'
++ echo running with Curtin from archive
+running with Curtin from archive
++ /home/ubuntu/autopkgtest/runner/autopkgtest -U -ddd --output-dir /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results --env DEPLOYMENT_RELEASE=bionic --env TEST_JUJU= --env TEST_CENTOS=0 --env TEST_RHEL= --env TEST_WINDOWS= --env TEST_CUSTOM_IMAGES=1 --env USE_PPC_NODES=0 --env USE_ARM64_NODES=0 --env KEEP_CI_RUNNING=0 --env PAUSE_CI=0 --env TEST_PERFORMANCE=0 --env DEBUG= --env SLAVE_NODE=HP-DL360-Gen9 '--setup-commands=export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update' --timeout-test=20000 /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas -- /home/ubuntu/autopkgtest/virt/autopkgtest-virt-qemu -d --show-boot --ram-size 3072 --qemu-options '-readconfig /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg' /home/ubuntu/images/autopkgtest-bionic-amd64.img
+autopkgtest: DBG: autopkgtest options: Namespace(apt_pocket=[], auto_control=True, build_parallel=None, built_binaries=True, copy=[], env=['DEPLOYMENT_RELEASE=bionic', 'TEST_JUJU=', 'TEST_CENTOS=0', 'TEST_RHEL=', 'TEST_WINDOWS=', 'TEST_CUSTOM_IMAGES=1', 'USE_PPC_NODES=0', 'USE_ARM64_NODES=0', 'KEEP_CI_RUNNING=0', 'PAUSE_CI=0', 'TEST_PERFORMANCE=0', 'DEBUG=', 'SLAVE_NODE=HP-DL360-Gen9'], gainroot=None, installed_click=None, logfile=None, output_dir='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results', override_control=None, packages=['/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas'], set_lang=None, setup_commands=['(O=$(bash -o pipefail -ec \'apt-get update | tee /proc/self/fd/2\') ||{ [ "${O%404*Not Found*}" = "$O" ] || exit 100; sleep 15; apt-get update; } || { sleep 60; apt-get update; } || false) && $(which eatmydata || true) apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew"', 'export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'], setup_commands_boot=[], shell=False, shell_fail=False, summary=None, testname=None, timeout_build=None, timeout_copy=None, timeout_factor=1.0, timeout_install=None, timeout_short=None, timeout_test=20000, user=None, verbosity=2)
+autopkgtest: DBG: virt-runner arguments: ['/home/ubuntu/autopkgtest/virt/autopkgtest-virt-qemu', '-d', '--show-boot', '--ram-size', '3072', '--qemu-options', '-readconfig /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg', '/home/ubuntu/images/autopkgtest-bionic-amd64.img']
+autopkgtest: DBG: actions: [('unbuilt-tree', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas', True)]
+autopkgtest: DBG: build binaries: True
+autopkgtest: DBG: testbed init
+autopkgtest [03:23:38]: git checkout: a93602a Add a debug-fail hook and implement it for autopkgtest-virt-ssh
+autopkgtest [03:23:38]: host jenkins-slave-2; command line: /home/ubuntu/autopkgtest/runner/autopkgtest -U -ddd --output-dir /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results --env DEPLOYMENT_RELEASE=bionic --env TEST_JUJU= --env TEST_CENTOS=0 --env TEST_RHEL= --env TEST_WINDOWS= --env TEST_CUSTOM_IMAGES=1 --env USE_PPC_NODES=0 --env USE_ARM64_NODES=0 --env KEEP_CI_RUNNING=0 --env PAUSE_CI=0 --env TEST_PERFORMANCE=0 --env DEBUG= --env SLAVE_NODE=HP-DL360-Gen9 '--setup-commands=export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update' --timeout-test=20000 /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas -- /home/ubuntu/autopkgtest/virt/autopkgtest-virt-qemu -d --show-boot --ram-size 3072 --qemu-options '-readconfig /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg' /home/ubuntu/images/autopkgtest-bionic-amd64.img
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed open, scratch=None
+autopkgtest: DBG: sending command to testbed: open
+autopkgtest-virt-qemu: DBG: executing open
+autopkgtest-virt-qemu: DBG: Creating temporary overlay image in /tmp/autopkgtest-virt-qemu.aytyr2gb/overlay.img
+autopkgtest-virt-qemu: DBG: execute-timeout: qemu-img create -f qcow2 -b /home/ubuntu/images/autopkgtest-bionic-amd64.img /tmp/autopkgtest-virt-qemu.aytyr2gb/overlay.img
+autopkgtest-virt-qemu: DBG: find_free_port: trying 10022
+autopkgtest-virt-qemu: DBG: find_free_port: 10022 is free
+autopkgtest-virt-qemu: DBG: Forwarding local port 10022 to VM ssh port 22
+autopkgtest-virt-qemu: DBG: Detected KVM capable Intel host CPU, enabling nested KVM
+qemu-system-x86_64:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg:3: 'vlan' is deprecated. Please use 'netdev' instead.
+autopkgtest-virt-qemu: DBG: expect: " login: "
+[    0.000000] Linux version 4.15.0-66-generic (buildd@lgw01-amd64-044) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #75-Ubuntu SMP Tue Oct 1 05:24:09 UTC 2019 (Ubuntu 4.15.0-66.75-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-66-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffddfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffde000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1ubuntu1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0xbffde max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] found SMP MP-table at [mem 0x000f6a80-0x000f6a8f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x334bd000-0x35a55fff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F68A0 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE15FC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE1458 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001418 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE154C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE15C4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x00000000bffddfff]
+[    0.000000] NODE_DATA(0) allocated [mem 0xbffb3000-0xbffddfff]
+[    0.000000] kvm-clock: cpu 0, msr 0:bff32001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 1740869797 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000bffddfff]
+[    0.000000]   Normal   empty
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffddfff]
+[    0.000000] Reserved but unavailable: 98 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x00000000bffddfff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 1 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x4fd with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:1 nr_cpu_ids:1 nr_node_ids:1
+[    0.000000] percpu: Embedded 46 pages/cpu s151552 r8192 d28672 u2097152
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr bfa24040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 773991
+[    0.000000] Policy zone: DMA32
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-66-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 3028580K/3145200K available (12300K kernel code, 2481K rwdata, 4260K rodata, 2436K init, 2388K bss, 116620K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39306 entries in 154 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=1.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
+[    0.004000] NR_IRQS: 524544, nr_irqs: 256, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004008] APIC: Switch to symmetric I/O mode setup
+[    0.005246] x2apic enabled
+[    0.005923] Switched APIC routing to physical x2apic.
+[    0.007823] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.008000] tsc: Detected 2397.222 MHz processor
+[    0.008000] Calibrating delay loop (skipped) preset value.. 4794.44 BogoMIPS (lpj=9588888)
+[    0.008000] pid_max: default: 32768 minimum: 301
+[    0.008000] Security Framework initialized
+[    0.008000] Yama: becoming mindful.
+[    0.008022] AppArmor: AppArmor initialized
+[    0.009348] Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.010748] Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes)
+[    0.012013] Mount-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.012961] Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.014223] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.014953] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.015756] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.016002] Spectre V2 : Mitigation: Full generic retpoline
+[    0.016805] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.017953] Speculative Store Bypass: Vulnerable
+[    0.018631] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.027679] Freeing SMP alternatives memory: 36K
+[    0.138270] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.139392] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.140000] Hierarchical SRCU implementation.
+[    0.140000] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.140001] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.140919] smp: Bringing up secondary CPUs ...
+[    0.141483] smp: Brought up 1 node, 1 CPU
+[    0.141980] smpboot: Max logical packages: 1
+[    0.142507] smpboot: Total of 1 processors activated (4794.44 BogoMIPS)
+[    0.144113] devtmpfs: initialized
+[    0.144577] x86/mm: Memory block size: 128MB
+[    0.145477] evm: security.selinux
+[    0.145898] evm: security.SMACK64
+[    0.146314] evm: security.SMACK64EXEC
+[    0.146770] evm: security.SMACK64TRANSMUTE
+[    0.147282] evm: security.SMACK64MMAP
+[    0.147817] evm: security.apparmor
+[    0.148014] evm: security.ima
+[    0.148464] evm: security.capability
+[    0.148996] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.150308] futex hash table entries: 256 (order: 2, 16384 bytes)
+[    0.151128] pinctrl core: initialized pinctrl subsystem
+[    0.152129] RTC time:  3:23:40, date: 06/16/20
+[    0.152763] NET: Registered protocol family 16
+[    0.153448] audit: initializing netlink subsys (disabled)
+[    0.154253] cpuidle: using governor ladder
+[    0.154784] cpuidle: using governor menu
+[    0.155377] ACPI: bus type PCI registered
+[    0.156005] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.156983] PCI: Using configuration type 1 for base access
+[    0.157761] audit: type=2000 audit(1592277821.116:1): state=initialized audit_enabled=0 res=1
+[    0.159715] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.160125] ACPI: Added _OSI(Module Device)
+[    0.160688] ACPI: Added _OSI(Processor Device)
+[    0.161288] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.161892] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.162935] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.164008] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.164644] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.166419] ACPI: Interpreter enabled
+[    0.166871] ACPI: (supports S0 S3 S4 S5)
+[    0.167401] ACPI: Using IOAPIC for interrupt routing
+[    0.168038] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.169343] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.172532] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.173345] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.174240] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.175105] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.176260] acpiphp: Slot [3] registered
+[    0.176830] acpiphp: Slot [4] registered
+[    0.177397] acpiphp: Slot [5] registered
+[    0.177987] acpiphp: Slot [6] registered
+[    0.178570] acpiphp: Slot [7] registered
+[    0.179152] acpiphp: Slot [8] registered
+[    0.180034] acpiphp: Slot [9] registered
+[    0.180637] acpiphp: Slot [10] registered
+[    0.181236] acpiphp: Slot [11] registered
+[    0.181832] acpiphp: Slot [12] registered
+[    0.182429] acpiphp: Slot [13] registered
+[    0.183027] acpiphp: Slot [14] registered
+[    0.184015] acpiphp: Slot [15] registered
+[    0.184618] acpiphp: Slot [16] registered
+[    0.185219] acpiphp: Slot [17] registered
+[    0.185828] acpiphp: Slot [18] registered
+[    0.186446] acpiphp: Slot [19] registered
+[    0.187066] acpiphp: Slot [20] registered
+[    0.187703] acpiphp: Slot [21] registered
+[    0.188037] acpiphp: Slot [22] registered
+[    0.188620] acpiphp: Slot [23] registered
+[    0.189207] acpiphp: Slot [24] registered
+[    0.189827] acpiphp: Slot [25] registered
+[    0.190503] acpiphp: Slot [26] registered
+[    0.191262] acpiphp: Slot [27] registered
+[    0.192043] acpiphp: Slot [28] registered
+[    0.192782] acpiphp: Slot [29] registered
+[    0.193453] acpiphp: Slot [30] registered
+[    0.194017] acpiphp: Slot [31] registered
+[    0.194560] PCI host bridge to bus 0000:00
+[    0.195103] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.196003] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.196892] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.197859] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.198813] pci_bus 0000:00: root bus resource [mem 0x100000000-0x17fffffff window]
+[    0.199818] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.205108] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.206076] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.207627] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.208002] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.209513] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.210488] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.256952] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.257796] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.258575] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.259378] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.260055] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.261020] SCSI subsystem initialized
+[    0.261620] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.262454] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.263637] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.264002] vgaarb: loaded
+[    0.264355] ACPI: bus type USB registered
+[    0.264934] usbcore: registered new interface driver usbfs
+[    0.265625] usbcore: registered new interface driver hub
+[    0.266289] usbcore: registered new device driver usb
+[    0.267000] EDAC MC: Ver: 3.0.0
+[    0.268193] PCI: Using ACPI for IRQ routing
+[    0.268963] NetLabel: Initializing
+[    0.269431] NetLabel:  domain hash size = 128
+[    0.270035] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.270855] NetLabel:  unlabeled traffic allowed by default
+[    0.272158] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.273076] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.273702] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.276044] clocksource: Switched to clocksource kvm-clock
+[    0.284979] VFS: Disk quotas dquot_6.6.0
+[    0.285509] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.286358] AppArmor: AppArmor Filesystem Enabled
+[    0.286945] pnp: PnP ACPI init
+[    0.288118] pnp: PnP ACPI: found 7 devices
+[    0.294091] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.295294] NET: Registered protocol family 2
+[    0.295952] TCP established hash table entries: 32768 (order: 6, 262144 bytes)
+[    0.296879] TCP bind hash table entries: 32768 (order: 7, 524288 bytes)
+[    0.297717] TCP: Hash tables configured (established 32768 bind 32768)
+[    0.298556] UDP hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.299408] UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.300231] NET: Registered protocol family 1
+[    0.300775] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.301503] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.302257] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.303077] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.304285] Unpacking initramfs...
+[    0.781017] Freeing initrd memory: 38500K
+[    0.781697] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228df7309b5, max_idle_ns: 440795314334 ns
+[    0.783032] Scanning for low memory corruption every 60 seconds
+[    0.784239] Initialise system trusted keyrings
+[    0.784836] Key type blacklist registered
+[    0.785396] workingset: timestamp_bits=36 max_order=20 bucket_order=0
+[    0.787031] zbud: loaded
+[    0.788121] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.788979] fuse init (API version 7.26)
+[    0.790138] Key type asymmetric registered
+[    0.790695] Asymmetric key parser 'x509' registered
+[    0.791358] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    0.792355] io scheduler noop registered
+[    0.792874] io scheduler deadline registered
+[    0.793464] io scheduler cfq registered (default)
+[    0.794301] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    0.795375] ACPI: Power Button [PWRF]
+[    0.815597] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    0.836882] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    0.857362] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    0.877778] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    0.879604] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    0.904882] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    0.930596] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    0.932635] Linux agpgart interface v0.103
+[    0.934181] loop: module loaded
+[    0.935337] scsi host0: ata_piix
+[    0.935819] scsi host1: ata_piix
+[    0.936252] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc0c0 irq 14
+[    0.937074] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc0c8 irq 15
+[    0.938180] libphy: Fixed MDIO Bus: probed
+[    0.938713] tun: Universal TUN/TAP device driver, 1.6
+[    0.939464] PPP generic driver version 2.4.2
+[    0.940099] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    0.940943] ehci-pci: EHCI PCI platform driver
+[    0.941490] ehci-platform: EHCI generic platform driver
+[    0.942132] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    0.942918] ohci-pci: OHCI PCI platform driver
+[    0.943533] ohci-platform: OHCI generic platform driver
+[    0.944498] uhci_hcd: USB Universal Host Controller Interface driver
+[    0.945453] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    0.947334] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    0.947995] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    0.948739] mousedev: PS/2 mouse device common for all mice
+[    0.949809] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    0.951351] rtc_cmos 00:00: RTC can wake from S4
+[    0.952237] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    0.953195] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    0.954183] i2c /dev entries driver
+[    0.954714] device-mapper: uevent: version 1.0.3
+[    0.955405] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    0.956604] ledtrig-cpu: registered to indicate activity on CPUs
+[    0.957611] NET: Registered protocol family 10
+[    0.961037] Segment Routing with IPv6
+[    0.961608] NET: Registered protocol family 17
+[    0.962268] Key type dns_resolver registered
+[    0.962950] mce: Using 10 MCE banks
+[    0.963476] RAS: Correctable Errors collector initialized.
+[    0.964206] sched_clock: Marking stable (964189362, 0)->(1159846726, -195657364)
+[    0.965316] registered taskstats version 1
+[    0.965919] Loading compiled-in X.509 certificates
+[    0.968393] Loaded X.509 cert 'Build time autogenerated kernel key: 01a66adcc10ca4ce7676a3458c33483b0e2b806e'
+[    0.969834] zswap: loaded using pool lzo/zbud
+[    0.972902] Key type big_key registered
+[    0.973427] Key type trusted registered
+[    0.975097] Key type encrypted registered
+[    0.975691] AppArmor: AppArmor sha1 policy hashing enabled
+[    0.976456] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    0.977235] ima: Allocated hash algorithm: sha1
+[    0.977798] evm: HMAC attrs: 0x1
+[    0.978573]   Magic number: 8:340:361
+[    0.979213] rtc_cmos 00:00: setting system clock to 2020-06-16 03:23:41 UTC (1592277821)
+[    0.980403] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    0.981201] EDD information not available.
+[    1.105517] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.108347] ata2.00: configured for MWDMA2
+[    1.110843] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.137088] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.139028] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.141522] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.147852] Freeing unused kernel image memory: 2436K
+[    1.156053] Write protecting the kernel read-only data: 20480k
+[    1.157246] Freeing unused kernel image memory: 2008K
+[    1.158193] Freeing unused kernel image memory: 1884K
+[    1.165684] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.166714] x86/mm: Checking user space page tables
+[    1.174440] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.262167] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.280685] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.285503] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.286807] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.289188]  vda: vda1 vda14 vda15
+[    1.301202] FDC 0 is a S82078B
+[    1.329171] virtio_net virtio0 ens3: renamed from eth0
+[    1.331166] virtio_net virtio1 ens4: renamed from eth1
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    1.420068] raid6: sse2x1   gen() 10332 MB/s
+[    1.468093] raid6: sse2x1   xor()  7215 MB/s
+[    1.516051] raid6: sse2x2   gen() 12571 MB/s
+[    1.564063] raid6: sse2x2   xor()  7904 MB/s
+[    1.612079] raid6: sse2x4   gen() 15435 MB/s
+[    1.660049] raid6: sse2x4   xor()  9082 MB/s
+[    1.660611] raid6: using algorithm sse2x4 gen() 15435 MB/s
+[    1.661310] raid6: .... xor() 9082 MB/s, rmw enabled
+[    1.661959] raid6: using intx1 recovery algorithm
+[    1.666441] xor: measuring software checksum speed
+[    1.704005]    prefetch64-sse: 18536.000 MB/sec
+[    1.744091]    generic_sse: 18159.000 MB/sec
+[    1.744651] xor: using function: prefetch64-sse (18536.000 MB/sec)
+[    1.762753] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    1.833874] random: fast init done
+[    1.916144] print_req_error: I/O error, dev fd0, sector 0
+[    1.917869] floppy: error 10 while reading block 0
+done.
+[    1.926012] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    1.927646] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    1.928683] random: wait-for-root: uninitialized urandom read (16 bytes read)
+Warning: fsck not present, so skipping root file system
+[    1.939028] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... done.
+[    2.145320] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.153630] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.157083] systemd[1]: Detected virtualization kvm.
+[    2.157875] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.3 LTS[0m!
+
+[    2.161581] systemd[1]: Set hostname to <autopkgtest>.
+[    2.302854] systemd[1]: Reached target Remote File Systems.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[    2.304925] systemd[1]: Reached target Swap.
+[[0;32m  OK  [0m] Reached target Swap.
+[    2.307244] systemd[1]: Created slice User and Session Slice.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[    2.310162] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
+[[0;32m  OK  [0m] Set up automount Arbitrary Executabâ¦rmats File System Automount Point.
+[    2.314186] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    2.316743] systemd[1]: Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Starting Remount Root and Kernel File Systems...
+         Mounting POSIX Message Queue File System...
+         Starting Load Kernel Modules...
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+[    2.357957] EXT4-fs (vda1): re-mounted. Opts: (null)
+         Starting Journal Service...
+         Mounting Kernel Debug File System...
+         Mounting Huge Pages File System...
+         Starting udev Coldplug all Devices...
+         Starting Uncomplicated firewall...
+         Starting Create list of required stâ¦ce nodes for the current kernel...
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+         Starting Set the console keyboard layout...
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Started Create list of required staâ¦vice nodes for the current kernel.
+         Starting Create Static Device Nodes in /dev...
+         Mounting FUSE Control File System...
+         Mounting Kernel Configuration File System...
+         Starting Apply Kernel Variables...
+         Starting Load/Save Random Seed...
+[[0;32m  OK  [0m] Started Journal Service.
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+         Starting udev Kernel Device Manager...
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Create Volatile Files and Directories...
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting AppArmor initialization...
+         Starting Set console font and keymap...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Network Name Resolution...
+         Starting Network Time Synchronization...
+         Starting Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Reached target Network.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Entropy daemon using the HAVEGE algorithm.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+[[0;32m  OK  [0m] Started irqbalance daemon.
+         Starting Permit User Sessions...
+         Starting LSB: Record successful boot for GRUB...
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+         Starting LSB: automatic crash report generation...
+         Starting OpenBSD Secure Shell server...
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting System Logging Service...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+         Starting Login Service...
+         Starting Thermal Daemon Service...
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started Login Service.
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+         Starting Discard unused blocks...
+         Starting Daily apt download activities...
+         Starting Message of the Day...
+         Starting Terminate Plymouth Boot Screen...
+         Starting Hold until boot process finishes up...
+[[0;32m  OK  [0m] Started Discard unused blocks.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+         Starting Daily apt upgrade and clean activities...
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+
+Ubuntu 18.04.3 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found ""login prompt on ttyS0""
+autopkgtest-virt-qemu: DBG: expect: "ok"
+autopkgtest-virt-qemu: DBG: expect: found ""b'ok'""
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on ttyS1
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "# "
+autopkgtest-virt-qemu: DBG: expect: found ""b'# '""
+autopkgtest-virt-qemu: DBG: Copying host timezone Etc/UTC to VM
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "/python"
+autopkgtest-virt-qemu: DBG: expect: found ""b'/python'""
+autopkgtest-virt-qemu: DBG: expect: "# "
+autopkgtest-virt-qemu: DBG: expect: found ""b'# '""
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd true
+autopkgtest-virt-qemu: DBG: can connect to autopkgtest sh in VM
+autopkgtest-virt-qemu: DBG: determine_normal_user: got user "ubuntu"
+autopkgtest-virt-qemu: DBG: auxverb = ['/tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd'], downtmp = None
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd mktemp --directory --tmpdir autopkgtest.XXXXXX
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd chmod 1777 /tmp/autopkgtest.Ihmrn9
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest.Ihmrn9
+autopkgtest: DBG: sending command to testbed: print-execute-command
+autopkgtest-virt-qemu: DBG: executing print-execute-command
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd
+autopkgtest: DBG: sending command to testbed: capabilities
+autopkgtest-virt-qemu: DBG: executing capabilities
+autopkgtest: DBG: got reply from testbed: ok revert revert-full-system root-on-testbed isolation-machine reboot suggested-normal-user=ubuntu
+autopkgtest: DBG: testbed capabilities: ['revert', 'revert-full-system', 'root-on-testbed', 'isolation-machine', 'reboot', 'suggested-normal-user=ubuntu']
+autopkgtest [03:23:57]: @@@@@@@@@@@@@@@@@@@@ test bed setup
+autopkgtest: DBG: testbed command ['bash', '-ec', 'for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do [ ! -d $d ] || touch -r $d /tmp/autopkgtest.Ihmrn9/${d//\\//_}.stamp; done'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '(O=$(bash -o pipefail -ec \'apt-get update | tee /proc/self/fd/2\') ||{ [ "${O%404*Not Found*}" = "$O" ] || exit 100; sleep 15; apt-get update; } || { sleep 60; apt-get update; } || false) && $(which eatmydata || true) apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew"'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/restricted Sources [7,716 B]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Sources [6,684 B]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/universe Sources [283 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main Sources [321 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [970 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [60.5 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,081 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [15.9 kB]
+Fetched 2,833 kB in 1s (2,080 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following packages were automatically installed and are no longer required:
+  python3-configobj python3-serial
+Use 'apt autoremove' to remove them.
+The following NEW packages will be installed:
+  libnetplan0 linux-headers-4.15.0-106 linux-headers-4.15.0-106-generic
+  linux-image-4.15.0-106-generic linux-modules-4.15.0-106-generic
+  linux-modules-extra-4.15.0-106-generic
+The following packages will be upgraded:
+  amd64-microcode apport apt apt-utils base-files bind9-host binutils
+  binutils-common binutils-x86-64-linux-gnu bsdutils ca-certificates cpio
+  distro-info-data dmidecode dmsetup dnsutils e2fsprogs fdisk file gcc-8-base
+  grub-common grub-efi-amd64 grub-efi-amd64-bin grub-efi-amd64-signed
+  grub2-common initramfs-tools initramfs-tools-bin initramfs-tools-core
+  intel-microcode iproute2 kmod libapt-inst2.0 libapt-pkg5.0 libbind9-160
+  libbinutils libblkid1 libbsd0 libcom-err2 libdevmapper1.02.1
+  libdns-export1100 libdns1100 libdrm-common libdrm2 libext2fs2 libfdisk1
+  libgcc1 libgcrypt20 libglib2.0-0 libglib2.0-data libgnutls30 libicu60
+  libidn2-0 libirs160 libisc-export169 libisc169 libisccc160 libisccfg160
+  libjson-c3 libkmod2 libldap-2.4-2 libldap-common liblwres160 libmagic-mgc
+  libmagic1 libmount1 libnss-systemd libpam-systemd libpcap0.8
+  libpython3.6-minimal libpython3.6-stdlib libsasl2-2 libsasl2-modules
+  libsasl2-modules-db libsmartcols1 libsqlite3-0 libss2 libssl1.1 libstdc++6
+  libsystemd0 libudev1 libuuid1 libxml2 linux-base linux-firmware
+  linux-generic linux-headers-generic linux-headers-virtual
+  linux-image-generic linux-image-virtual linux-virtual mount netplan.io nplan
+  openssl python-apt-common python3-apport python3-apt python3-problem-report
+  python3-software-properties python3.6 python3.6-minimal rsync
+  software-properties-common sudo systemd systemd-sysv tcpdump tzdata
+  ubuntu-minimal udev util-linux uuid-runtime vim-common vim-tiny xxd
+115 upgraded, 6 newly installed, 0 to remove and 0 not upgraded.
+Need to get 183 MB of archives.
+After this operation, 346 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 base-files amd64 10.1ubuntu2.8 [59.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bsdutils amd64 1:2.31.1-0.4ubuntu3.6 [60.3 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-bin amd64 0.130ubuntu3.9 [10.2 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-core all 0.130ubuntu3.9 [48.2 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools all 0.130ubuntu3.9 [9,568 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libext2fs2 amd64 1.44.1-1ubuntu1.3 [157 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 e2fsprogs amd64 1.44.1-1ubuntu1.3 [391 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnss-systemd amd64 237-3ubuntu10.41 [105 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libudev1 amd64 237-3ubuntu10.41 [56.8 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 udev amd64 237-3ubuntu10.41 [1,101 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpam-systemd amd64 237-3ubuntu10.41 [107 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd amd64 237-3ubuntu10.41 [2,914 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsystemd0 amd64 237-3ubuntu10.41 [207 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd-sysv amd64 237-3ubuntu10.41 [14.7 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 kmod amd64 24-1ubuntu3.4 [88.7 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libkmod2 amd64 24-1ubuntu3.4 [40.1 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libuuid1 amd64 2.31.1-0.4ubuntu3.6 [20.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libblkid1 amd64 2.31.1-0.4ubuntu3.6 [124 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmount1 amd64 2.31.1-0.4ubuntu3.6 [136 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libfdisk1 amd64 2.31.1-0.4ubuntu3.6 [164 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsmartcols1 amd64 2.31.1-0.4ubuntu3.6 [83.7 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 fdisk amd64 2.31.1-0.4ubuntu3.6 [108 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 util-linux amd64 2.31.1-0.4ubuntu3.6 [903 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 mount amd64 2.31.1-0.4ubuntu3.6 [107 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpio amd64 2.12+dfsg-6ubuntu0.18.04.1 [86.2 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-base all 4.5ubuntu1.1 [17.7 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-8-base amd64 8.4.0-1ubuntu1~18.04 [18.7 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcc1 amd64 1:8.4.0-1ubuntu1~18.04 [40.6 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libstdc++6 amd64 8.4.0-1ubuntu1~18.04 [400 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-pkg5.0 amd64 1.6.12ubuntu0.1 [807 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-inst2.0 amd64 1.6.12ubuntu0.1 [54.4 kB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt amd64 1.6.12ubuntu0.1 [1,201 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt-utils amd64 1.6.12ubuntu0.1 [207 kB]
+Get:34 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libidn2-0 amd64 2.0.4-1.1ubuntu0.2 [48.7 kB]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgnutls30 amd64 3.5.18-1ubuntu1.3 [646 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.1-1ubuntu2.1~18.04.6 [1,301 kB]
+Get:37 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3.6 amd64 3.6.9-1~18.04ubuntu1 [203 kB]
+Get:38 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython3.6-stdlib amd64 3.6.9-1~18.04ubuntu1 [1,710 kB]
+Get:39 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3.6-minimal amd64 3.6.9-1~18.04ubuntu1 [1,609 kB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython3.6-minimal amd64 3.6.9-1~18.04ubuntu1 [533 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsqlite3-0 amd64 3.22.0-1ubuntu0.4 [499 kB]
+Get:42 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 uuid-runtime amd64 2.31.1-0.4ubuntu3.6 [34.8 kB]
+Get:43 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcom-err2 amd64 1.44.1-1ubuntu1.3 [8,848 B]
+Get:44 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcrypt20 amd64 1.8.1-4ubuntu1.2 [417 kB]
+Get:45 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libss2 amd64 1.44.1-1ubuntu1.3 [11.1 kB]
+Get:46 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssl amd64 1.1.1-1ubuntu2.1~18.04.6 [614 kB]
+Get:47 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 ca-certificates all 20190110~18.04.1 [146 kB]
+Get:48 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info-data all 0.37ubuntu0.7 [4,676 B]
+Get:49 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdevmapper1.02.1 amd64 2:1.02.145-4.1ubuntu3.18.04.3 [127 kB]
+Get:50 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 dmsetup amd64 2:1.02.145-4.1ubuntu3.18.04.3 [74.4 kB]
+Get:51 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 file amd64 1:5.32-2ubuntu0.4 [22.1 kB]
+Get:52 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagic1 amd64 1:5.32-2ubuntu0.4 [68.6 kB]
+Get:53 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagic-mgc amd64 1:5.32-2ubuntu0.4 [184 kB]
+Get:54 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 iproute2 amd64 4.15.0-2ubuntu1.1 [723 kB]
+Get:55 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libbsd0 amd64 0.8.7-1ubuntu0.1 [41.6 kB]
+Get:56 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisc-export169 amd64 1:9.11.3+dfsg-1ubuntu1.12 [163 kB]
+Get:57 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdns-export1100 amd64 1:9.11.3+dfsg-1ubuntu1.12 [748 kB]
+Get:58 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libglib2.0-0 amd64 2.56.4-0ubuntu0.18.04.6 [1,171 kB]
+Get:59 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libglib2.0-data all 2.56.4-0ubuntu0.18.04.6 [4,540 B]
+Get:60 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libicu60 amd64 60.2-3ubuntu3.1 [8,054 kB]
+Get:61 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libjson-c3 amd64 0.12.1-1.3ubuntu0.3 [21.7 kB]
+Get:62 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libxml2 amd64 2.9.4+dfsg1-6.1ubuntu1.3 [663 kB]
+Get:63 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnetplan0 amd64 0.99-0ubuntu3~18.04.3 [22.6 kB]
+Get:64 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 netplan.io amd64 0.99-0ubuntu3~18.04.3 [70.7 kB]
+Get:65 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 nplan all 0.99-0ubuntu3~18.04.3 [1,800 B]
+Get:66 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 sudo amd64 1.8.21p2-3ubuntu1.2 [427 kB]
+Get:67 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 tzdata all 2020a-0ubuntu0.18.04 [190 kB]
+Get:68 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 xxd amd64 2:8.0.1453-1ubuntu1.3 [49.4 kB]
+Get:69 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 vim-tiny amd64 2:8.0.1453-1ubuntu1.3 [476 kB]
+Get:70 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 vim-common all 2:8.0.1453-1ubuntu1.3 [70.6 kB]
+Get:71 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 ubuntu-minimal amd64 1.417.4 [2,704 B]
+Get:72 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libirs160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [19.1 kB]
+Get:73 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bind9-host amd64 1:9.11.3+dfsg-1ubuntu1.12 [53.4 kB]
+Get:74 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 dnsutils amd64 1:9.11.3+dfsg-1ubuntu1.12 [145 kB]
+Get:75 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libbind9-160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [27.6 kB]
+Get:76 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisccfg160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [48.4 kB]
+Get:77 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisccc160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [17.9 kB]
+Get:78 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdns1100 amd64 1:9.11.3+dfsg-1ubuntu1.12 [967 kB]
+Get:79 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisc169 amd64 1:9.11.3+dfsg-1ubuntu1.12 [238 kB]
+Get:80 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 liblwres160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [34.6 kB]
+Get:81 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 dmidecode amd64 3.1-1ubuntu0.1 [50.9 kB]
+Get:82 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdrm-common all 2.4.99-1ubuntu1~18.04.2 [5,328 B]
+Get:83 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdrm2 amd64 2.4.99-1ubuntu1~18.04.2 [31.7 kB]
+Get:84 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpcap0.8 amd64 1.8.1-6ubuntu1.18.04.1 [118 kB]
+Get:85 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python-apt-common all 1.6.5ubuntu0.3 [16.8 kB]
+Get:86 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-apt amd64 1.6.5ubuntu0.3 [149 kB]
+Get:87 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 rsync amd64 3.1.2-2.1ubuntu1.1 [334 kB]
+Get:88 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 tcpdump amd64 4.9.3-0ubuntu0.18.04.1 [364 kB]
+Get:89 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64 amd64 2.02-2ubuntu8.15 [47.8 kB]
+Get:90 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:91 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-signed amd64 1.93.16+2.02-2ubuntu8.15 [299 kB]
+Get:92 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-bin amd64 2.02-2ubuntu8.15 [655 kB]
+Get:93 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1,775 kB]
+Get:94 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-problem-report all 2.20.9-0ubuntu7.15 [10.6 kB]
+Get:95 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-apport all 2.20.9-0ubuntu7.15 [82.2 kB]
+Get:96 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apport all 2.20.9-0ubuntu7.15 [124 kB]
+Get:97 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils-x86-64-linux-gnu amd64 2.30-21ubuntu1~18.04.3 [1,839 kB]
+Get:98 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils-common amd64 2.30-21ubuntu1~18.04.3 [196 kB]
+Get:99 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils amd64 2.30-21ubuntu1~18.04.3 [3,388 B]
+Get:100 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libbinutils amd64 2.30-21ubuntu1~18.04.3 [488 kB]
+Get:101 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-modules-db amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1 [14.8 kB]
+Get:102 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-2 amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1 [49.2 kB]
+Get:103 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libldap-common all 2.4.45+dfsg-1ubuntu1.5 [16.9 kB]
+Get:104 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libldap-2.4-2 amd64 2.4.45+dfsg-1ubuntu1.5 [155 kB]
+Get:105 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-modules amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1 [48.8 kB]
+Get:106 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:107 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-4.15.0-106-generic amd64 4.15.0-106.107 [13.0 MB]
+Get:108 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-4.15.0-106-generic amd64 4.15.0-106.107 [8,008 kB]
+Get:109 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-4.15.0-106-generic amd64 4.15.0-106.107 [32.8 MB]
+Get:110 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:111 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2,526 kB]
+Get:112 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic amd64 4.15.0.106.94 [1,868 B]
+Get:113 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic amd64 4.15.0.106.94 [2,472 B]
+Get:114 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-virtual amd64 4.15.0.106.94 [1,860 B]
+Get:115 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-virtual amd64 4.15.0.106.94 [2,452 B]
+Get:116 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-virtual amd64 4.15.0.106.94 [1,844 B]
+Get:117 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-106 all 4.15.0-106.107 [10.9 MB]
+Get:118 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-106-generic amd64 4.15.0-106.107 [1,098 kB]
+Get:119 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic amd64 4.15.0.106.94 [2,432 B]
+Get:120 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 software-properties-common all 0.96.24.32.13 [10.0 kB]
+Get:121 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-software-properties all 0.96.24.32.13 [23.8 kB]
+Preconfiguring packages ...
+Fetched 183 MB in 7s (26.1 MB/s)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../base-files_10.1ubuntu2.8_amd64.deb ...
+Warning: Stopping motd-news.service, but it can still be activated by:
+  motd-news.timer
+Unpacking base-files (10.1ubuntu2.8) over (10.1ubuntu2.7) ...
+Setting up base-files (10.1ubuntu2.8) ...
+Installing new version of config file /etc/issue ...
+Installing new version of config file /etc/issue.net ...
+Installing new version of config file /etc/lsb-release ...
+motd-news.service is a disabled or a static unit, not starting it.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../bsdutils_1%3a2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking bsdutils (1:2.31.1-0.4ubuntu3.6) over (1:2.31.1-0.4ubuntu3.4) ...
+Setting up bsdutils (1:2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../initramfs-tools-bin_0.130ubuntu3.9_amd64.deb ...
+Unpacking initramfs-tools-bin (0.130ubuntu3.9) over (0.130ubuntu3.8) ...
+Preparing to unpack .../initramfs-tools-core_0.130ubuntu3.9_all.deb ...
+Unpacking initramfs-tools-core (0.130ubuntu3.9) over (0.130ubuntu3.8) ...
+Preparing to unpack .../initramfs-tools_0.130ubuntu3.9_all.deb ...
+Unpacking initramfs-tools (0.130ubuntu3.9) over (0.130ubuntu3.8) ...
+Preparing to unpack .../libext2fs2_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking libext2fs2:amd64 (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up libext2fs2:amd64 (1.44.1-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../e2fsprogs_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking e2fsprogs (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up e2fsprogs (1.44.1-1ubuntu1.3) ...
+update-initramfs: deferring update (trigger activated)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libnss-systemd_237-3ubuntu10.41_amd64.deb ...
+Unpacking libnss-systemd:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../libudev1_237-3ubuntu10.41_amd64.deb ...
+Unpacking libudev1:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Setting up libudev1:amd64 (237-3ubuntu10.41) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../udev_237-3ubuntu10.41_amd64.deb ...
+Unpacking udev (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../libpam-systemd_237-3ubuntu10.41_amd64.deb ...
+Unpacking libpam-systemd:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../systemd_237-3ubuntu10.41_amd64.deb ...
+Unpacking systemd (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../libsystemd0_237-3ubuntu10.41_amd64.deb ...
+Unpacking libsystemd0:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Setting up libsystemd0:amd64 (237-3ubuntu10.41) ...
+Setting up systemd (237-3ubuntu10.41) ...
+Installing new version of config file /etc/dhcp/dhclient-enter-hooks.d/resolved ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../systemd-sysv_237-3ubuntu10.41_amd64.deb ...
+Unpacking systemd-sysv (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../kmod_24-1ubuntu3.4_amd64.deb ...
+Unpacking kmod (24-1ubuntu3.4) over (24-1ubuntu3.2) ...
+Preparing to unpack .../libkmod2_24-1ubuntu3.4_amd64.deb ...
+Unpacking libkmod2:amd64 (24-1ubuntu3.4) over (24-1ubuntu3.2) ...
+Preparing to unpack .../libuuid1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libuuid1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libuuid1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libblkid1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libblkid1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libblkid1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libmount1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libmount1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libmount1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libfdisk1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libfdisk1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libfdisk1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libsmartcols1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libsmartcols1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libsmartcols1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../fdisk_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking fdisk (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up fdisk (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../util-linux_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking util-linux (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up util-linux (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../mount_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking mount (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Preparing to unpack .../cpio_2.12+dfsg-6ubuntu0.18.04.1_amd64.deb ...
+Unpacking cpio (2.12+dfsg-6ubuntu0.18.04.1) over (2.12+dfsg-6) ...
+Preparing to unpack .../linux-base_4.5ubuntu1.1_all.deb ...
+Unpacking linux-base (4.5ubuntu1.1) over (4.5ubuntu1) ...
+Preparing to unpack .../gcc-8-base_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-8-base:amd64 (8.4.0-1ubuntu1~18.04) over (8.3.0-6ubuntu1~18.04.1) ...
+Setting up gcc-8-base:amd64 (8.4.0-1ubuntu1~18.04) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libgcc1_1%3a8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libgcc1:amd64 (1:8.4.0-1ubuntu1~18.04) over (1:8.3.0-6ubuntu1~18.04.1) ...
+Setting up libgcc1:amd64 (1:8.4.0-1ubuntu1~18.04) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libstdc++6_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libstdc++6:amd64 (8.4.0-1ubuntu1~18.04) over (8.3.0-6ubuntu1~18.04.1) ...
+Setting up libstdc++6:amd64 (8.4.0-1ubuntu1~18.04) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libapt-pkg5.0_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking libapt-pkg5.0:amd64 (1.6.12ubuntu0.1) over (1.6.12) ...
+Setting up libapt-pkg5.0:amd64 (1.6.12ubuntu0.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libapt-inst2.0_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking libapt-inst2.0:amd64 (1.6.12ubuntu0.1) over (1.6.12) ...
+Preparing to unpack .../apt_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking apt (1.6.12ubuntu0.1) over (1.6.12) ...
+Setting up apt (1.6.12ubuntu0.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../apt-utils_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking apt-utils (1.6.12ubuntu0.1) over (1.6.12) ...
+Preparing to unpack .../libidn2-0_2.0.4-1.1ubuntu0.2_amd64.deb ...
+Unpacking libidn2-0:amd64 (2.0.4-1.1ubuntu0.2) over (2.0.4-1.1build2) ...
+Setting up libidn2-0:amd64 (2.0.4-1.1ubuntu0.2) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libgnutls30_3.5.18-1ubuntu1.3_amd64.deb ...
+Unpacking libgnutls30:amd64 (3.5.18-1ubuntu1.3) over (3.5.18-1ubuntu1.1) ...
+Setting up libgnutls30:amd64 (3.5.18-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../0-libssl1.1_1.1.1-1ubuntu2.1~18.04.6_amd64.deb ...
+Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.6) over (1.1.1-1ubuntu2.1~18.04.4) ...
+Preparing to unpack .../1-python3.6_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking python3.6 (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../2-libpython3.6-stdlib_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking libpython3.6-stdlib:amd64 (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../3-python3.6-minimal_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking python3.6-minimal (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../4-libpython3.6-minimal_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking libpython3.6-minimal:amd64 (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../5-libsqlite3-0_3.22.0-1ubuntu0.4_amd64.deb ...
+Unpacking libsqlite3-0:amd64 (3.22.0-1ubuntu0.4) over (3.22.0-1ubuntu0.1) ...
+Preparing to unpack .../6-uuid-runtime_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking uuid-runtime (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Preparing to unpack .../7-libcom-err2_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking libcom-err2:amd64 (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up libcom-err2:amd64 (1.44.1-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libgcrypt20_1.8.1-4ubuntu1.2_amd64.deb ...
+Unpacking libgcrypt20:amd64 (1.8.1-4ubuntu1.2) over (1.8.1-4ubuntu1.1) ...
+Setting up libgcrypt20:amd64 (1.8.1-4ubuntu1.2) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libss2_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking libss2:amd64 (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up libss2:amd64 (1.44.1-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../00-openssl_1.1.1-1ubuntu2.1~18.04.6_amd64.deb ...
+Unpacking openssl (1.1.1-1ubuntu2.1~18.04.6) over (1.1.1-1ubuntu2.1~18.04.4) ...
+Preparing to unpack .../01-ca-certificates_20190110~18.04.1_all.deb ...
+Unpacking ca-certificates (20190110~18.04.1) over (20180409) ...
+Preparing to unpack .../02-distro-info-data_0.37ubuntu0.7_all.deb ...
+Unpacking distro-info-data (0.37ubuntu0.7) over (0.37ubuntu0.6) ...
+Preparing to unpack .../03-libdevmapper1.02.1_2%3a1.02.145-4.1ubuntu3.18.04.3_amd64.deb ...
+Unpacking libdevmapper1.02.1:amd64 (2:1.02.145-4.1ubuntu3.18.04.3) over (2:1.02.145-4.1ubuntu3.18.04.1) ...
+Preparing to unpack .../04-dmsetup_2%3a1.02.145-4.1ubuntu3.18.04.3_amd64.deb ...
+Unpacking dmsetup (2:1.02.145-4.1ubuntu3.18.04.3) over (2:1.02.145-4.1ubuntu3.18.04.1) ...
+Preparing to unpack .../05-file_1%3a5.32-2ubuntu0.4_amd64.deb ...
+Unpacking file (1:5.32-2ubuntu0.4) over (1:5.32-2ubuntu0.2) ...
+Preparing to unpack .../06-libmagic1_1%3a5.32-2ubuntu0.4_amd64.deb ...
+Unpacking libmagic1:amd64 (1:5.32-2ubuntu0.4) over (1:5.32-2ubuntu0.2) ...
+Preparing to unpack .../07-libmagic-mgc_1%3a5.32-2ubuntu0.4_amd64.deb ...
+Unpacking libmagic-mgc (1:5.32-2ubuntu0.4) over (1:5.32-2ubuntu0.2) ...
+Preparing to unpack .../08-iproute2_4.15.0-2ubuntu1.1_amd64.deb ...
+Unpacking iproute2 (4.15.0-2ubuntu1.1) over (4.15.0-2ubuntu1) ...
+Preparing to unpack .../09-libbsd0_0.8.7-1ubuntu0.1_amd64.deb ...
+Unpacking libbsd0:amd64 (0.8.7-1ubuntu0.1) over (0.8.7-1) ...
+Preparing to unpack .../10-libisc-export169_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisc-export169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../11-libdns-export1100_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libdns-export1100 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../12-libglib2.0-0_2.56.4-0ubuntu0.18.04.6_amd64.deb ...
+Unpacking libglib2.0-0:amd64 (2.56.4-0ubuntu0.18.04.6) over (2.56.4-0ubuntu0.18.04.4) ...
+Preparing to unpack .../13-libglib2.0-data_2.56.4-0ubuntu0.18.04.6_all.deb ...
+Unpacking libglib2.0-data (2.56.4-0ubuntu0.18.04.6) over (2.56.4-0ubuntu0.18.04.4) ...
+Preparing to unpack .../14-libicu60_60.2-3ubuntu3.1_amd64.deb ...
+Unpacking libicu60:amd64 (60.2-3ubuntu3.1) over (60.2-3ubuntu3) ...
+Preparing to unpack .../15-libjson-c3_0.12.1-1.3ubuntu0.3_amd64.deb ...
+Unpacking libjson-c3:amd64 (0.12.1-1.3ubuntu0.3) over (0.12.1-1.3) ...
+Preparing to unpack .../16-libxml2_2.9.4+dfsg1-6.1ubuntu1.3_amd64.deb ...
+Unpacking libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.3) over (2.9.4+dfsg1-6.1ubuntu1.2) ...
+Selecting previously unselected package libnetplan0:amd64.
+Preparing to unpack .../17-libnetplan0_0.99-0ubuntu3~18.04.3_amd64.deb ...
+Unpacking libnetplan0:amd64 (0.99-0ubuntu3~18.04.3) ...
+Preparing to unpack .../18-netplan.io_0.99-0ubuntu3~18.04.3_amd64.deb ...
+Unpacking netplan.io (0.99-0ubuntu3~18.04.3) over (0.98-0ubuntu1~18.04.1) ...
+Preparing to unpack .../19-nplan_0.99-0ubuntu3~18.04.3_all.deb ...
+Unpacking nplan (0.99-0ubuntu3~18.04.3) over (0.98-0ubuntu1~18.04.1) ...
+Preparing to unpack .../20-sudo_1.8.21p2-3ubuntu1.2_amd64.deb ...
+Unpacking sudo (1.8.21p2-3ubuntu1.2) over (1.8.21p2-3ubuntu1.1) ...
+Preparing to unpack .../21-tzdata_2020a-0ubuntu0.18.04_all.deb ...
+Unpacking tzdata (2020a-0ubuntu0.18.04) over (2019c-0ubuntu0.18.04) ...
+Preparing to unpack .../22-xxd_2%3a8.0.1453-1ubuntu1.3_amd64.deb ...
+Unpacking xxd (2:8.0.1453-1ubuntu1.3) over (2:8.0.1453-1ubuntu1.1) ...
+Preparing to unpack .../23-vim-tiny_2%3a8.0.1453-1ubuntu1.3_amd64.deb ...
+Unpacking vim-tiny (2:8.0.1453-1ubuntu1.3) over (2:8.0.1453-1ubuntu1.1) ...
+Preparing to unpack .../24-vim-common_2%3a8.0.1453-1ubuntu1.3_all.deb ...
+Unpacking vim-common (2:8.0.1453-1ubuntu1.3) over (2:8.0.1453-1ubuntu1.1) ...
+Preparing to unpack .../25-ubuntu-minimal_1.417.4_amd64.deb ...
+Unpacking ubuntu-minimal (1.417.4) over (1.417.3) ...
+Preparing to unpack .../26-libirs160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libirs160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../27-bind9-host_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking bind9-host (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../28-dnsutils_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking dnsutils (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../29-libbind9-160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libbind9-160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../30-libisccfg160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisccfg160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../31-libisccc160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisccc160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../32-libdns1100_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libdns1100:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../33-libisc169_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisc169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../34-liblwres160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking liblwres160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../35-dmidecode_3.1-1ubuntu0.1_amd64.deb ...
+Unpacking dmidecode (3.1-1ubuntu0.1) over (3.1-1) ...
+Preparing to unpack .../36-libdrm-common_2.4.99-1ubuntu1~18.04.2_all.deb ...
+Unpacking libdrm-common (2.4.99-1ubuntu1~18.04.2) over (2.4.97-1ubuntu1~18.04.1) ...
+Preparing to unpack .../37-libdrm2_2.4.99-1ubuntu1~18.04.2_amd64.deb ...
+Unpacking libdrm2:amd64 (2.4.99-1ubuntu1~18.04.2) over (2.4.97-1ubuntu1~18.04.1) ...
+Preparing to unpack .../38-libpcap0.8_1.8.1-6ubuntu1.18.04.1_amd64.deb ...
+Unpacking libpcap0.8:amd64 (1.8.1-6ubuntu1.18.04.1) over (1.8.1-6ubuntu1) ...
+Preparing to unpack .../39-python-apt-common_1.6.5ubuntu0.3_all.deb ...
+Unpacking python-apt-common (1.6.5ubuntu0.3) over (1.6.4) ...
+Preparing to unpack .../40-python3-apt_1.6.5ubuntu0.3_amd64.deb ...
+Unpacking python3-apt (1.6.5ubuntu0.3) over (1.6.4) ...
+Preparing to unpack .../41-rsync_3.1.2-2.1ubuntu1.1_amd64.deb ...
+Unpacking rsync (3.1.2-2.1ubuntu1.1) over (3.1.2-2.1ubuntu1) ...
+Preparing to unpack .../42-tcpdump_4.9.3-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking tcpdump (4.9.3-0ubuntu0.18.04.1) over (4.9.2-3) ...
+Preparing to unpack .../43-grub-efi-amd64_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-efi-amd64 (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../44-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../45-grub-efi-amd64-signed_1.93.16+2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-efi-amd64-signed (1.93.16+2.02-2ubuntu8.15) over (1.93.14+2.02-2ubuntu8.13) ...
+Preparing to unpack .../46-grub-efi-amd64-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-efi-amd64-bin (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../47-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../48-python3-problem-report_2.20.9-0ubuntu7.15_all.deb ...
+Unpacking python3-problem-report (2.20.9-0ubuntu7.15) over (2.20.9-0ubuntu7.7) ...
+Preparing to unpack .../49-python3-apport_2.20.9-0ubuntu7.15_all.deb ...
+Unpacking python3-apport (2.20.9-0ubuntu7.15) over (2.20.9-0ubuntu7.7) ...
+Preparing to unpack .../50-apport_2.20.9-0ubuntu7.15_all.deb ...
+Unpacking apport (2.20.9-0ubuntu7.15) over (2.20.9-0ubuntu7.7) ...
+Preparing to unpack .../51-binutils-x86-64-linux-gnu_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking binutils-x86-64-linux-gnu (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../52-binutils-common_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking binutils-common:amd64 (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../53-binutils_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking binutils (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../54-libbinutils_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking libbinutils:amd64 (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../55-libsasl2-modules-db_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb ...
+Unpacking libsasl2-modules-db:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) over (2.1.27~101-g0780600+dfsg-3ubuntu2) ...
+Preparing to unpack .../56-libsasl2-2_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb ...
+Unpacking libsasl2-2:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) over (2.1.27~101-g0780600+dfsg-3ubuntu2) ...
+Preparing to unpack .../57-libldap-common_2.4.45+dfsg-1ubuntu1.5_all.deb ...
+Unpacking libldap-common (2.4.45+dfsg-1ubuntu1.5) over (2.4.45+dfsg-1ubuntu1.4) ...
+Preparing to unpack .../58-libldap-2.4-2_2.4.45+dfsg-1ubuntu1.5_amd64.deb ...
+Unpacking libldap-2.4-2:amd64 (2.4.45+dfsg-1ubuntu1.5) over (2.4.45+dfsg-1ubuntu1.4) ...
+Preparing to unpack .../59-libsasl2-modules_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb ...
+Unpacking libsasl2-modules:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) over (2.1.27~101-g0780600+dfsg-3ubuntu2) ...
+Preparing to unpack .../60-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) over (1.173.9) ...
+Selecting previously unselected package linux-modules-4.15.0-106-generic.
+Preparing to unpack .../61-linux-modules-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-modules-4.15.0-106-generic (4.15.0-106.107) ...
+Selecting previously unselected package linux-image-4.15.0-106-generic.
+Preparing to unpack .../62-linux-image-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-image-4.15.0-106-generic (4.15.0-106.107) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-106-generic.
+Preparing to unpack .../63-linux-modules-extra-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-106-generic (4.15.0-106.107) ...
+Preparing to unpack .../64-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) over (3.20180524.1~ubuntu0.18.04.2) ...
+Preparing to unpack .../65-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) over (3.20190618.0ubuntu0.18.04.1) ...
+Preparing to unpack .../66-linux-generic_4.15.0.106.94_amd64.deb ...
+Unpacking linux-generic (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../67-linux-image-generic_4.15.0.106.94_amd64.deb ...
+Unpacking linux-image-generic (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../68-linux-virtual_4.15.0.106.94_amd64.deb ...
+Unpacking linux-virtual (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../69-linux-image-virtual_4.15.0.106.94_amd64.deb ...
+Unpacking linux-image-virtual (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../70-linux-headers-virtual_4.15.0.106.94_amd64.deb ...
+Unpacking linux-headers-virtual (4.15.0.106.94) over (4.15.0.66.68) ...
+Selecting previously unselected package linux-headers-4.15.0-106.
+Preparing to unpack .../71-linux-headers-4.15.0-106_4.15.0-106.107_all.deb ...
+Unpacking linux-headers-4.15.0-106 (4.15.0-106.107) ...
+Selecting previously unselected package linux-headers-4.15.0-106-generic.
+Preparing to unpack .../72-linux-headers-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-headers-4.15.0-106-generic (4.15.0-106.107) ...
+Preparing to unpack .../73-linux-headers-generic_4.15.0.106.94_amd64.deb ...
+Unpacking linux-headers-generic (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../74-software-properties-common_0.96.24.32.13_all.deb ...
+Unpacking software-properties-common (0.96.24.32.13) over (0.96.24.32.11) ...
+Preparing to unpack .../75-python3-software-properties_0.96.24.32.13_all.deb ...
+Unpacking python3-software-properties (0.96.24.32.13) over (0.96.24.32.11) ...
+Setting up python-apt-common (1.6.5ubuntu0.3) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up libapt-inst2.0:amd64 (1.6.12ubuntu0.1) ...
+Setting up libnss-systemd:amd64 (237-3ubuntu10.41) ...
+Setting up cpio (2.12+dfsg-6ubuntu0.18.04.1) ...
+Setting up libicu60:amd64 (60.2-3ubuntu3.1) ...
+Setting up python3-apt (1.6.5ubuntu0.3) ...
+Setting up xxd (2:8.0.1453-1ubuntu1.3) ...
+Setting up sudo (1.8.21p2-3ubuntu1.2) ...
+Setting up linux-headers-4.15.0-106 (4.15.0-106.107) ...
+Setting up dmidecode (3.1-1ubuntu0.1) ...
+Setting up libldap-common (2.4.45+dfsg-1ubuntu1.5) ...
+Setting up apt-utils (1.6.12ubuntu0.1) ...
+Setting up linux-modules-4.15.0-106-generic (4.15.0-106.107) ...
+Setting up libjson-c3:amd64 (0.12.1-1.3ubuntu0.3) ...
+Setting up tzdata (2020a-0ubuntu0.18.04) ...
+
+Current default time zone: 'Etc/UTC'
+Local time is now:      Tue Jun 16 03:24:42 UTC 2020.
+Universal Time is now:  Tue Jun 16 03:24:42 UTC 2020.
+Run 'dpkg-reconfigure tzdata' if you wish to change it.
+
+Setting up systemd-sysv (237-3ubuntu10.41) ...
+Setting up libglib2.0-0:amd64 (2.56.4-0ubuntu0.18.04.6) ...
+No schema files found: doing nothing.
+Setting up libsasl2-modules-db:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) ...
+Setting up linux-base (4.5ubuntu1.1) ...
+Setting up mount (2.31.1-0.4ubuntu3.6) ...
+Setting up libsasl2-2:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) ...
+Setting up distro-info-data (0.37ubuntu0.7) ...
+Setting up libdevmapper1.02.1:amd64 (2:1.02.145-4.1ubuntu3.18.04.3) ...
+Setting up iproute2 (4.15.0-2ubuntu1.1) ...
+Setting up libbsd0:amd64 (0.8.7-1ubuntu0.1) ...
+Setting up libkmod2:amd64 (24-1ubuntu3.4) ...
+Setting up libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.3) ...
+Setting up libmagic-mgc (1:5.32-2ubuntu0.4) ...
+Setting up uuid-runtime (2.31.1-0.4ubuntu3.6) ...
+Setting up libmagic1:amd64 (1:5.32-2ubuntu0.4) ...
+Setting up libdrm-common (2.4.99-1ubuntu1~18.04.2) ...
+Setting up rsync (3.1.2-2.1ubuntu1.1) ...
+Setting up python3-problem-report (2.20.9-0ubuntu7.15) ...
+Setting up binutils-common:amd64 (2.30-21ubuntu1~18.04.3) ...
+Setting up libglib2.0-data (2.56.4-0ubuntu0.18.04.6) ...
+Setting up udev (237-3ubuntu10.41) ...
+update-initramfs: deferring update (trigger activated)
+Setting up libldap-2.4-2:amd64 (2.4.45+dfsg-1ubuntu1.5) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.6) ...
+Setting up openssl (1.1.1-1ubuntu2.1~18.04.6) ...
+Setting up vim-common (2:8.0.1453-1ubuntu1.3) ...
+Setting up libsqlite3-0:amd64 (3.22.0-1ubuntu0.4) ...
+Setting up dmsetup (2:1.02.145-4.1ubuntu3.18.04.3) ...
+update-initramfs: deferring update (trigger activated)
+Setting up python3-software-properties (0.96.24.32.13) ...
+Setting up initramfs-tools-bin (0.130ubuntu3.9) ...
+Setting up libnetplan0:amd64 (0.99-0ubuntu3~18.04.3) ...
+Setting up libsasl2-modules:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) ...
+Setting up ca-certificates (20190110~18.04.1) ...
+Updating certificates in /etc/ssl/certs...
+2 added, 8 removed; done.
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-66-generic
+update-initramfs: Generating /boot/initrd.img-4.15.0-65-generic
+Setting up liblwres160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up libpcap0.8:amd64 (1.8.1-6ubuntu1.18.04.1) ...
+Setting up software-properties-common (0.96.24.32.13) ...
+Setting up vim-tiny (2:8.0.1453-1ubuntu1.3) ...
+Setting up libisc169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up kmod (24-1ubuntu3.4) ...
+Installing new version of config file /etc/modprobe.d/blacklist-framebuffer.conf ...
+Setting up libisccc160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-headers-4.15.0-106-generic (4.15.0-106.107) ...
+Setting up libpam-systemd:amd64 (237-3ubuntu10.41) ...
+Setting up grub-efi-amd64-bin (2.02-2ubuntu8.15) ...
+Setting up libbinutils:amd64 (2.30-21ubuntu1~18.04.3) ...
+Setting up initramfs-tools-core (0.130ubuntu3.9) ...
+Setting up libisc-export169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: deferring update (trigger activated)
+Setting up netplan.io (0.99-0ubuntu3~18.04.3) ...
+Setting up file (1:5.32-2ubuntu0.4) ...
+Setting up python3-apport (2.20.9-0ubuntu7.15) ...
+Setting up tcpdump (4.9.3-0ubuntu0.18.04.1) ...
+Setting up libdrm2:amd64 (2.4.99-1ubuntu1~18.04.2) ...
+Setting up libpython3.6-minimal:amd64 (3.6.9-1~18.04ubuntu1) ...
+Setting up nplan (0.99-0ubuntu3~18.04.3) ...
+Setting up linux-image-4.15.0-106-generic (4.15.0-106.107) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-66-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-66-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-106-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-106-generic
+Setting up libdns-export1100 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up apport (2.20.9-0ubuntu7.15) ...
+Installing new version of config file /etc/init.d/apport ...
+apport-autoreport.service is a disabled or a static unit, not starting it.
+Setting up ubuntu-minimal (1.417.4) ...
+Setting up libdns1100:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-headers-generic (4.15.0.106.94) ...
+Setting up binutils-x86-64-linux-gnu (2.30-21ubuntu1~18.04.3) ...
+Setting up libpython3.6-stdlib:amd64 (3.6.9-1~18.04ubuntu1) ...
+Setting up grub-efi-amd64 (2.02-2ubuntu8.15) ...
+Sourcing file `/etc/default/grub'
+Sourcing file `/etc/default/grub.d/50-cloudimg-settings.cfg'
+Sourcing file `/etc/default/grub.d/90-autopkgtest.cfg'
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-4.15.0-106-generic
+Found linux image: /boot/vmlinuz-4.15.0-66-generic
+Found initrd image: /boot/initrd.img-4.15.0-66-generic
+Found linux image: /boot/vmlinuz-4.15.0-65-generic
+Found initrd image: /boot/initrd.img-4.15.0-65-generic
+Found Ubuntu 18.04.3 LTS (18.04) on /dev/vdb1
+done
+Setting up linux-modules-extra-4.15.0-106-generic (4.15.0-106.107) ...
+Setting up python3.6-minimal (3.6.9-1~18.04ubuntu1) ...
+Setting up grub-efi-amd64-signed (1.93.16+2.02-2ubuntu8.15) ...
+Setting up libisccfg160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-image-virtual (4.15.0.106.94) ...
+Setting up linux-headers-virtual (4.15.0.106.94) ...
+Setting up linux-virtual (4.15.0.106.94) ...
+Setting up binutils (2.30-21ubuntu1~18.04.3) ...
+Setting up linux-image-generic (4.15.0.106.94) ...
+Setting up python3.6 (3.6.9-1~18.04ubuntu1) ...
+Setting up libirs160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up libbind9-160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-generic (4.15.0.106.94) ...
+Setting up bind9-host (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up dnsutils (1:9.11.3+dfsg-1ubuntu1.12) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for mime-support (3.60ubuntu1) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for plymouth-theme-ubuntu-text (0.9.3-1ubuntu7.18.04.2) ...
+update-initramfs: deferring update (trigger activated)
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for ca-certificates (20190110~18.04.1) ...
+Updating certificates in /etc/ssl/certs...
+0 added, 0 removed; done.
+Running hooks in /etc/ca-certificates/update.d...
+done.
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-66-generic
+Processing triggers for linux-image-4.15.0-106-generic (4.15.0-106.107) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-106-generic
+/etc/kernel/postinst.d/x-grub-legacy-ec2:
+Searching for GRUB installation directory ... found: /boot/grub
+Searching for default file ... found: /boot/grub/default
+Testing for an existing GRUB menu.lst file ... found: /boot/grub/menu.lst
+Searching for splash image ... none found, skipping ...
+Found kernel: /boot/vmlinuz-4.15.0-65-generic
+Found kernel: /boot/vmlinuz-4.15.0-106-generic
+Found kernel: /boot/vmlinuz-4.15.0-66-generic
+Found kernel: /boot/vmlinuz-4.15.0-65-generic
+Updating /boot/grub/menu.lst ... done
+
+/etc/kernel/postinst.d/zz-update-grub:
+Sourcing file `/etc/default/grub'
+Sourcing file `/etc/default/grub.d/50-cloudimg-settings.cfg'
+Sourcing file `/etc/default/grub.d/90-autopkgtest.cfg'
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-4.15.0-106-generic
+Found initrd image: /boot/initrd.img-4.15.0-106-generic
+Found linux image: /boot/vmlinuz-4.15.0-66-generic
+Found initrd image: /boot/initrd.img-4.15.0-66-generic
+Found linux image: /boot/vmlinuz-4.15.0-65-generic
+Found initrd image: /boot/initrd.img-4.15.0-65-generic
+Found Ubuntu 18.04.3 LTS (18.04) on /dev/vdb1
+done
+Processing triggers for shim-signed (1.37~18.04.3+15+1533136590.3beb971-0ubuntu1) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Reading package lists...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['bash', '-ec', '[ ! -e /run/autopkgtest_no_reboot.stamp ] || exit 0;for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do s=/tmp/autopkgtest.Ihmrn9/${d//\\//_}.stamp;  [ ! -d $d ] || [ `stat -c %Y $d` = `stat -c %Y $s` ]; done'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest [03:26:03]: rebooting testbed after setup commands that affected boot
+autopkgtest: DBG: sending command to testbed: reboot
+autopkgtest-virt-qemu: DBG: executing reboot
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec for d in /var/cache /home; do if [ -w $d ]; then   tar --warning=none --create --absolute-names     -f $d/autopkgtest-tmpdir.tar '/tmp/autopkgtest.Ihmrn9';   rm -f /run/autopkgtest-reboot-prepare-mark;   exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: saved current downtmp, rebooting
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -c (sleep 3; reboot) >/dev/null 2>&1 &
+autopkgtest-virt-qemu: DBG: expect: " login: "
+[[0;32m  OK  [0m] Stopped target Graphical Interface.
+[[0;32m  OK  [0m] Closed Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Stopped target Multi-User System.
+[[0;32m  OK  [0m] Stopped target Login Prompts.
+         Stopping Getty on tty1...
+         Stopping Serial Getty on ttyS0...
+         Stopping LSB: automatic crash report generation...
+         Stopping Dispatcher daemon for systemd-networkd...
+         Stopping Deferred execution scheduler...
+         Stopping LSB: Record successful boot for GRUB...
+         Stopping Regular background program processing daemon...
+         Stopping OpenBSD Secure Shell server...
+[[0;32m  OK  [0m] Stopped target Host and Network Name Lookups.
+         Stopping D-Bus System Message Bus...
+         Stopping Daemon for generating UUIDs...
+         Stopping System Logging Service...
+         Stopping autopkgtest root shell on ttyS1...
+         Stopping Login Service...
+[[0;32m  OK  [0m] Stopped target Timers.
+[[0;32m  OK  [0m] Stopped Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Stopped Discard unused blocks once a week.
+[[0;32m  OK  [0m] Stopped Message of the Day.
+[[0;32m  OK  [0m] Stopped Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Stopped Daily apt download activities.
+[[0;32m  OK  [0m] Stopped target System Time Synchronized.
+[[0;32m  OK  [0m] Stopped Regular background program processing daemon.
+[[0;32m  OK  [0m] Stopped autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Stopped Deferred execution scheduler.
+[[0;32m  OK  [0m] Stopped Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Stopped System Logging Service.
+[[0;32m  OK  [0m] Stopped Login Service.
+[[0;32m  OK  [0m] Stopped OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Stopped Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Stopped Getty on tty1.
+[[0;32m  OK  [0m] Stopped Daemon for generating UUIDs.
+[[0;32m  OK  [0m] Stopped D-Bus System Message Bus.
+[[0;32m  OK  [0m] Stopped LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Stopped LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Removed slice system-getty.slice.
+[[0;32m  OK  [0m] Removed slice system-serial\x2dgetty.slice.
+         Stopping Permit User Sessions...
+[[0;32m  OK  [0m] Stopped Permit User Sessions.
+[[0;32m  OK  [0m] Stopped target Network.
+         Stopping Network Name Resolution...
+[[0;32m  OK  [0m] Stopped target Remote File Systems.
+[[0;32m  OK  [0m] Stopped target Basic System.
+[[0;32m  OK  [0m] Stopped target Sockets.
+[[0;32m  OK  [0m] Closed Syslog Socket.
+[[0;32m  OK  [0m] Closed ACPID Listen Socket.
+[[0;32m  OK  [0m] Closed UUID daemon activation socket.
+[[0;32m  OK  [0m] Closed D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Stopped target Paths.
+[[0;32m  OK  [0m] Stopped ACPI Events Check.
+[[0;32m  OK  [0m] Stopped target System Initialization.
+[[0;32m  OK  [0m] Stopped target Local Encrypted Volumes.
+         Stopping Network Time Synchronization...
+         Stopping Update UTMP about System Boot/Shutdown...
+         Stopping Load/Save Random Seed...
+[[0;32m  OK  [0m] Stopped target Swap.
+[[0;32m  OK  [0m] Stopped Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Stopped Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Stopped target Slices.
+[[0;32m  OK  [0m] Removed slice User and Session Slice.
+[[0;32m  OK  [0m] Stopped Network Name Resolution.
+[[0;32m  OK  [0m] Stopped Network Time Synchronization.
+[[0;32m  OK  [0m] Stopped Load/Save Random Seed.
+[[0;32m  OK  [0m] Stopped Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Stopped Create Volatile Files and Directories.
+[[0;32m  OK  [0m] Stopped target Local File Systems.
+         Unmounting /run/autopkgtest/shared...
+         Unmounting /boot/efi...
+         Stopping Network Service...
+[[0;32m  OK  [0m] Stopped Network Service.
+[[0;32m  OK  [0m] Stopped Apply Kernel Variables.
+[[0;32m  OK  [0m] Stopped Load Kernel Modules.
+[[0;32m  OK  [0m] Unmounted /run/autopkgtest/shared.
+[[0;32m  OK  [0m] Unmounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Unmount All Filesystems.
+[[0;32m  OK  [0m] Stopped target Local File Systems (Pre).
+[[0;32m  OK  [0m] Stopped Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Stopped Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Reached target Shutdown.
+[[0;32m  OK  [0m] Reached target Final Step.
+         Starting Reboot...
+[  146.086302] reboot: Restarting system
+[    0.000000] Linux version 4.15.0-106-generic (buildd@lcy01-amd64-016) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 (Ubuntu 4.15.0-106.107-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-106-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffddfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffde000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1ubuntu1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0xbffde max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] found SMP MP-table at [mem 0x000f6a80-0x000f6a8f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x3338b000-0x359bcfff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F68A0 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE15FC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE1458 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001418 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE154C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE15C4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x00000000bffddfff]
+[    0.000000] NODE_DATA(0) allocated [mem 0xbffb3000-0xbffddfff]
+[    0.000000] kvm-clock: cpu 0, msr 0:bff32001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 159615753399 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000bffddfff]
+[    0.000000]   Normal   empty
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffddfff]
+[    0.000000] Reserved but unavailable: 98 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x00000000bffddfff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 1 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x4fd with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:1 nr_cpu_ids:1 nr_node_ids:1
+[    0.000000] percpu: Embedded 45 pages/cpu s147456 r8192 d28672 u2097152
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr bfc23040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 773991
+[    0.000000] Policy zone: DMA32
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-106-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 3027636K/3145200K available (12300K kernel code, 2481K rwdata, 4272K rodata, 2436K init, 2720K bss, 117564K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39378 entries in 154 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=1.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
+[    0.004000] NR_IRQS: 524544, nr_irqs: 256, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004009] APIC: Switch to symmetric I/O mode setup
+[    0.006312] x2apic enabled
+[    0.007956] Switched APIC routing to physical x2apic.
+[    0.011247] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.012000] tsc: Detected 2397.222 MHz processor
+[    0.012007] Calibrating delay loop (skipped) preset value.. 4794.44 BogoMIPS (lpj=9588888)
+[    0.013449] pid_max: default: 32768 minimum: 301
+[    0.014271] Security Framework initialized
+[    0.014979] Yama: becoming mindful.
+[    0.015648] AppArmor: AppArmor initialized
+[    0.016718] Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.018293] Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes)
+[    0.020019] Mount-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.021173] Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.022657] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.023578] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.024003] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.025465] Spectre V2 : Mitigation: Full generic retpoline
+[    0.026411] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.028003] Speculative Store Bypass: Vulnerable
+[    0.028821] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.039161] Freeing SMP alternatives memory: 36K
+[    0.149984] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.152000] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.152048] Hierarchical SRCU implementation.
+[    0.154157] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.156003] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.157621] smp: Bringing up secondary CPUs ...
+[    0.158808] smp: Brought up 1 node, 1 CPU
+[    0.160003] smpboot: Max logical packages: 1
+[    0.161112] smpboot: Total of 1 processors activated (4794.44 BogoMIPS)
+[    0.163088] devtmpfs: initialized
+[    0.164081] x86/mm: Memory block size: 128MB
+[    0.165574] evm: security.selinux
+[    0.166437] evm: security.SMACK64
+[    0.167286] evm: security.SMACK64EXEC
+[    0.168005] evm: security.SMACK64TRANSMUTE
+[    0.169060] evm: security.SMACK64MMAP
+[    0.170004] evm: security.apparmor
+[    0.170879] evm: security.ima
+[    0.172003] evm: security.capability
+[    0.173068] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.175564] futex hash table entries: 256 (order: 2, 16384 bytes)
+[    0.176070] pinctrl core: initialized pinctrl subsystem
+[    0.177649] RTC time:  3:26:20, date: 06/16/20
+[    0.180132] NET: Registered protocol family 16
+[    0.181536] audit: initializing netlink subsys (disabled)
+[    0.183398] cpuidle: using governor ladder
+[    0.184005] cpuidle: using governor menu
+[    0.185244] ACPI: bus type PCI registered
+[    0.186431] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.188010] audit: type=2000 audit(1592277979.051:1): state=initialized audit_enabled=0 res=1
+[    0.190702] PCI: Using configuration type 1 for base access
+[    0.193890] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.196223] ACPI: Added _OSI(Module Device)
+[    0.196923] ACPI: Added _OSI(Processor Device)
+[    0.197641] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.198395] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.200013] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.200733] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.201592] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.203248] ACPI: Interpreter enabled
+[    0.204038] ACPI: (supports S0 S3 S4 S5)
+[    0.204754] ACPI: Using IOAPIC for interrupt routing
+[    0.205673] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.207462] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.211070] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.212009] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.213237] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.214395] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.216333] acpiphp: Slot [3] registered
+[    0.217079] acpiphp: Slot [4] registered
+[    0.217826] acpiphp: Slot [5] registered
+[    0.218577] acpiphp: Slot [6] registered
+[    0.220047] acpiphp: Slot [7] registered
+[    0.220798] acpiphp: Slot [8] registered
+[    0.221545] acpiphp: Slot [9] registered
+[    0.222291] acpiphp: Slot [10] registered
+[    0.223041] acpiphp: Slot [11] registered
+[    0.224046] acpiphp: Slot [12] registered
+[    0.224801] acpiphp: Slot [13] registered
+[    0.225572] acpiphp: Slot [14] registered
+[    0.226342] acpiphp: Slot [15] registered
+[    0.227093] acpiphp: Slot [16] registered
+[    0.228045] acpiphp: Slot [17] registered
+[    0.228797] acpiphp: Slot [18] registered
+[    0.229552] acpiphp: Slot [19] registered
+[    0.230303] acpiphp: Slot [20] registered
+[    0.231056] acpiphp: Slot [21] registered
+[    0.232035] acpiphp: Slot [22] registered
+[    0.232863] acpiphp: Slot [23] registered
+[    0.233669] acpiphp: Slot [24] registered
+[    0.234424] acpiphp: Slot [25] registered
+[    0.235184] acpiphp: Slot [26] registered
+[    0.235936] acpiphp: Slot [27] registered
+[    0.236047] acpiphp: Slot [28] registered
+[    0.236795] acpiphp: Slot [29] registered
+[    0.237552] acpiphp: Slot [30] registered
+[    0.238302] acpiphp: Slot [31] registered
+[    0.239027] PCI host bridge to bus 0000:00
+[    0.240006] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.241202] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.242389] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.244002] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.245308] pci_bus 0000:00: root bus resource [mem 0x100000000-0x17fffffff window]
+[    0.246666] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.252516] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.253779] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.254922] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.256003] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.257942] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.259220] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.308522] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.309646] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.310642] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.312106] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.313042] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.314169] SCSI subsystem initialized
+[    0.314873] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.315810] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.316003] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.316909] vgaarb: loaded
+[    0.317431] ACPI: bus type USB registered
+[    0.318401] usbcore: registered new interface driver usbfs
+[    0.320030] usbcore: registered new interface driver hub
+[    0.321395] usbcore: registered new device driver usb
+[    0.322443] EDAC MC: Ver: 3.0.0
+[    0.323349] PCI: Using ACPI for IRQ routing
+[    0.324339] NetLabel: Initializing
+[    0.324923] NetLabel:  domain hash size = 128
+[    0.325823] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.326757] NetLabel:  unlabeled traffic allowed by default
+[    0.328781] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.330041] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.330917] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.336077] clocksource: Switched to clocksource kvm-clock
+[    0.347260] VFS: Disk quotas dquot_6.6.0
+[    0.347962] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.349204] AppArmor: AppArmor Filesystem Enabled
+[    0.350021] pnp: PnP ACPI init
+[    0.351131] pnp: PnP ACPI: found 7 devices
+[    0.357368] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.358872] NET: Registered protocol family 2
+[    0.359737] TCP established hash table entries: 32768 (order: 6, 262144 bytes)
+[    0.360981] TCP bind hash table entries: 32768 (order: 7, 524288 bytes)
+[    0.362129] TCP: Hash tables configured (established 32768 bind 32768)
+[    0.363230] UDP hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.364283] UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.365436] NET: Registered protocol family 1
+[    0.366206] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.367240] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.368247] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.369377] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.370898] Unpacking initramfs...
+[    0.926800] Freeing initrd memory: 39112K
+[    0.927539] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228df7309b5, max_idle_ns: 440795314334 ns
+[    0.929297] Scanning for low memory corruption every 60 seconds
+[    0.930730] Initialise system trusted keyrings
+[    0.931446] Key type blacklist registered
+[    0.932131] workingset: timestamp_bits=36 max_order=20 bucket_order=0
+[    0.934075] zbud: loaded
+[    0.934945] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.935966] fuse init (API version 7.26)
+[    0.937418] Key type asymmetric registered
+[    0.938075] Asymmetric key parser 'x509' registered
+[    0.938874] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    0.940107] io scheduler noop registered
+[    0.940757] io scheduler deadline registered
+[    0.941489] io scheduler cfq registered (default)
+[    0.942451] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    0.943693] ACPI: Power Button [PWRF]
+[    0.967830] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    0.992911] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    1.018207] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    1.043172] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    1.045245] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    1.071878] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    1.099371] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    1.101831] Linux agpgart interface v0.103
+[    1.103521] loop: module loaded
+[    1.104913] scsi host0: ata_piix
+[    1.105498] scsi host1: ata_piix
+[    1.106040] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc0c0 irq 14
+[    1.107092] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc0c8 irq 15
+[    1.108512] libphy: Fixed MDIO Bus: probed
+[    1.109164] tun: Universal TUN/TAP device driver, 1.6
+[    1.109976] PPP generic driver version 2.4.2
+[    1.110952] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.111964] ehci-pci: EHCI PCI platform driver
+[    1.112680] ehci-platform: EHCI generic platform driver
+[    1.113513] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    1.114472] ohci-pci: OHCI PCI platform driver
+[    1.115170] ohci-platform: OHCI generic platform driver
+[    1.115986] uhci_hcd: USB Universal Host Controller Interface driver
+[    1.117035] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    1.119124] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.119903] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.120778] mousedev: PS/2 mouse device common for all mice
+[    1.121964] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    1.123590] rtc_cmos 00:00: RTC can wake from S4
+[    1.124650] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    1.125799] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    1.126973] i2c /dev entries driver
+[    1.127571] device-mapper: uevent: version 1.0.3
+[    1.128375] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    1.129714] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.130881] NET: Registered protocol family 10
+[    1.135060] Segment Routing with IPv6
+[    1.135686] NET: Registered protocol family 17
+[    1.136441] Key type dns_resolver registered
+[    1.137224] mce: Using 10 MCE banks
+[    1.137797] RAS: Correctable Errors collector initialized.
+[    1.138666] sched_clock: Marking stable (1136392330, 0)->(1427346685, -290954355)
+[    1.139924] registered taskstats version 1
+[    1.140635] Loading compiled-in X.509 certificates
+[    1.143705] Loaded X.509 cert 'Build time autogenerated kernel key: b1772ce3e036cbf6bf2b7e9ed9be0f8806d61091'
+[    1.145297] zswap: loaded using pool lzo/zbud
+[    1.149088] Key type big_key registered
+[    1.149721] Key type trusted registered
+[    1.151833] Key type encrypted registered
+[    1.152522] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.153385] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    1.154357] ima: Allocated hash algorithm: sha1
+[    1.155079] evm: HMAC attrs: 0x1
+[    1.156082]   Magic number: 8:890:411
+[    1.156870] rtc_cmos 00:00: setting system clock to 2020-06-16 03:26:21 UTC (1592277981)
+[    1.158186] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    1.159124] EDD information not available.
+[    1.270041] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.272795] ata2.00: configured for MWDMA2
+[    1.275269] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.301219] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.303330] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.305670] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.310829] Freeing unused kernel image memory: 2436K
+[    1.320114] Write protecting the kernel read-only data: 20480k
+[    1.323150] Freeing unused kernel image memory: 2008K
+[    1.325353] Freeing unused kernel image memory: 1872K
+[    1.335346] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.336441] x86/mm: Checking user space page tables
+[    1.344536] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.461263] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.468988] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.480606] FDC 0 is a S82078B
+[    1.483759]  vda: vda1 vda14 vda15
+[    1.493893] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.495460] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.541640] virtio_net virtio0 ens3: renamed from eth0
+[    1.548897] virtio_net virtio1 ens4: renamed from eth1
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    1.628067] raid6: sse2x1   gen()  9140 MB/s
+[    1.676006] raid6: sse2x1   xor()  7412 MB/s
+[    1.724109] raid6: sse2x2   gen() 13138 MB/s
+[    1.772094] raid6: sse2x2   xor()  7917 MB/s
+[    1.820064] raid6: sse2x4   gen() 15362 MB/s
+[    1.868015] raid6: sse2x4   xor()  9238 MB/s
+[    1.868706] raid6: using algorithm sse2x4 gen() 15362 MB/s
+[    1.869475] raid6: .... xor() 9238 MB/s, rmw enabled
+[    1.870184] raid6: using intx1 recovery algorithm
+[    1.875483] xor: measuring software checksum speed
+[    1.916048]    prefetch64-sse: 19605.000 MB/sec
+[    1.956033]    generic_sse: 18040.000 MB/sec
+[    1.956562] xor: using function: prefetch64-sse (19605.000 MB/sec)
+[    1.973392] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    2.044714] random: fast init done
+[    2.128143] print_req_error: I/O error, dev fd0, sector 0
+[    2.129860] floppy: error 10 while reading block 0
+done.
+[    2.137620] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    2.139937] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    2.141728] random: wait-for-root: uninitialized urandom read (16 bytes read)
+Warning: fsck not present, so skipping root file system
+[    2.151594] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... done.
+[    2.276900] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.284402] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.287743] systemd[1]: Detected virtualization kvm.
+[    2.288583] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.4 LTS[0m!
+
+[    2.293289] systemd[1]: Set hostname to <autopkgtest>.
+[    2.397016] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[    2.399497] systemd[1]: Reached target Swap.
+[[0;32m  OK  [0m] Reached target Swap.
+[    2.401258] systemd[1]: Created slice User and Session Slice.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[    2.403304] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    2.405122] systemd[1]: Listening on Syslog Socket.
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+[    2.406868] systemd[1]: Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Starting udev Coldplug all Devices...
+         Starting Set the console keyboard layout...
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+         Mounting POSIX Message Queue File System...
+         Starting Create list of required stâ¦ce nodes for the current kernel...
+         Starting Load Kernel Modules...
+         Starting Uncomplicated firewall...
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[[0;32m  OK  [0m] Reached target Slices.
+         Starting Journal Service...
+         Starting Remount Root and Kernel File Systems...
+         Mounting Huge Pages File System...[    2.512610] EXT4-fs (vda1): re-mounted. Opts: (null)
+
+[[0;32m  OK  [0m] Set up automount Arbitrary Executabâ¦rmats File System Automount Point.
+         Mounting Kernel Debug File System...
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Started Create list of required staâ¦vice nodes for the current kernel.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+         Starting Load/Save Random Seed...
+         Mounting FUSE Control File System...
+         Mounting Kernel Configuration File System...
+         Starting Apply Kernel Variables...
+         Starting Create Static Device Nodes in /dev...
+[[0;32m  OK  [0m] Started Journal Service.
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting AppArmor initialization...
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting Create Volatile Files and Directories...
+         Starting Set console font and keymap...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Update UTMP about System Boot/Shutdown...
+         Starting Network Time Synchronization...
+         Starting Network Name Resolution...
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Reached target Network.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Entropy daemon using the HAVEGE algorithm.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Reached target Basic System.
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting LSB: Record successful boot for GRUB...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+         Starting Login Service...
+         Starting System Logging Service...
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+         Starting Thermal Daemon Service...
+         Starting Permit User Sessions...
+[[0;32m  OK  [0m] Started irqbalance daemon.
+         Starting OpenBSD Secure Shell server...
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+         Starting LSB: automatic crash report generation...
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started Login Service.
+         Starting Terminate Plymouth Boot Screen...
+         Starting Hold until boot process finishes up...
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+
+Ubuntu 18.04.4 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found ""login prompt on ttyS0""
+autopkgtest-virt-qemu: DBG: expect: "ok"
+autopkgtest-virt-qemu: DBG: expect: found ""b'ok'""
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on ttyS1
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "# "
+autopkgtest-virt-qemu: DBG: expect: found ""b'# '""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec for d in /var/cache /home; do if [ -e $d/autopkgtest-tmpdir.tar ]; then  tar --warning=none --extract --absolute-names      -f $d/autopkgtest-tmpdir.tar; rm $d/autopkgtest-tmpdir.tar; exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: restored downtmp after reboot
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [03:26:30]: testbed running kernel: Linux 4.15.0-106-generic #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020
+autopkgtest: DBG: testbed command ['sh', '-c', 'nproc; cat /proc/cpuinfo 2>/dev/null || true'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--print-architecture'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [03:26:31]: testbed dpkg architecture: amd64
+autopkgtest: DBG: testbed command ['which', 'eatmydata'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed has eatmydata
+autopkgtest: DBG: testbed command ['which', 'dpkg-query'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', "dpkg-query --show -f '${Package}\\t${Version}\\n' > /tmp/autopkgtest.Ihmrn9/testbed-packages"], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/testbed-packages'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/testbed-packages
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Binaries: initialising
+autopkgtest [03:26:34]: @@@@@@@@@@@@@@@@@@@@ unbuilt-tree /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas
+autopkgtest: DBG: blame += /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas
+autopkgtest: DBG: testbed reset: modified=False, deps_installed=[](r: False), deps_new=[](r: False)
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.Ihmrn9'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/ /tmp/autopkgtest.Ihmrn9/ubtree-maas/
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/ /tmp/autopkgtest.Ihmrn9/ubtree-maas/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/', '--warning=none', '-c', '.', '-f', '-'], ['/tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd', 'sh', '-ec', 'if ! test -d /tmp/autopkgtest.Ihmrn9/ubtree-maas/; then mkdir -- /tmp/autopkgtest.Ihmrn9/ubtree-maas/; fi; cd /tmp/autopkgtest.Ihmrn9/ubtree-maas/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas/ --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec if ! test -d /tmp/autopkgtest.Ihmrn9/ubtree-maas/; then mkdir -- /tmp/autopkgtest.Ihmrn9/ubtree-maas/; fi; cd /tmp/autopkgtest.Ihmrn9/ubtree-maas/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.Ihmrn9/ubtree-maas'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: install_deps: deps_new=[], recommends=False
+autopkgtest: DBG: testbed command ['which', 'dpkg-source'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'su --shell=/bin/sh ubuntu -c \'set -e; exec 3>&1 >&2; set -x; cd /; builddir=$(mktemp -d /tmp/autopkgtest.Ihmrn9/build.XXX); cd $builddir; cp -rd --preserve=timestamps -- "/tmp/autopkgtest.Ihmrn9/ubtree-maas" real-tree; [ -x real-tree/debian/rules ] && dpkg-source --before-build real-tree; chmod -R a+rX .; cd [a-z0-9]*/.; pwd >&3; sed -n "1 {s/).*//; s/ (/\\n/; p}" debian/changelog >&3; set +e; grep -q "^Restrictions:.*\\bbuild-needed\\b" debian/tests/control 2>/dev/null; echo $? >&3\''], kind build, sout pipe, serr raw, env ['DEPLOYMENT_RELEASE=bionic', 'TEST_JUJU=', 'TEST_CENTOS=0', 'TEST_RHEL=', 'TEST_WINDOWS=', 'TEST_CUSTOM_IMAGES=1', 'USE_PPC_NODES=0', 'USE_ARM64_NODES=0', 'KEEP_CI_RUNNING=0', 'PAUSE_CI=0', 'TEST_PERFORMANCE=0', 'DEBUG=', 'SLAVE_NODE=HP-DL360-Gen9']
++ cd /
++ mktemp -d /tmp/autopkgtest.Ihmrn9/build.XXX
++ builddir=/tmp/autopkgtest.Ihmrn9/build.7ky
++ cd /tmp/autopkgtest.Ihmrn9/build.7ky
++ cp -rd --preserve=timestamps -- /tmp/autopkgtest.Ihmrn9/ubtree-maas real-tree
++ [ -x real-tree/debian/rules ]
++ dpkg-source --before-build real-tree
++ chmod -R a+rX .
++ cd real-tree/.
++ pwd
++ sed -n 1 {s/).*//; s/ (/\n/; p} debian/changelog
++ set +e
++ grep -q ^Restrictions:.*\bbuild-needed\b debian/tests/control
++ echo 1
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [03:26:37]: testing package dummy version 0.1+-g+ci-1build1
+autopkgtest [03:26:37]: build needed for binaries
+autopkgtest: DBG: needs_reset, previously=False, requested by build_source() line 451
+autopkgtest: DBG: install_deps: deps_new=[], recommends=False
+autopkgtest: DBG: /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas: satisfying debhelper (>= 9.20120311), , build-essential, fakeroot
+autopkgtest: DBG: /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas: architecture resolved: debhelper (>= 9.20120311), build-essential, fakeroot
+autopkgtest: DBG: testbed command ['test', '-w', '/var/lib/dpkg/status'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: can use apt-get on testbed: True
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.Ihmrn9'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/autopkgtest-satdep.deb /tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/autopkgtest-satdep.deb /tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['cat'], ['/tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd', 'sh', '-ec', 'cat >/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/autopkgtest-satdep.deb'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< cat
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec cat >/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--unpack', '/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['/bin/sh', '-ec', '/usr/bin/eatmydata apt-get install --assume-yes --fix-broken -o APT::Status-Fd=3 -o APT::Install-Recommends=False -o Dpkg::Options::=--force-confnew -o Debug::pkgProblemResolver=true 3>&2 2>&1'], kind install, sout raw, serr pipe, env ['DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Correcting dependencies...Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+ Done
+Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+The following packages were automatically installed and are no longer required:
+  linux-headers-4.15.0-65 linux-headers-4.15.0-65-generic
+  linux-image-4.15.0-65-generic linux-modules-4.15.0-65-generic
+  python3-configobj python3-serial
+Use 'apt autoremove' to remove them.
+The following additional packages will be installed:
+  autoconf automake autopoint autotools-dev build-essential cpp cpp-7
+  debhelper dh-autoreconf dh-strip-nondeterminism fakeroot g++ g++-7 gcc gcc-7
+  gcc-7-base gettext intltool-debian libarchive-zip-perl libasan4 libatomic1
+  libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libcroco3 libfakeroot
+  libfile-stripnondeterminism-perl libgcc-7-dev libgomp1 libisl19 libitm1
+  liblsan0 libmpc3 libmpx2 libquadmath0 libstdc++-7-dev libtimedate-perl
+  libtool libtsan0 libubsan0 linux-libc-dev m4 po-debconf
+Suggested packages:
+  autoconf-archive gnu-standards autoconf-doc cpp-doc gcc-7-locales dh-make
+  dwz g++-multilib g++-7-multilib gcc-7-doc libstdc++6-7-dbg gcc-multilib
+  manpages-dev flex bison gdb gcc-doc gcc-7-multilib libgcc1-dbg libgomp1-dbg
+  libitm1-dbg libatomic1-dbg libasan4-dbg liblsan0-dbg libtsan0-dbg
+  libubsan0-dbg libcilkrts5-dbg libmpx2-dbg libquadmath0-dbg gettext-doc
+  libasprintf-dev libgettextpo-dev glibc-doc libstdc++-7-doc libtool-doc
+  gfortran | fortran95-compiler gcj-jdk m4-doc libmail-box-perl
+Recommended packages:
+  manpages manpages-dev libarchive-cpio-perl libltdl-dev libmail-sendmail-perl
+The following NEW packages will be installed:
+  autoconf automake autopoint autotools-dev build-essential cpp cpp-7
+  debhelper dh-autoreconf dh-strip-nondeterminism fakeroot g++ g++-7 gcc gcc-7
+  gcc-7-base gettext intltool-debian libarchive-zip-perl libasan4 libatomic1
+  libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libcroco3 libfakeroot
+  libfile-stripnondeterminism-perl libgcc-7-dev libgomp1 libisl19 libitm1
+  liblsan0 libmpc3 libmpx2 libquadmath0 libstdc++-7-dev libtimedate-perl
+  libtool libtsan0 libubsan0 linux-libc-dev m4 po-debconf
+0 upgraded, 44 newly installed, 0 to remove and 0 not upgraded.
+1 not fully installed or removed.
+Need to get 41.5 MB of archives.
+After this operation, 156 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 autotools-dev all 20180224.1 [39.6 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 m4 amd64 1.4.18-1 [197 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic/main amd64 autoconf all 2.69-11 [322 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic/main amd64 automake all 1:1.15.1-3ubuntu2 [509 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 autopoint all 0.19.8.1-6ubuntu0.3 [426 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7-base amd64 7.5.0-3ubuntu1~18.04 [18.3 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 libisl19 amd64 0.19-1 [551 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic/main amd64 libmpc3 amd64 1.1.0-1 [40.8 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp-7 amd64 7.5.0-3ubuntu1~18.04 [8,591 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp amd64 4:7.4.0-1ubuntu2.3 [27.7 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcc1-0 amd64 8.4.0-1ubuntu1~18.04 [39.4 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgomp1 amd64 8.4.0-1ubuntu1~18.04 [76.5 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libitm1 amd64 8.4.0-1ubuntu1~18.04 [27.9 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libatomic1 amd64 8.4.0-1ubuntu1~18.04 [9,192 B]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libasan4 amd64 7.5.0-3ubuntu1~18.04 [358 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 liblsan0 amd64 8.4.0-1ubuntu1~18.04 [133 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libtsan0 amd64 8.4.0-1ubuntu1~18.04 [288 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libubsan0 amd64 7.5.0-3ubuntu1~18.04 [126 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcilkrts5 amd64 7.5.0-3ubuntu1~18.04 [42.5 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmpx2 amd64 8.4.0-1ubuntu1~18.04 [11.6 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libquadmath0 amd64 8.4.0-1ubuntu1~18.04 [134 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcc-7-dev amd64 7.5.0-3ubuntu1~18.04 [2,378 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7 amd64 7.5.0-3ubuntu1~18.04 [9,381 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc amd64 4:7.4.0-1ubuntu2.3 [5,184 B]
+Get:25 http://archive.ubuntu.com/ubuntu bionic/main amd64 libc-dev-bin amd64 2.27-3ubuntu1 [71.8 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-libc-dev amd64 4.15.0-106.107 [991 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic/main amd64 libc6-dev amd64 2.27-3ubuntu1 [2,587 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtool all 2.4.6-2 [194 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-autoreconf all 17 [15.8 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libarchive-zip-perl all 1.60-1ubuntu0.1 [84.6 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-stripnondeterminism-perl all 0.040-1.1~build1 [13.8 kB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtimedate-perl all 2.3000-2 [37.5 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-strip-nondeterminism all 0.040-1.1~build1 [5,208 B]
+Get:34 http://archive.ubuntu.com/ubuntu bionic/main amd64 libcroco3 amd64 0.6.12-2 [81.3 kB]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gettext amd64 0.19.8.1-6ubuntu0.3 [1,293 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic/main amd64 intltool-debian all 0.35.0+20060710.4 [24.9 kB]
+Get:37 http://archive.ubuntu.com/ubuntu bionic/main amd64 po-debconf all 1.0.20 [232 kB]
+Get:38 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 debhelper all 11.1.6ubuntu2 [902 kB]
+Get:39 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libstdc++-7-dev amd64 7.5.0-3ubuntu1~18.04 [1,471 kB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++-7 amd64 7.5.0-3ubuntu1~18.04 [9,697 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++ amd64 4:7.4.0-1ubuntu2.3 [1,568 B]
+Get:42 http://archive.ubuntu.com/ubuntu bionic/main amd64 build-essential amd64 12.4ubuntu1 [4,758 B]
+Get:43 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfakeroot amd64 1.22-2ubuntu1 [25.9 kB]
+Get:44 http://archive.ubuntu.com/ubuntu bionic/main amd64 fakeroot amd64 1.22-2ubuntu1 [62.3 kB]
+Fetched 41.5 MB in 2s (20.6 MB/s)
+Selecting previously unselected package autotools-dev.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 126921 files and directories currently installed.)
+Preparing to unpack .../00-autotools-dev_20180224.1_all.deb ...
+Unpacking autotools-dev (20180224.1) ...
+Selecting previously unselected package m4.
+Preparing to unpack .../01-m4_1.4.18-1_amd64.deb ...
+Unpacking m4 (1.4.18-1) ...
+Selecting previously unselected package autoconf.
+Preparing to unpack .../02-autoconf_2.69-11_all.deb ...
+Unpacking autoconf (2.69-11) ...
+Selecting previously unselected package automake.
+Preparing to unpack .../03-automake_1%3a1.15.1-3ubuntu2_all.deb ...
+Unpacking automake (1:1.15.1-3ubuntu2) ...
+Selecting previously unselected package autopoint.
+Preparing to unpack .../04-autopoint_0.19.8.1-6ubuntu0.3_all.deb ...
+Unpacking autopoint (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package gcc-7-base:amd64.
+Preparing to unpack .../05-gcc-7-base_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libisl19:amd64.
+Preparing to unpack .../06-libisl19_0.19-1_amd64.deb ...
+Unpacking libisl19:amd64 (0.19-1) ...
+Selecting previously unselected package libmpc3:amd64.
+Preparing to unpack .../07-libmpc3_1.1.0-1_amd64.deb ...
+Unpacking libmpc3:amd64 (1.1.0-1) ...
+Selecting previously unselected package cpp-7.
+Preparing to unpack .../08-cpp-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package cpp.
+Preparing to unpack .../09-cpp_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking cpp (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libcc1-0:amd64.
+Preparing to unpack .../10-libcc1-0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgomp1:amd64.
+Preparing to unpack .../11-libgomp1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libitm1:amd64.
+Preparing to unpack .../12-libitm1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libatomic1:amd64.
+Preparing to unpack .../13-libatomic1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libasan4:amd64.
+Preparing to unpack .../14-libasan4_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package liblsan0:amd64.
+Preparing to unpack .../15-liblsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libtsan0:amd64.
+Preparing to unpack .../16-libtsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libubsan0:amd64.
+Preparing to unpack .../17-libubsan0_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libcilkrts5:amd64.
+Preparing to unpack .../18-libcilkrts5_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libmpx2:amd64.
+Preparing to unpack .../19-libmpx2_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libquadmath0:amd64.
+Preparing to unpack .../20-libquadmath0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgcc-7-dev:amd64.
+Preparing to unpack .../21-libgcc-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc-7.
+Preparing to unpack .../22-gcc-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc.
+Preparing to unpack .../23-gcc_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking gcc (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libc-dev-bin.
+Preparing to unpack .../24-libc-dev-bin_2.27-3ubuntu1_amd64.deb ...
+Unpacking libc-dev-bin (2.27-3ubuntu1) ...
+Selecting previously unselected package linux-libc-dev:amd64.
+Preparing to unpack .../25-linux-libc-dev_4.15.0-106.107_amd64.deb ...
+Unpacking linux-libc-dev:amd64 (4.15.0-106.107) ...
+Selecting previously unselected package libc6-dev:amd64.
+Preparing to unpack .../26-libc6-dev_2.27-3ubuntu1_amd64.deb ...
+Unpacking libc6-dev:amd64 (2.27-3ubuntu1) ...
+Selecting previously unselected package libtool.
+Preparing to unpack .../27-libtool_2.4.6-2_all.deb ...
+Unpacking libtool (2.4.6-2) ...
+Selecting previously unselected package dh-autoreconf.
+Preparing to unpack .../28-dh-autoreconf_17_all.deb ...
+Unpacking dh-autoreconf (17) ...
+Selecting previously unselected package libarchive-zip-perl.
+Preparing to unpack .../29-libarchive-zip-perl_1.60-1ubuntu0.1_all.deb ...
+Unpacking libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Selecting previously unselected package libfile-stripnondeterminism-perl.
+Preparing to unpack .../30-libfile-stripnondeterminism-perl_0.040-1.1~build1_all.deb ...
+Unpacking libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Selecting previously unselected package libtimedate-perl.
+Preparing to unpack .../31-libtimedate-perl_2.3000-2_all.deb ...
+Unpacking libtimedate-perl (2.3000-2) ...
+Selecting previously unselected package dh-strip-nondeterminism.
+Preparing to unpack .../32-dh-strip-nondeterminism_0.040-1.1~build1_all.deb ...
+Unpacking dh-strip-nondeterminism (0.040-1.1~build1) ...
+Selecting previously unselected package libcroco3:amd64.
+Preparing to unpack .../33-libcroco3_0.6.12-2_amd64.deb ...
+Unpacking libcroco3:amd64 (0.6.12-2) ...
+Selecting previously unselected package gettext.
+Preparing to unpack .../34-gettext_0.19.8.1-6ubuntu0.3_amd64.deb ...
+Unpacking gettext (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package intltool-debian.
+Preparing to unpack .../35-intltool-debian_0.35.0+20060710.4_all.deb ...
+Unpacking intltool-debian (0.35.0+20060710.4) ...
+Selecting previously unselected package po-debconf.
+Preparing to unpack .../36-po-debconf_1.0.20_all.deb ...
+Unpacking po-debconf (1.0.20) ...
+Selecting previously unselected package debhelper.
+Preparing to unpack .../37-debhelper_11.1.6ubuntu2_all.deb ...
+Unpacking debhelper (11.1.6ubuntu2) ...
+Selecting previously unselected package libstdc++-7-dev:amd64.
+Preparing to unpack .../38-libstdc++-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++-7.
+Preparing to unpack .../39-g++-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking g++-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++.
+Preparing to unpack .../40-g++_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking g++ (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package build-essential.
+Preparing to unpack .../41-build-essential_12.4ubuntu1_amd64.deb ...
+Unpacking build-essential (12.4ubuntu1) ...
+Selecting previously unselected package libfakeroot:amd64.
+Preparing to unpack .../42-libfakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking libfakeroot:amd64 (1.22-2ubuntu1) ...
+Selecting previously unselected package fakeroot.
+Preparing to unpack .../43-fakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking fakeroot (1.22-2ubuntu1) ...
+Setting up libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Setting up libtimedate-perl (2.3000-2) ...
+Setting up libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up linux-libc-dev:amd64 (4.15.0-106.107) ...
+Setting up m4 (1.4.18-1) ...
+Setting up liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libcroco3:amd64 (0.6.12-2) ...
+Setting up gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up autotools-dev (20180224.1) ...
+Setting up libfakeroot:amd64 (1.22-2ubuntu1) ...
+Setting up libmpc3:amd64 (1.1.0-1) ...
+Setting up libc-dev-bin (2.27-3ubuntu1) ...
+Setting up libc6-dev:amd64 (2.27-3ubuntu1) ...
+Setting up libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up autopoint (0.19.8.1-6ubuntu0.3) ...
+Setting up libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Setting up libisl19:amd64 (0.19-1) ...
+Setting up libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up gettext (0.19.8.1-6ubuntu0.3) ...
+Setting up libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up autoconf (2.69-11) ...
+Setting up fakeroot (1.22-2ubuntu1) ...
+update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
+Setting up libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up intltool-debian (0.35.0+20060710.4) ...
+Setting up automake (1:1.15.1-3ubuntu2) ...
+update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
+Setting up cpp (4:7.4.0-1ubuntu2.3) ...
+Setting up po-debconf (1.0.20) ...
+Setting up gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up g++-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up gcc (4:7.4.0-1ubuntu2.3) ...
+Setting up g++ (4:7.4.0-1ubuntu2.3) ...
+update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
+Setting up libtool (2.4.6-2) ...
+Setting up build-essential (12.4ubuntu1) ...
+Setting up dh-autoreconf (17) ...
+Setting up dh-strip-nondeterminism (0.040-1.1~build1) ...
+Setting up debhelper (11.1.6ubuntu2) ...
+Setting up autopkgtest-satdep (0) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--status', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-get', '--simulate', '--quiet', '-o', 'APT::Get::Show-User-Simulation-Note=False', '--auto-remove', 'purge', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Marking test dependencies as manually installed: dh-autoreconf debhelper dh-strip-nondeterminism libfile-stripnondeterminism-perl libarchive-zip-perl libtimedate-perl linux-headers-4.15.0-65-generic linux-headers-4.15.0-65 linux-image-4.15.0-65-generic linux-modules-4.15.0-65-generic python3-configobj python3-serial
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'dh-autoreconf', 'debhelper', 'dh-strip-nondeterminism', 'libfile-stripnondeterminism-perl', 'libarchive-zip-perl', 'libtimedate-perl', 'linux-headers-4.15.0-65-generic', 'linux-headers-4.15.0-65', 'linux-image-4.15.0-65-generic', 'linux-modules-4.15.0-65-generic', 'python3-configobj', 'python3-serial'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--purge', 'autopkgtest-satdep'], kind short, sout raw, serr raw, env []
+(Reading database ... 130845 files and directories currently installed.)
+Removing autopkgtest-satdep (0) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'su --shell=/bin/sh ubuntu -c \'set -e; exec 3>&1 >&2; set -x; cd /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree; DEB_BUILD_OPTIONS="parallel=1 $DEB_BUILD_OPTIONS" dpkg-buildpackage -us -uc -b; dpkg-source --before-build .\''], kind build, sout pipe, serr raw, env ['DEPLOYMENT_RELEASE=bionic', 'TEST_JUJU=', 'TEST_CENTOS=0', 'TEST_RHEL=', 'TEST_WINDOWS=', 'TEST_CUSTOM_IMAGES=1', 'USE_PPC_NODES=0', 'USE_ARM64_NODES=0', 'KEEP_CI_RUNNING=0', 'PAUSE_CI=0', 'TEST_PERFORMANCE=0', 'DEBUG=', 'SLAVE_NODE=HP-DL360-Gen9']
++ cd /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree
++ DEB_BUILD_OPTIONS=parallel=1  dpkg-buildpackage -us -uc -b
+dpkg-buildpackage: info: source package dummy
+dpkg-buildpackage: info: source version 0.1+-g+ci-1build1
+dpkg-buildpackage: info: source distribution bionic
+dpkg-buildpackage: info: source changed by Andres Rodriguez <andreserl@ubuntu.com>
+ dpkg-source --before-build real-tree
+dpkg-buildpackage: info: host architecture amd64
+ fakeroot debian/rules clean
+dh clean
+   dh_clean
+ debian/rules build
+dh build
+   dh_update_autotools_config
+ fakeroot debian/rules binary
+dh binary
+   dh_testroot
+   dh_prep
+   dh_installdocs
+   dh_installchangelogs
+   dh_perl
+   dh_link
+   dh_strip_nondeterminism
+   dh_compress
+   dh_fixperms
+   dh_missing
+   dh_strip
+   dh_makeshlibs
+   dh_shlibdeps
+   dh_installdeb
+   dh_gencontrol
+dpkg-gencontrol: warning: Depends field of package dummy: unknown substitution variable ${shlibs:Depends}
+   dh_md5sums
+   dh_builddeb
+dpkg-deb: building package 'dummy' in '../dummy_0.1+-g+ci-1build1_amd64.deb'.
+ dpkg-genbuildinfo --build=binary
+ dpkg-genchanges --build=binary >../dummy_0.1+-g+ci-1build1_amd64.changes
+dpkg-genchanges: info: binary-only upload (no source code included)
+ dpkg-source --after-build real-tree
+dpkg-buildpackage: info: binary-only upload (no source included)
++ dpkg-source --before-build .
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd', 'sh', '-ec', 'cd /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; tar --warning=none -c . -f -'], ['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/', '--warning=none', '--preserve-permissions', '--extract', '--no-same-owner', '-f', '-'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec cd /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; tar --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas> want built binaries, getting and registering built debs
+autopkgtest: DBG: testbed command ['sh', '-ec', 'cd "/tmp/autopkgtest.Ihmrn9/build.7ky"; echo *.deb'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas> debs=['dummy_0.1+-g+ci-1build1_amd64.deb']
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas>  deb=dummy_0.1+-g+ci-1build1_amd64.deb, pkgname=dummy
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/../dummy_0.1%2B-g%2Bci-1build1_amd64.deb /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1%2B-g%2Bci-1build1_amd64.deb
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/../dummy_0.1%2B-g%2Bci-1build1_amd64.deb /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1%2B-g%2Bci-1build1_amd64.deb
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/../dummy_0.1+-g+ci-1build1_amd64.deb'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1+-g+ci-1build1_amd64.deb'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/../dummy_0.1+-g+ci-1build1_amd64.deb
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: Binaries: register deb=/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/dummy_0.1+-g+ci-1build1_amd64.deb pkgname=dummy 
+autopkgtest: DBG: build_source: <unbuilt-tree:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas> got all built binaries
+autopkgtest: DBG: processing dependency maas
+autopkgtest: DBG: processing dependency maas-dhcp
+autopkgtest: DBG: processing dependency maas-dns
+autopkgtest: DBG: processing dependency maas-cli
+autopkgtest: DBG: processing dependency python3-mock
+autopkgtest: DBG: processing dependency python3-nose
+autopkgtest: DBG: processing dependency python3-setuptools
+autopkgtest: DBG: processing dependency python3-yaml
+autopkgtest: DBG: processing dependency devscripts
+autopkgtest: DBG: processing dependency build-essential
+autopkgtest: DBG: processing dependency pep8
+autopkgtest: DBG: processing dependency pyflakes
+autopkgtest: DBG: processing dependency fakeroot
+autopkgtest: DBG: processing dependency debhelper
+autopkgtest: DBG: processing dependency python3-oauthlib
+autopkgtest: DBG: processing dependency python3-testtools
+autopkgtest: DBG: Test defined: name maas-package-test path debian/tests/maas-package-test command "None" restrictions ['needs-root'] features [] depends ['maas', 'maas-dhcp', 'maas-dns', 'maas-cli', 'python3-mock', 'python3-nose', 'python3-setuptools', 'python3-yaml', 'devscripts', 'build-essential', 'pep8', 'pyflakes', 'fakeroot', 'debhelper', 'python3-oauthlib', 'python3-testtools'] clicks [] installed clicks []
+autopkgtest [03:27:05]: test maas-package-test: preparing testbed
+autopkgtest: DBG: testbed reset: modified=True, deps_installed=[](r: False), deps_new=['maas', 'maas-dhcp', 'maas-dns', 'maas-cli', 'python3-mock', 'python3-nose', 'python3-setuptools', 'python3-yaml', 'devscripts', 'build-essential', 'pep8', 'pyflakes', 'fakeroot', 'debhelper', 'python3-oauthlib', 'python3-testtools'](r: False)
+autopkgtest: DBG: testbed reset
+autopkgtest: DBG: sending command to testbed: revert
+autopkgtest-virt-qemu: DBG: executing revert
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.aytyr2gb/runcmd rm -rf -- /tmp/autopkgtest.Ihmrn9
+qemu-system-x86_64: terminating on signal 15 from pid 13444 (/usr/bin/python3)
+autopkgtest-virt-qemu: DBG: Creating temporary overlay image in /tmp/autopkgtest-virt-qemu.z3vh4zot/overlay.img
+autopkgtest-virt-qemu: DBG: execute-timeout: qemu-img create -f qcow2 -b /home/ubuntu/images/autopkgtest-bionic-amd64.img /tmp/autopkgtest-virt-qemu.z3vh4zot/overlay.img
+autopkgtest-virt-qemu: DBG: find_free_port: trying 10022
+autopkgtest-virt-qemu: DBG: find_free_port: 10022 is free
+autopkgtest-virt-qemu: DBG: Forwarding local port 10022 to VM ssh port 22
+autopkgtest-virt-qemu: DBG: Detected KVM capable Intel host CPU, enabling nested KVM
+qemu-system-x86_64:/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/maas-ci-config/etc/region.cfg:3: 'vlan' is deprecated. Please use 'netdev' instead.
+autopkgtest-virt-qemu: DBG: expect: " login: "
+[    0.000000] Linux version 4.15.0-66-generic (buildd@lgw01-amd64-044) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #75-Ubuntu SMP Tue Oct 1 05:24:09 UTC 2019 (Ubuntu 4.15.0-66.75-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-66-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffddfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffde000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1ubuntu1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0xbffde max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] found SMP MP-table at [mem 0x000f6a80-0x000f6a8f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x334bd000-0x35a55fff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F68A0 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE15FC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE1458 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001418 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE154C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE15C4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x00000000bffddfff]
+[    0.000000] NODE_DATA(0) allocated [mem 0xbffb3000-0xbffddfff]
+[    0.000000] kvm-clock: cpu 0, msr 0:bff32001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 1776772753 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000bffddfff]
+[    0.000000]   Normal   empty
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffddfff]
+[    0.000000] Reserved but unavailable: 98 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x00000000bffddfff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 1 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x4fd with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:1 nr_cpu_ids:1 nr_node_ids:1
+[    0.000000] percpu: Embedded 46 pages/cpu s151552 r8192 d28672 u2097152
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr bfc24040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 773991
+[    0.000000] Policy zone: DMA32
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-66-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 3028580K/3145200K available (12300K kernel code, 2481K rwdata, 4260K rodata, 2436K init, 2388K bss, 116620K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39306 entries in 154 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=1.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
+[    0.004000] NR_IRQS: 524544, nr_irqs: 256, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004009] APIC: Switch to symmetric I/O mode setup
+[    0.005442] x2apic enabled
+[    0.006282] Switched APIC routing to physical x2apic.
+[    0.008558] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.009653] tsc: Detected 2397.222 MHz processor
+[    0.010461] Calibrating delay loop (skipped) preset value.. 4794.44 BogoMIPS (lpj=9588888)
+[    0.010461] pid_max: default: 32768 minimum: 301
+[    0.012035] Security Framework initialized
+[    0.012742] Yama: becoming mindful.
+[    0.013361] AppArmor: AppArmor initialized
+[    0.014998] Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.016431] Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes)
+[    0.017635] Mount-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.018766] Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.020284] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.021201] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.022200] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.024003] Spectre V2 : Mitigation: Full generic retpoline
+[    0.024952] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.026342] Speculative Store Bypass: Vulnerable
+[    0.027151] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.037507] Freeing SMP alternatives memory: 36K
+[    0.148379] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.149986] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.151601] Hierarchical SRCU implementation.
+[    0.152692] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.153800] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.154870] smp: Bringing up secondary CPUs ...
+[    0.155664] smp: Brought up 1 node, 1 CPU
+[    0.156002] smpboot: Max logical packages: 1
+[    0.156747] smpboot: Total of 1 processors activated (4794.44 BogoMIPS)
+[    0.158088] devtmpfs: initialized
+[    0.158732] x86/mm: Memory block size: 128MB
+[    0.160358] evm: security.selinux
+[    0.160962] evm: security.SMACK64
+[    0.161543] evm: security.SMACK64EXEC
+[    0.162191] evm: security.SMACK64TRANSMUTE
+[    0.162892] evm: security.SMACK64MMAP
+[    0.163520] evm: security.apparmor
+[    0.164004] evm: security.ima
+[    0.164522] evm: security.capability
+[    0.165133] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.166436] futex hash table entries: 256 (order: 2, 16384 bytes)
+[    0.167252] pinctrl core: initialized pinctrl subsystem
+[    0.168128] RTC time:  3:27:08, date: 06/16/20
+[    0.168872] NET: Registered protocol family 16
+[    0.169535] audit: initializing netlink subsys (disabled)
+[    0.170322] cpuidle: using governor ladder
+[    0.170859] cpuidle: using governor menu
+[    0.171399] ACPI: bus type PCI registered
+[    0.172002] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.173018] PCI: Using configuration type 1 for base access
+[    0.173781] audit: type=2000 audit(1592278028.947:1): state=initialized audit_enabled=0 res=1
+[    0.175640] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.176137] ACPI: Added _OSI(Module Device)
+[    0.176856] ACPI: Added _OSI(Processor Device)
+[    0.177438] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.178139] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.178836] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.179415] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.180008] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.181881] ACPI: Interpreter enabled
+[    0.182387] ACPI: (supports S0 S3 S4 S5)
+[    0.182904] ACPI: Using IOAPIC for interrupt routing
+[    0.184022] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.185453] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.188772] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.189598] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.190479] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.191342] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.192243] acpiphp: Slot [3] registered
+[    0.192787] acpiphp: Slot [4] registered
+[    0.193374] acpiphp: Slot [5] registered
+[    0.193928] acpiphp: Slot [6] registered
+[    0.194517] acpiphp: Slot [7] registered
+[    0.195056] acpiphp: Slot [8] registered
+[    0.196052] acpiphp: Slot [9] registered
+[    0.196646] acpiphp: Slot [10] registered
+[    0.197187] acpiphp: Slot [11] registered
+[    0.197781] acpiphp: Slot [12] registered
+[    0.198448] acpiphp: Slot [13] registered
+[    0.199063] acpiphp: Slot [14] registered
+[    0.200038] acpiphp: Slot [15] registered
+[    0.200701] acpiphp: Slot [16] registered
+[    0.201306] acpiphp: Slot [17] registered
+[    0.201913] acpiphp: Slot [18] registered
+[    0.202530] acpiphp: Slot [19] registered
+[    0.203138] acpiphp: Slot [20] registered
+[    0.203765] acpiphp: Slot [21] registered
+[    0.204041] acpiphp: Slot [22] registered
+[    0.204649] acpiphp: Slot [23] registered
+[    0.205258] acpiphp: Slot [24] registered
+[    0.205868] acpiphp: Slot [25] registered
+[    0.206474] acpiphp: Slot [26] registered
+[    0.207085] acpiphp: Slot [27] registered
+[    0.208038] acpiphp: Slot [28] registered
+[    0.208663] acpiphp: Slot [29] registered
+[    0.209270] acpiphp: Slot [30] registered
+[    0.209880] acpiphp: Slot [31] registered
+[    0.210466] PCI host bridge to bus 0000:00
+[    0.211391] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.212003] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.212894] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.213877] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.214771] pci_bus 0000:00: root bus resource [mem 0x100000000-0x17fffffff window]
+[    0.216003] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.221419] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.222293] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.223858] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.224002] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.225441] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.226433] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.273416] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.274356] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.276106] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.276946] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.277726] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.278689] SCSI subsystem initialized
+[    0.279274] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.280000] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.280003] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.280745] vgaarb: loaded
+[    0.281117] ACPI: bus type USB registered
+[    0.281677] usbcore: registered new interface driver usbfs
+[    0.282403] usbcore: registered new interface driver hub
+[    0.284013] usbcore: registered new device driver usb
+[    0.284751] EDAC MC: Ver: 3.0.0
+[    0.285466] PCI: Using ACPI for IRQ routing
+[    0.286316] NetLabel: Initializing
+[    0.286820] NetLabel:  domain hash size = 128
+[    0.287459] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.288014] NetLabel:  unlabeled traffic allowed by default
+[    0.289323] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.290367] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.291037] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.296040] clocksource: Switched to clocksource kvm-clock
+[    0.305308] VFS: Disk quotas dquot_6.6.0
+[    0.305874] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.306874] AppArmor: AppArmor Filesystem Enabled
+[    0.307539] pnp: PnP ACPI init
+[    0.308464] pnp: PnP ACPI: found 7 devices
+[    0.314481] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.315724] NET: Registered protocol family 2
+[    0.316466] TCP established hash table entries: 32768 (order: 6, 262144 bytes)
+[    0.317516] TCP bind hash table entries: 32768 (order: 7, 524288 bytes)
+[    0.318410] TCP: Hash tables configured (established 32768 bind 32768)
+[    0.319281] UDP hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.320105] UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.320961] NET: Registered protocol family 1
+[    0.321520] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.322689] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.323448] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.324321] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.325432] Unpacking initramfs...
+[    0.753703] Freeing initrd memory: 38500K
+[    0.754314] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228df7309b5, max_idle_ns: 440795314334 ns
+[    0.755662] Scanning for low memory corruption every 60 seconds
+[    0.756892] Initialise system trusted keyrings
+[    0.757486] Key type blacklist registered
+[    0.758049] workingset: timestamp_bits=36 max_order=20 bucket_order=0
+[    0.759624] zbud: loaded
+[    0.760406] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.761297] fuse init (API version 7.26)
+[    0.762414] Key type asymmetric registered
+[    0.762941] Asymmetric key parser 'x509' registered
+[    0.763613] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    0.764640] io scheduler noop registered
+[    0.765210] io scheduler deadline registered
+[    0.765798] io scheduler cfq registered (default)
+[    0.766569] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    0.767607] ACPI: Power Button [PWRF]
+[    0.787187] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    0.807580] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    0.827854] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    0.847334] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    0.849048] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    0.872811] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    0.896854] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    0.898617] Linux agpgart interface v0.103
+[    0.899976] loop: module loaded
+[    0.900954] scsi host0: ata_piix
+[    0.901379] scsi host1: ata_piix
+[    0.901778] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc0c0 irq 14
+[    0.902551] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc0c8 irq 15
+[    0.903587] libphy: Fixed MDIO Bus: probed
+[    0.904128] tun: Universal TUN/TAP device driver, 1.6
+[    0.904775] PPP generic driver version 2.4.2
+[    0.905293] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    0.906061] ehci-pci: EHCI PCI platform driver
+[    0.906610] ehci-platform: EHCI generic platform driver
+[    0.907215] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    0.907998] ohci-pci: OHCI PCI platform driver
+[    0.908798] ohci-platform: OHCI generic platform driver
+[    0.909436] uhci_hcd: USB Universal Host Controller Interface driver
+[    0.910233] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    0.911971] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    0.912583] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    0.913250] mousedev: PS/2 mouse device common for all mice
+[    0.914147] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    0.915408] rtc_cmos 00:00: RTC can wake from S4
+[    0.916299] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    0.917246] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    0.918283] i2c /dev entries driver
+[    0.918736] device-mapper: uevent: version 1.0.3
+[    0.919335] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    0.920357] ledtrig-cpu: registered to indicate activity on CPUs
+[    0.921277] NET: Registered protocol family 10
+[    0.924268] Segment Routing with IPv6
+[    0.924773] NET: Registered protocol family 17
+[    0.925384] Key type dns_resolver registered
+[    0.925951] mce: Using 10 MCE banks
+[    0.926383] RAS: Correctable Errors collector initialized.
+[    0.927034] sched_clock: Marking stable (924005889, 0)->(1170113971, -246108082)
+[    0.927993] registered taskstats version 1
+[    0.928584] Loading compiled-in X.509 certificates
+[    0.930750] Loaded X.509 cert 'Build time autogenerated kernel key: 01a66adcc10ca4ce7676a3458c33483b0e2b806e'
+[    0.931977] zswap: loaded using pool lzo/zbud
+[    0.934882] Key type big_key registered
+[    0.935345] Key type trusted registered
+[    0.936948] Key type encrypted registered
+[    0.937427] AppArmor: AppArmor sha1 policy hashing enabled
+[    0.938053] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    0.938761] ima: Allocated hash algorithm: sha1
+[    0.939335] evm: HMAC attrs: 0x1
+[    0.940190]   Magic number: 8:443:462
+[    0.940798] rtc_cmos 00:00: setting system clock to 2020-06-16 03:27:09 UTC (1592278029)
+[    0.941825] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    0.942549] EDD information not available.
+[    1.068970] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.070525] ata2.00: configured for MWDMA2
+[    1.071939] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.096826] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.098355] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.100164] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.104621] Freeing unused kernel image memory: 2436K
+[    1.112052] Write protecting the kernel read-only data: 20480k
+[    1.113197] Freeing unused kernel image memory: 2008K
+[    1.114148] Freeing unused kernel image memory: 1884K
+[    1.121190] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.122150] x86/mm: Checking user space page tables
+[    1.129325] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.212835] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.220921] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.232592] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.237232] FDC 0 is a S82078B
+[    1.240560]  vda: vda1 vda14 vda15
+[    1.242142] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.299753] virtio_net virtio0 ens3: renamed from eth0
+[    1.303221] virtio_net virtio1 ens4: renamed from eth1
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    1.388013] raid6: sse2x1   gen()  8231 MB/s
+[    1.436008] raid6: sse2x1   xor()  5625 MB/s
+[    1.484011] raid6: sse2x2   gen()  9844 MB/s
+[    1.532008] raid6: sse2x2   xor()  8290 MB/s
+[    1.580007] raid6: sse2x4   gen() 15574 MB/s
+[    1.628025] raid6: sse2x4   xor()  8680 MB/s
+[    1.628608] raid6: using algorithm sse2x4 gen() 15574 MB/s
+[    1.629232] raid6: .... xor() 8680 MB/s, rmw enabled
+[    1.629843] raid6: using intx1 recovery algorithm
+[    1.633807] xor: measuring software checksum speed
+[    1.672005]    prefetch64-sse: 19443.000 MB/sec
+[    1.712009]    generic_sse: 17862.000 MB/sec
+[    1.712580] xor: using function: prefetch64-sse (19443.000 MB/sec)
+[    1.732023] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    1.777527] random: fast init done
+[    1.880118] print_req_error: I/O error, dev fd0, sector 0
+[    1.881704] floppy: error 10 while reading block 0
+done.
+[    1.889529] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    1.891851] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    1.893100] random: wait-for-root: uninitialized urandom read (16 bytes read)
+Warning: fsck not present, so skipping root file system
+[    1.903470] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... done.
+[    2.080857] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.090931] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.095094] systemd[1]: Detected virtualization kvm.
+[    2.095939] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.3 LTS[0m!
+
+[    2.100026] systemd[1]: Set hostname to <autopkgtest>.
+[    2.248902] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[    2.251013] systemd[1]: Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[    2.253138] systemd[1]: Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[    2.254911] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
+[[0;32m  OK  [0m] Set up automount Arbitrary Executabâ¦rmats File System Automount Point.
+[    2.257497] systemd[1]: Created slice User and Session Slice.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[    2.259185] systemd[1]: Reached target Slices.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Reached target Swap.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Mounting POSIX Message Queue File System...
+         Starting Uncomplicated firewall...
+         Starting Remount Root and Kernel File Systems...
+         Starting Load Kernel Modules...
+         Starting Create list of required stâ¦ce nodes for the current kernel...
+[    2.278413] EXT4-fs (vda1): re-mounted. Opts: (null)
+         Starting udev Coldplug all Devices...
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+         Starting Journal Service...
+         Starting Set the console keyboard layout...
+         Mounting Kernel Debug File System...
+         Mounting Huge Pages File System...
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Create list of required staâ¦vice nodes for the current kernel.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+[[0;32m  OK  [0m] Started Journal Service.
+         Starting Create Static Device Nodes in /dev...
+         Mounting Kernel Configuration File System...
+         Mounting FUSE Control File System...
+         Starting Apply Kernel Variables...
+         Starting Flush Journal to Persistent Storage...
+         Starting Load/Save Random Seed...
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Set console font and keymap...
+         Starting Create Volatile Files and Directories...
+         Starting AppArmor initialization...
+         Starting Tell Plymouth To Write Out Runtime Data...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+         Starting Network Name Resolution...
+         Starting Network Time Synchronization...
+         Starting Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Reached target Network.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Entropy daemon using the HAVEGE algorithm.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+[[0;32m  OK  [0m] Started irqbalance daemon.
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+         Starting LSB: automatic crash report generation...
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting LSB: Record successful boot for GRUB...
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+         Starting System Logging Service...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+         Starting Thermal Daemon Service...
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+         Starting Login Service...
+         Starting Permit User Sessions...
+         Starting OpenBSD Secure Shell server...
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Started Login Service.
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+         Starting Discard unused blocks...
+         Starting Daily apt download activities...
+         Starting Message of the Day...
+         Starting Hold until boot process finishes up...
+         Starting Terminate Plymouth Boot Screen...
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Started Discard unused blocks.
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+         Starting Daily apt upgrade and clean activities...
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+
+Ubuntu 18.04.3 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found ""login prompt on ttyS0""
+autopkgtest-virt-qemu: DBG: expect: "ok"
+autopkgtest-virt-qemu: DBG: expect: found ""b'ok'""
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on ttyS1
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "# "
+autopkgtest-virt-qemu: DBG: expect: found ""b'# '""
+autopkgtest-virt-qemu: DBG: Copying host timezone Etc/UTC to VM
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "/python"
+autopkgtest-virt-qemu: DBG: expect: found ""b'/python'""
+autopkgtest-virt-qemu: DBG: expect: "# "
+autopkgtest-virt-qemu: DBG: expect: found ""b'# '""
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd true
+autopkgtest-virt-qemu: DBG: can connect to autopkgtest sh in VM
+autopkgtest-virt-qemu: DBG: determine_normal_user: got user "ubuntu"
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd mkdir --mode=1777 --parents /tmp/autopkgtest.Ihmrn9
+autopkgtest-virt-qemu: DBG: auxverb = ['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd'], downtmp = /tmp/autopkgtest.Ihmrn9
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest.Ihmrn9
+autopkgtest: DBG: sending command to testbed: print-execute-command
+autopkgtest-virt-qemu: DBG: executing print-execute-command
+autopkgtest: DBG: got reply from testbed: ok /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd
+autopkgtest: DBG: sending command to testbed: capabilities
+autopkgtest-virt-qemu: DBG: executing capabilities
+autopkgtest: DBG: got reply from testbed: ok revert revert-full-system root-on-testbed isolation-machine reboot suggested-normal-user=ubuntu
+autopkgtest: DBG: testbed capabilities: ['revert', 'revert-full-system', 'root-on-testbed', 'isolation-machine', 'reboot', 'suggested-normal-user=ubuntu']
+autopkgtest [03:27:24]: @@@@@@@@@@@@@@@@@@@@ test bed setup
+autopkgtest: DBG: testbed command ['bash', '-ec', 'for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do [ ! -d $d ] || touch -r $d /tmp/autopkgtest.Ihmrn9/${d//\\//_}.stamp; done'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '(O=$(bash -o pipefail -ec \'apt-get update | tee /proc/self/fd/2\') ||{ [ "${O%404*Not Found*}" = "$O" ] || exit 100; sleep 15; apt-get update; } || { sleep 60; apt-get update; } || false) && $(which eatmydata || true) apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew"'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main Sources [321 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/restricted Sources [7,716 B]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Sources [6,684 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/universe Sources [283 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [60.5 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,081 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [15.9 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [970 kB]
+Fetched 2,833 kB in 1s (2,171 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Calculating upgrade...
+The following packages were automatically installed and are no longer required:
+  python3-configobj python3-serial
+Use 'apt autoremove' to remove them.
+The following NEW packages will be installed:
+  libnetplan0 linux-headers-4.15.0-106 linux-headers-4.15.0-106-generic
+  linux-image-4.15.0-106-generic linux-modules-4.15.0-106-generic
+  linux-modules-extra-4.15.0-106-generic
+The following packages will be upgraded:
+  amd64-microcode apport apt apt-utils base-files bind9-host binutils
+  binutils-common binutils-x86-64-linux-gnu bsdutils ca-certificates cpio
+  distro-info-data dmidecode dmsetup dnsutils e2fsprogs fdisk file gcc-8-base
+  grub-common grub-efi-amd64 grub-efi-amd64-bin grub-efi-amd64-signed
+  grub2-common initramfs-tools initramfs-tools-bin initramfs-tools-core
+  intel-microcode iproute2 kmod libapt-inst2.0 libapt-pkg5.0 libbind9-160
+  libbinutils libblkid1 libbsd0 libcom-err2 libdevmapper1.02.1
+  libdns-export1100 libdns1100 libdrm-common libdrm2 libext2fs2 libfdisk1
+  libgcc1 libgcrypt20 libglib2.0-0 libglib2.0-data libgnutls30 libicu60
+  libidn2-0 libirs160 libisc-export169 libisc169 libisccc160 libisccfg160
+  libjson-c3 libkmod2 libldap-2.4-2 libldap-common liblwres160 libmagic-mgc
+  libmagic1 libmount1 libnss-systemd libpam-systemd libpcap0.8
+  libpython3.6-minimal libpython3.6-stdlib libsasl2-2 libsasl2-modules
+  libsasl2-modules-db libsmartcols1 libsqlite3-0 libss2 libssl1.1 libstdc++6
+  libsystemd0 libudev1 libuuid1 libxml2 linux-base linux-firmware
+  linux-generic linux-headers-generic linux-headers-virtual
+  linux-image-generic linux-image-virtual linux-virtual mount netplan.io nplan
+  openssl python-apt-common python3-apport python3-apt python3-problem-report
+  python3-software-properties python3.6 python3.6-minimal rsync
+  software-properties-common sudo systemd systemd-sysv tcpdump tzdata
+  ubuntu-minimal udev util-linux uuid-runtime vim-common vim-tiny xxd
+115 upgraded, 6 newly installed, 0 to remove and 0 not upgraded.
+Need to get 183 MB of archives.
+After this operation, 346 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 base-files amd64 10.1ubuntu2.8 [59.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bsdutils amd64 1:2.31.1-0.4ubuntu3.6 [60.3 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-bin amd64 0.130ubuntu3.9 [10.2 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools-core all 0.130ubuntu3.9 [48.2 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 initramfs-tools all 0.130ubuntu3.9 [9,568 B]
+Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libext2fs2 amd64 1.44.1-1ubuntu1.3 [157 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 e2fsprogs amd64 1.44.1-1ubuntu1.3 [391 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnss-systemd amd64 237-3ubuntu10.41 [105 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libudev1 amd64 237-3ubuntu10.41 [56.8 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 udev amd64 237-3ubuntu10.41 [1,101 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpam-systemd amd64 237-3ubuntu10.41 [107 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd amd64 237-3ubuntu10.41 [2,914 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsystemd0 amd64 237-3ubuntu10.41 [207 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 systemd-sysv amd64 237-3ubuntu10.41 [14.7 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 kmod amd64 24-1ubuntu3.4 [88.7 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libkmod2 amd64 24-1ubuntu3.4 [40.1 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libuuid1 amd64 2.31.1-0.4ubuntu3.6 [20.1 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libblkid1 amd64 2.31.1-0.4ubuntu3.6 [124 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmount1 amd64 2.31.1-0.4ubuntu3.6 [136 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libfdisk1 amd64 2.31.1-0.4ubuntu3.6 [164 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsmartcols1 amd64 2.31.1-0.4ubuntu3.6 [83.7 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 fdisk amd64 2.31.1-0.4ubuntu3.6 [108 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 util-linux amd64 2.31.1-0.4ubuntu3.6 [903 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 mount amd64 2.31.1-0.4ubuntu3.6 [107 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpio amd64 2.12+dfsg-6ubuntu0.18.04.1 [86.2 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-base all 4.5ubuntu1.1 [17.7 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-8-base amd64 8.4.0-1ubuntu1~18.04 [18.7 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcc1 amd64 1:8.4.0-1ubuntu1~18.04 [40.6 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libstdc++6 amd64 8.4.0-1ubuntu1~18.04 [400 kB]
+Get:30 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-pkg5.0 amd64 1.6.12ubuntu0.1 [807 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libapt-inst2.0 amd64 1.6.12ubuntu0.1 [54.4 kB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt amd64 1.6.12ubuntu0.1 [1,201 kB]
+Get:33 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apt-utils amd64 1.6.12ubuntu0.1 [207 kB]
+Get:34 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libidn2-0 amd64 2.0.4-1.1ubuntu0.2 [48.7 kB]
+Get:35 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgnutls30 amd64 3.5.18-1ubuntu1.3 [646 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.1-1ubuntu2.1~18.04.6 [1,301 kB]
+Get:37 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3.6 amd64 3.6.9-1~18.04ubuntu1 [203 kB]
+Get:38 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython3.6-stdlib amd64 3.6.9-1~18.04ubuntu1 [1,710 kB]
+Get:39 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3.6-minimal amd64 3.6.9-1~18.04ubuntu1 [1,609 kB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython3.6-minimal amd64 3.6.9-1~18.04ubuntu1 [533 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsqlite3-0 amd64 3.22.0-1ubuntu0.4 [499 kB]
+Get:42 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 uuid-runtime amd64 2.31.1-0.4ubuntu3.6 [34.8 kB]
+Get:43 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcom-err2 amd64 1.44.1-1ubuntu1.3 [8,848 B]
+Get:44 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcrypt20 amd64 1.8.1-4ubuntu1.2 [417 kB]
+Get:45 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libss2 amd64 1.44.1-1ubuntu1.3 [11.1 kB]
+Get:46 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 openssl amd64 1.1.1-1ubuntu2.1~18.04.6 [614 kB]
+Get:47 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 ca-certificates all 20190110~18.04.1 [146 kB]
+Get:48 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info-data all 0.37ubuntu0.7 [4,676 B]
+Get:49 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdevmapper1.02.1 amd64 2:1.02.145-4.1ubuntu3.18.04.3 [127 kB]
+Get:50 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 dmsetup amd64 2:1.02.145-4.1ubuntu3.18.04.3 [74.4 kB]
+Get:51 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 file amd64 1:5.32-2ubuntu0.4 [22.1 kB]
+Get:52 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagic1 amd64 1:5.32-2ubuntu0.4 [68.6 kB]
+Get:53 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagic-mgc amd64 1:5.32-2ubuntu0.4 [184 kB]
+Get:54 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 iproute2 amd64 4.15.0-2ubuntu1.1 [723 kB]
+Get:55 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libbsd0 amd64 0.8.7-1ubuntu0.1 [41.6 kB]
+Get:56 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisc-export169 amd64 1:9.11.3+dfsg-1ubuntu1.12 [163 kB]
+Get:57 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdns-export1100 amd64 1:9.11.3+dfsg-1ubuntu1.12 [748 kB]
+Get:58 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libglib2.0-0 amd64 2.56.4-0ubuntu0.18.04.6 [1,171 kB]
+Get:59 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libglib2.0-data all 2.56.4-0ubuntu0.18.04.6 [4,540 B]
+Get:60 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libicu60 amd64 60.2-3ubuntu3.1 [8,054 kB]
+Get:61 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libjson-c3 amd64 0.12.1-1.3ubuntu0.3 [21.7 kB]
+Get:62 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libxml2 amd64 2.9.4+dfsg1-6.1ubuntu1.3 [663 kB]
+Get:63 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnetplan0 amd64 0.99-0ubuntu3~18.04.3 [22.6 kB]
+Get:64 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 netplan.io amd64 0.99-0ubuntu3~18.04.3 [70.7 kB]
+Get:65 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 nplan all 0.99-0ubuntu3~18.04.3 [1,800 B]
+Get:66 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 sudo amd64 1.8.21p2-3ubuntu1.2 [427 kB]
+Get:67 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 tzdata all 2020a-0ubuntu0.18.04 [190 kB]
+Get:68 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 xxd amd64 2:8.0.1453-1ubuntu1.3 [49.4 kB]
+Get:69 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 vim-tiny amd64 2:8.0.1453-1ubuntu1.3 [476 kB]
+Get:70 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 vim-common all 2:8.0.1453-1ubuntu1.3 [70.6 kB]
+Get:71 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 ubuntu-minimal amd64 1.417.4 [2,704 B]
+Get:72 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libirs160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [19.1 kB]
+Get:73 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bind9-host amd64 1:9.11.3+dfsg-1ubuntu1.12 [53.4 kB]
+Get:74 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 dnsutils amd64 1:9.11.3+dfsg-1ubuntu1.12 [145 kB]
+Get:75 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libbind9-160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [27.6 kB]
+Get:76 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisccfg160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [48.4 kB]
+Get:77 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisccc160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [17.9 kB]
+Get:78 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdns1100 amd64 1:9.11.3+dfsg-1ubuntu1.12 [967 kB]
+Get:79 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisc169 amd64 1:9.11.3+dfsg-1ubuntu1.12 [238 kB]
+Get:80 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 liblwres160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [34.6 kB]
+Get:81 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 dmidecode amd64 3.1-1ubuntu0.1 [50.9 kB]
+Get:82 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdrm-common all 2.4.99-1ubuntu1~18.04.2 [5,328 B]
+Get:83 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdrm2 amd64 2.4.99-1ubuntu1~18.04.2 [31.7 kB]
+Get:84 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpcap0.8 amd64 1.8.1-6ubuntu1.18.04.1 [118 kB]
+Get:85 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python-apt-common all 1.6.5ubuntu0.3 [16.8 kB]
+Get:86 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-apt amd64 1.6.5ubuntu0.3 [149 kB]
+Get:87 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 rsync amd64 3.1.2-2.1ubuntu1.1 [334 kB]
+Get:88 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 tcpdump amd64 4.9.3-0ubuntu0.18.04.1 [364 kB]
+Get:89 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64 amd64 2.02-2ubuntu8.15 [47.8 kB]
+Get:90 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub2-common amd64 2.02-2ubuntu8.15 [532 kB]
+Get:91 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-signed amd64 1.93.16+2.02-2ubuntu8.15 [299 kB]
+Get:92 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-efi-amd64-bin amd64 2.02-2ubuntu8.15 [655 kB]
+Get:93 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 grub-common amd64 2.02-2ubuntu8.15 [1,775 kB]
+Get:94 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-problem-report all 2.20.9-0ubuntu7.15 [10.6 kB]
+Get:95 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-apport all 2.20.9-0ubuntu7.15 [82.2 kB]
+Get:96 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 apport all 2.20.9-0ubuntu7.15 [124 kB]
+Get:97 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils-x86-64-linux-gnu amd64 2.30-21ubuntu1~18.04.3 [1,839 kB]
+Get:98 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils-common amd64 2.30-21ubuntu1~18.04.3 [196 kB]
+Get:99 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 binutils amd64 2.30-21ubuntu1~18.04.3 [3,388 B]
+Get:100 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libbinutils amd64 2.30-21ubuntu1~18.04.3 [488 kB]
+Get:101 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-modules-db amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1 [14.8 kB]
+Get:102 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-2 amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1 [49.2 kB]
+Get:103 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libldap-common all 2.4.45+dfsg-1ubuntu1.5 [16.9 kB]
+Get:104 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libldap-2.4-2 amd64 2.4.45+dfsg-1ubuntu1.5 [155 kB]
+Get:105 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libsasl2-modules amd64 2.1.27~101-g0780600+dfsg-3ubuntu2.1 [48.8 kB]
+Get:106 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-firmware all 1.173.18 [75.1 MB]
+Get:107 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-4.15.0-106-generic amd64 4.15.0-106.107 [13.0 MB]
+Get:108 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-4.15.0-106-generic amd64 4.15.0-106.107 [8,008 kB]
+Get:109 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-modules-extra-4.15.0-106-generic amd64 4.15.0-106.107 [32.8 MB]
+Get:110 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 amd64-microcode amd64 3.20191021.1+really3.20181128.1~ubuntu0.18.04.1 [31.6 kB]
+Get:111 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 intel-microcode amd64 3.20200609.0ubuntu0.18.04.1 [2,526 kB]
+Get:112 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-generic amd64 4.15.0.106.94 [1,868 B]
+Get:113 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-generic amd64 4.15.0.106.94 [2,472 B]
+Get:114 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-virtual amd64 4.15.0.106.94 [1,860 B]
+Get:115 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-image-virtual amd64 4.15.0.106.94 [2,452 B]
+Get:116 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-virtual amd64 4.15.0.106.94 [1,844 B]
+Get:117 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-106 all 4.15.0-106.107 [10.9 MB]
+Get:118 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-4.15.0-106-generic amd64 4.15.0-106.107 [1,098 kB]
+Get:119 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-headers-generic amd64 4.15.0.106.94 [2,432 B]
+Get:120 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 software-properties-common all 0.96.24.32.13 [10.0 kB]
+Get:121 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-software-properties all 0.96.24.32.13 [23.8 kB]
+Preconfiguring packages ...
+Fetched 183 MB in 7s (28.1 MB/s)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../base-files_10.1ubuntu2.8_amd64.deb ...
+Warning: Stopping motd-news.service, but it can still be activated by:
+  motd-news.timer
+Unpacking base-files (10.1ubuntu2.8) over (10.1ubuntu2.7) ...
+Setting up base-files (10.1ubuntu2.8) ...
+Installing new version of config file /etc/issue ...
+Installing new version of config file /etc/issue.net ...
+Installing new version of config file /etc/lsb-release ...
+motd-news.service is a disabled or a static unit, not starting it.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../bsdutils_1%3a2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking bsdutils (1:2.31.1-0.4ubuntu3.6) over (1:2.31.1-0.4ubuntu3.4) ...
+Setting up bsdutils (1:2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../initramfs-tools-bin_0.130ubuntu3.9_amd64.deb ...
+Unpacking initramfs-tools-bin (0.130ubuntu3.9) over (0.130ubuntu3.8) ...
+Preparing to unpack .../initramfs-tools-core_0.130ubuntu3.9_all.deb ...
+Unpacking initramfs-tools-core (0.130ubuntu3.9) over (0.130ubuntu3.8) ...
+Preparing to unpack .../initramfs-tools_0.130ubuntu3.9_all.deb ...
+Unpacking initramfs-tools (0.130ubuntu3.9) over (0.130ubuntu3.8) ...
+Preparing to unpack .../libext2fs2_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking libext2fs2:amd64 (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up libext2fs2:amd64 (1.44.1-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../e2fsprogs_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking e2fsprogs (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up e2fsprogs (1.44.1-1ubuntu1.3) ...
+update-initramfs: deferring update (trigger activated)
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libnss-systemd_237-3ubuntu10.41_amd64.deb ...
+Unpacking libnss-systemd:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../libudev1_237-3ubuntu10.41_amd64.deb ...
+Unpacking libudev1:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Setting up libudev1:amd64 (237-3ubuntu10.41) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../udev_237-3ubuntu10.41_amd64.deb ...
+Unpacking udev (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../libpam-systemd_237-3ubuntu10.41_amd64.deb ...
+Unpacking libpam-systemd:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../systemd_237-3ubuntu10.41_amd64.deb ...
+Unpacking systemd (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../libsystemd0_237-3ubuntu10.41_amd64.deb ...
+Unpacking libsystemd0:amd64 (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Setting up libsystemd0:amd64 (237-3ubuntu10.41) ...
+Setting up systemd (237-3ubuntu10.41) ...
+Installing new version of config file /etc/dhcp/dhclient-enter-hooks.d/resolved ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../systemd-sysv_237-3ubuntu10.41_amd64.deb ...
+Unpacking systemd-sysv (237-3ubuntu10.41) over (237-3ubuntu10.31) ...
+Preparing to unpack .../kmod_24-1ubuntu3.4_amd64.deb ...
+Unpacking kmod (24-1ubuntu3.4) over (24-1ubuntu3.2) ...
+Preparing to unpack .../libkmod2_24-1ubuntu3.4_amd64.deb ...
+Unpacking libkmod2:amd64 (24-1ubuntu3.4) over (24-1ubuntu3.2) ...
+Preparing to unpack .../libuuid1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libuuid1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libuuid1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libblkid1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libblkid1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libblkid1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libmount1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libmount1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libmount1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libfdisk1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libfdisk1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libfdisk1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libsmartcols1_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking libsmartcols1:amd64 (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up libsmartcols1:amd64 (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../fdisk_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking fdisk (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up fdisk (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../util-linux_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking util-linux (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Setting up util-linux (2.31.1-0.4ubuntu3.6) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../mount_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking mount (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Preparing to unpack .../cpio_2.12+dfsg-6ubuntu0.18.04.1_amd64.deb ...
+Unpacking cpio (2.12+dfsg-6ubuntu0.18.04.1) over (2.12+dfsg-6) ...
+Preparing to unpack .../linux-base_4.5ubuntu1.1_all.deb ...
+Unpacking linux-base (4.5ubuntu1.1) over (4.5ubuntu1) ...
+Preparing to unpack .../gcc-8-base_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-8-base:amd64 (8.4.0-1ubuntu1~18.04) over (8.3.0-6ubuntu1~18.04.1) ...
+Setting up gcc-8-base:amd64 (8.4.0-1ubuntu1~18.04) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libgcc1_1%3a8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libgcc1:amd64 (1:8.4.0-1ubuntu1~18.04) over (1:8.3.0-6ubuntu1~18.04.1) ...
+Setting up libgcc1:amd64 (1:8.4.0-1ubuntu1~18.04) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libstdc++6_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libstdc++6:amd64 (8.4.0-1ubuntu1~18.04) over (8.3.0-6ubuntu1~18.04.1) ...
+Setting up libstdc++6:amd64 (8.4.0-1ubuntu1~18.04) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libapt-pkg5.0_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking libapt-pkg5.0:amd64 (1.6.12ubuntu0.1) over (1.6.12) ...
+Setting up libapt-pkg5.0:amd64 (1.6.12ubuntu0.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libapt-inst2.0_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking libapt-inst2.0:amd64 (1.6.12ubuntu0.1) over (1.6.12) ...
+Preparing to unpack .../apt_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking apt (1.6.12ubuntu0.1) over (1.6.12) ...
+Setting up apt (1.6.12ubuntu0.1) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../apt-utils_1.6.12ubuntu0.1_amd64.deb ...
+Unpacking apt-utils (1.6.12ubuntu0.1) over (1.6.12) ...
+Preparing to unpack .../libidn2-0_2.0.4-1.1ubuntu0.2_amd64.deb ...
+Unpacking libidn2-0:amd64 (2.0.4-1.1ubuntu0.2) over (2.0.4-1.1build2) ...
+Setting up libidn2-0:amd64 (2.0.4-1.1ubuntu0.2) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libgnutls30_3.5.18-1ubuntu1.3_amd64.deb ...
+Unpacking libgnutls30:amd64 (3.5.18-1ubuntu1.3) over (3.5.18-1ubuntu1.1) ...
+Setting up libgnutls30:amd64 (3.5.18-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../0-libssl1.1_1.1.1-1ubuntu2.1~18.04.6_amd64.deb ...
+Unpacking libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.6) over (1.1.1-1ubuntu2.1~18.04.4) ...
+Preparing to unpack .../1-python3.6_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking python3.6 (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../2-libpython3.6-stdlib_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking libpython3.6-stdlib:amd64 (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../3-python3.6-minimal_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking python3.6-minimal (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../4-libpython3.6-minimal_3.6.9-1~18.04ubuntu1_amd64.deb ...
+Unpacking libpython3.6-minimal:amd64 (3.6.9-1~18.04ubuntu1) over (3.6.8-1~18.04.3) ...
+Preparing to unpack .../5-libsqlite3-0_3.22.0-1ubuntu0.4_amd64.deb ...
+Unpacking libsqlite3-0:amd64 (3.22.0-1ubuntu0.4) over (3.22.0-1ubuntu0.1) ...
+Preparing to unpack .../6-uuid-runtime_2.31.1-0.4ubuntu3.6_amd64.deb ...
+Unpacking uuid-runtime (2.31.1-0.4ubuntu3.6) over (2.31.1-0.4ubuntu3.4) ...
+Preparing to unpack .../7-libcom-err2_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking libcom-err2:amd64 (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up libcom-err2:amd64 (1.44.1-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libgcrypt20_1.8.1-4ubuntu1.2_amd64.deb ...
+Unpacking libgcrypt20:amd64 (1.8.1-4ubuntu1.2) over (1.8.1-4ubuntu1.1) ...
+Setting up libgcrypt20:amd64 (1.8.1-4ubuntu1.2) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../libss2_1.44.1-1ubuntu1.3_amd64.deb ...
+Unpacking libss2:amd64 (1.44.1-1ubuntu1.3) over (1.44.1-1ubuntu1.2) ...
+Setting up libss2:amd64 (1.44.1-1ubuntu1.3) ...
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 91296 files and directories currently installed.)
+Preparing to unpack .../00-openssl_1.1.1-1ubuntu2.1~18.04.6_amd64.deb ...
+Unpacking openssl (1.1.1-1ubuntu2.1~18.04.6) over (1.1.1-1ubuntu2.1~18.04.4) ...
+Preparing to unpack .../01-ca-certificates_20190110~18.04.1_all.deb ...
+Unpacking ca-certificates (20190110~18.04.1) over (20180409) ...
+Preparing to unpack .../02-distro-info-data_0.37ubuntu0.7_all.deb ...
+Unpacking distro-info-data (0.37ubuntu0.7) over (0.37ubuntu0.6) ...
+Preparing to unpack .../03-libdevmapper1.02.1_2%3a1.02.145-4.1ubuntu3.18.04.3_amd64.deb ...
+Unpacking libdevmapper1.02.1:amd64 (2:1.02.145-4.1ubuntu3.18.04.3) over (2:1.02.145-4.1ubuntu3.18.04.1) ...
+Preparing to unpack .../04-dmsetup_2%3a1.02.145-4.1ubuntu3.18.04.3_amd64.deb ...
+Unpacking dmsetup (2:1.02.145-4.1ubuntu3.18.04.3) over (2:1.02.145-4.1ubuntu3.18.04.1) ...
+Preparing to unpack .../05-file_1%3a5.32-2ubuntu0.4_amd64.deb ...
+Unpacking file (1:5.32-2ubuntu0.4) over (1:5.32-2ubuntu0.2) ...
+Preparing to unpack .../06-libmagic1_1%3a5.32-2ubuntu0.4_amd64.deb ...
+Unpacking libmagic1:amd64 (1:5.32-2ubuntu0.4) over (1:5.32-2ubuntu0.2) ...
+Preparing to unpack .../07-libmagic-mgc_1%3a5.32-2ubuntu0.4_amd64.deb ...
+Unpacking libmagic-mgc (1:5.32-2ubuntu0.4) over (1:5.32-2ubuntu0.2) ...
+Preparing to unpack .../08-iproute2_4.15.0-2ubuntu1.1_amd64.deb ...
+Unpacking iproute2 (4.15.0-2ubuntu1.1) over (4.15.0-2ubuntu1) ...
+Preparing to unpack .../09-libbsd0_0.8.7-1ubuntu0.1_amd64.deb ...
+Unpacking libbsd0:amd64 (0.8.7-1ubuntu0.1) over (0.8.7-1) ...
+Preparing to unpack .../10-libisc-export169_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisc-export169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../11-libdns-export1100_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libdns-export1100 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../12-libglib2.0-0_2.56.4-0ubuntu0.18.04.6_amd64.deb ...
+Unpacking libglib2.0-0:amd64 (2.56.4-0ubuntu0.18.04.6) over (2.56.4-0ubuntu0.18.04.4) ...
+Preparing to unpack .../13-libglib2.0-data_2.56.4-0ubuntu0.18.04.6_all.deb ...
+Unpacking libglib2.0-data (2.56.4-0ubuntu0.18.04.6) over (2.56.4-0ubuntu0.18.04.4) ...
+Preparing to unpack .../14-libicu60_60.2-3ubuntu3.1_amd64.deb ...
+Unpacking libicu60:amd64 (60.2-3ubuntu3.1) over (60.2-3ubuntu3) ...
+Preparing to unpack .../15-libjson-c3_0.12.1-1.3ubuntu0.3_amd64.deb ...
+Unpacking libjson-c3:amd64 (0.12.1-1.3ubuntu0.3) over (0.12.1-1.3) ...
+Preparing to unpack .../16-libxml2_2.9.4+dfsg1-6.1ubuntu1.3_amd64.deb ...
+Unpacking libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.3) over (2.9.4+dfsg1-6.1ubuntu1.2) ...
+Selecting previously unselected package libnetplan0:amd64.
+Preparing to unpack .../17-libnetplan0_0.99-0ubuntu3~18.04.3_amd64.deb ...
+Unpacking libnetplan0:amd64 (0.99-0ubuntu3~18.04.3) ...
+Preparing to unpack .../18-netplan.io_0.99-0ubuntu3~18.04.3_amd64.deb ...
+Unpacking netplan.io (0.99-0ubuntu3~18.04.3) over (0.98-0ubuntu1~18.04.1) ...
+Preparing to unpack .../19-nplan_0.99-0ubuntu3~18.04.3_all.deb ...
+Unpacking nplan (0.99-0ubuntu3~18.04.3) over (0.98-0ubuntu1~18.04.1) ...
+Preparing to unpack .../20-sudo_1.8.21p2-3ubuntu1.2_amd64.deb ...
+Unpacking sudo (1.8.21p2-3ubuntu1.2) over (1.8.21p2-3ubuntu1.1) ...
+Preparing to unpack .../21-tzdata_2020a-0ubuntu0.18.04_all.deb ...
+Unpacking tzdata (2020a-0ubuntu0.18.04) over (2019c-0ubuntu0.18.04) ...
+Preparing to unpack .../22-xxd_2%3a8.0.1453-1ubuntu1.3_amd64.deb ...
+Unpacking xxd (2:8.0.1453-1ubuntu1.3) over (2:8.0.1453-1ubuntu1.1) ...
+Preparing to unpack .../23-vim-tiny_2%3a8.0.1453-1ubuntu1.3_amd64.deb ...
+Unpacking vim-tiny (2:8.0.1453-1ubuntu1.3) over (2:8.0.1453-1ubuntu1.1) ...
+Preparing to unpack .../24-vim-common_2%3a8.0.1453-1ubuntu1.3_all.deb ...
+Unpacking vim-common (2:8.0.1453-1ubuntu1.3) over (2:8.0.1453-1ubuntu1.1) ...
+Preparing to unpack .../25-ubuntu-minimal_1.417.4_amd64.deb ...
+Unpacking ubuntu-minimal (1.417.4) over (1.417.3) ...
+Preparing to unpack .../26-libirs160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libirs160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../27-bind9-host_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking bind9-host (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../28-dnsutils_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking dnsutils (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../29-libbind9-160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libbind9-160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../30-libisccfg160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisccfg160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../31-libisccc160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisccc160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../32-libdns1100_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libdns1100:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../33-libisc169_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisc169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../34-liblwres160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking liblwres160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) over (1:9.11.3+dfsg-1ubuntu1.9) ...
+Preparing to unpack .../35-dmidecode_3.1-1ubuntu0.1_amd64.deb ...
+Unpacking dmidecode (3.1-1ubuntu0.1) over (3.1-1) ...
+Preparing to unpack .../36-libdrm-common_2.4.99-1ubuntu1~18.04.2_all.deb ...
+Unpacking libdrm-common (2.4.99-1ubuntu1~18.04.2) over (2.4.97-1ubuntu1~18.04.1) ...
+Preparing to unpack .../37-libdrm2_2.4.99-1ubuntu1~18.04.2_amd64.deb ...
+Unpacking libdrm2:amd64 (2.4.99-1ubuntu1~18.04.2) over (2.4.97-1ubuntu1~18.04.1) ...
+Preparing to unpack .../38-libpcap0.8_1.8.1-6ubuntu1.18.04.1_amd64.deb ...
+Unpacking libpcap0.8:amd64 (1.8.1-6ubuntu1.18.04.1) over (1.8.1-6ubuntu1) ...
+Preparing to unpack .../39-python-apt-common_1.6.5ubuntu0.3_all.deb ...
+Unpacking python-apt-common (1.6.5ubuntu0.3) over (1.6.4) ...
+Preparing to unpack .../40-python3-apt_1.6.5ubuntu0.3_amd64.deb ...
+Unpacking python3-apt (1.6.5ubuntu0.3) over (1.6.4) ...
+Preparing to unpack .../41-rsync_3.1.2-2.1ubuntu1.1_amd64.deb ...
+Unpacking rsync (3.1.2-2.1ubuntu1.1) over (3.1.2-2.1ubuntu1) ...
+Preparing to unpack .../42-tcpdump_4.9.3-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking tcpdump (4.9.3-0ubuntu0.18.04.1) over (4.9.2-3) ...
+Preparing to unpack .../43-grub-efi-amd64_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-efi-amd64 (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../44-grub2-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub2-common (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../45-grub-efi-amd64-signed_1.93.16+2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-efi-amd64-signed (1.93.16+2.02-2ubuntu8.15) over (1.93.14+2.02-2ubuntu8.13) ...
+Preparing to unpack .../46-grub-efi-amd64-bin_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-efi-amd64-bin (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../47-grub-common_2.02-2ubuntu8.15_amd64.deb ...
+Unpacking grub-common (2.02-2ubuntu8.15) over (2.02-2ubuntu8.13) ...
+Preparing to unpack .../48-python3-problem-report_2.20.9-0ubuntu7.15_all.deb ...
+Unpacking python3-problem-report (2.20.9-0ubuntu7.15) over (2.20.9-0ubuntu7.7) ...
+Preparing to unpack .../49-python3-apport_2.20.9-0ubuntu7.15_all.deb ...
+Unpacking python3-apport (2.20.9-0ubuntu7.15) over (2.20.9-0ubuntu7.7) ...
+Preparing to unpack .../50-apport_2.20.9-0ubuntu7.15_all.deb ...
+Unpacking apport (2.20.9-0ubuntu7.15) over (2.20.9-0ubuntu7.7) ...
+Preparing to unpack .../51-binutils-x86-64-linux-gnu_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking binutils-x86-64-linux-gnu (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../52-binutils-common_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking binutils-common:amd64 (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../53-binutils_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking binutils (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../54-libbinutils_2.30-21ubuntu1~18.04.3_amd64.deb ...
+Unpacking libbinutils:amd64 (2.30-21ubuntu1~18.04.3) over (2.30-21ubuntu1~18.04.2) ...
+Preparing to unpack .../55-libsasl2-modules-db_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb ...
+Unpacking libsasl2-modules-db:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) over (2.1.27~101-g0780600+dfsg-3ubuntu2) ...
+Preparing to unpack .../56-libsasl2-2_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb ...
+Unpacking libsasl2-2:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) over (2.1.27~101-g0780600+dfsg-3ubuntu2) ...
+Preparing to unpack .../57-libldap-common_2.4.45+dfsg-1ubuntu1.5_all.deb ...
+Unpacking libldap-common (2.4.45+dfsg-1ubuntu1.5) over (2.4.45+dfsg-1ubuntu1.4) ...
+Preparing to unpack .../58-libldap-2.4-2_2.4.45+dfsg-1ubuntu1.5_amd64.deb ...
+Unpacking libldap-2.4-2:amd64 (2.4.45+dfsg-1ubuntu1.5) over (2.4.45+dfsg-1ubuntu1.4) ...
+Preparing to unpack .../59-libsasl2-modules_2.1.27~101-g0780600+dfsg-3ubuntu2.1_amd64.deb ...
+Unpacking libsasl2-modules:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) over (2.1.27~101-g0780600+dfsg-3ubuntu2) ...
+Preparing to unpack .../60-linux-firmware_1.173.18_all.deb ...
+Unpacking linux-firmware (1.173.18) over (1.173.9) ...
+Selecting previously unselected package linux-modules-4.15.0-106-generic.
+Preparing to unpack .../61-linux-modules-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-modules-4.15.0-106-generic (4.15.0-106.107) ...
+Selecting previously unselected package linux-image-4.15.0-106-generic.
+Preparing to unpack .../62-linux-image-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-image-4.15.0-106-generic (4.15.0-106.107) ...
+Selecting previously unselected package linux-modules-extra-4.15.0-106-generic.
+Preparing to unpack .../63-linux-modules-extra-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-modules-extra-4.15.0-106-generic (4.15.0-106.107) ...
+Preparing to unpack .../64-amd64-microcode_3.20191021.1+really3.20181128.1~ubuntu0.18.04.1_amd64.deb ...
+Unpacking amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) over (3.20180524.1~ubuntu0.18.04.2) ...
+Preparing to unpack .../65-intel-microcode_3.20200609.0ubuntu0.18.04.1_amd64.deb ...
+Unpacking intel-microcode (3.20200609.0ubuntu0.18.04.1) over (3.20190618.0ubuntu0.18.04.1) ...
+Preparing to unpack .../66-linux-generic_4.15.0.106.94_amd64.deb ...
+Unpacking linux-generic (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../67-linux-image-generic_4.15.0.106.94_amd64.deb ...
+Unpacking linux-image-generic (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../68-linux-virtual_4.15.0.106.94_amd64.deb ...
+Unpacking linux-virtual (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../69-linux-image-virtual_4.15.0.106.94_amd64.deb ...
+Unpacking linux-image-virtual (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../70-linux-headers-virtual_4.15.0.106.94_amd64.deb ...
+Unpacking linux-headers-virtual (4.15.0.106.94) over (4.15.0.66.68) ...
+Selecting previously unselected package linux-headers-4.15.0-106.
+Preparing to unpack .../71-linux-headers-4.15.0-106_4.15.0-106.107_all.deb ...
+Unpacking linux-headers-4.15.0-106 (4.15.0-106.107) ...
+Selecting previously unselected package linux-headers-4.15.0-106-generic.
+Preparing to unpack .../72-linux-headers-4.15.0-106-generic_4.15.0-106.107_amd64.deb ...
+Unpacking linux-headers-4.15.0-106-generic (4.15.0-106.107) ...
+Preparing to unpack .../73-linux-headers-generic_4.15.0.106.94_amd64.deb ...
+Unpacking linux-headers-generic (4.15.0.106.94) over (4.15.0.66.68) ...
+Preparing to unpack .../74-software-properties-common_0.96.24.32.13_all.deb ...
+Unpacking software-properties-common (0.96.24.32.13) over (0.96.24.32.11) ...
+Preparing to unpack .../75-python3-software-properties_0.96.24.32.13_all.deb ...
+Unpacking python3-software-properties (0.96.24.32.13) over (0.96.24.32.11) ...
+Setting up python-apt-common (1.6.5ubuntu0.3) ...
+Setting up intel-microcode (3.20200609.0ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+intel-microcode: microcode will be updated at next boot
+Setting up libapt-inst2.0:amd64 (1.6.12ubuntu0.1) ...
+Setting up libnss-systemd:amd64 (237-3ubuntu10.41) ...
+Setting up cpio (2.12+dfsg-6ubuntu0.18.04.1) ...
+Setting up libicu60:amd64 (60.2-3ubuntu3.1) ...
+Setting up python3-apt (1.6.5ubuntu0.3) ...
+Setting up xxd (2:8.0.1453-1ubuntu1.3) ...
+Setting up sudo (1.8.21p2-3ubuntu1.2) ...
+Setting up linux-headers-4.15.0-106 (4.15.0-106.107) ...
+Setting up dmidecode (3.1-1ubuntu0.1) ...
+Setting up libldap-common (2.4.45+dfsg-1ubuntu1.5) ...
+Setting up apt-utils (1.6.12ubuntu0.1) ...
+Setting up linux-modules-4.15.0-106-generic (4.15.0-106.107) ...
+Setting up libjson-c3:amd64 (0.12.1-1.3ubuntu0.3) ...
+Setting up tzdata (2020a-0ubuntu0.18.04) ...
+
+Current default time zone: 'Etc/UTC'
+Local time is now:      Tue Jun 16 03:28:09 UTC 2020.
+Universal Time is now:  Tue Jun 16 03:28:09 UTC 2020.
+Run 'dpkg-reconfigure tzdata' if you wish to change it.
+
+Setting up systemd-sysv (237-3ubuntu10.41) ...
+Setting up libglib2.0-0:amd64 (2.56.4-0ubuntu0.18.04.6) ...
+No schema files found: doing nothing.
+Setting up libsasl2-modules-db:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) ...
+Setting up linux-base (4.5ubuntu1.1) ...
+Setting up mount (2.31.1-0.4ubuntu3.6) ...
+Setting up libsasl2-2:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) ...
+Setting up distro-info-data (0.37ubuntu0.7) ...
+Setting up libdevmapper1.02.1:amd64 (2:1.02.145-4.1ubuntu3.18.04.3) ...
+Setting up iproute2 (4.15.0-2ubuntu1.1) ...
+Setting up libbsd0:amd64 (0.8.7-1ubuntu0.1) ...
+Setting up libkmod2:amd64 (24-1ubuntu3.4) ...
+Setting up libxml2:amd64 (2.9.4+dfsg1-6.1ubuntu1.3) ...
+Setting up libmagic-mgc (1:5.32-2ubuntu0.4) ...
+Setting up uuid-runtime (2.31.1-0.4ubuntu3.6) ...
+Setting up libmagic1:amd64 (1:5.32-2ubuntu0.4) ...
+Setting up libdrm-common (2.4.99-1ubuntu1~18.04.2) ...
+Setting up rsync (3.1.2-2.1ubuntu1.1) ...
+Setting up python3-problem-report (2.20.9-0ubuntu7.15) ...
+Setting up binutils-common:amd64 (2.30-21ubuntu1~18.04.3) ...
+Setting up libglib2.0-data (2.56.4-0ubuntu0.18.04.6) ...
+Setting up udev (237-3ubuntu10.41) ...
+update-initramfs: deferring update (trigger activated)
+Setting up libldap-2.4-2:amd64 (2.4.45+dfsg-1ubuntu1.5) ...
+Setting up grub-common (2.02-2ubuntu8.15) ...
+update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
+Setting up libssl1.1:amd64 (1.1.1-1ubuntu2.1~18.04.6) ...
+Setting up openssl (1.1.1-1ubuntu2.1~18.04.6) ...
+Setting up vim-common (2:8.0.1453-1ubuntu1.3) ...
+Setting up libsqlite3-0:amd64 (3.22.0-1ubuntu0.4) ...
+Setting up dmsetup (2:1.02.145-4.1ubuntu3.18.04.3) ...
+update-initramfs: deferring update (trigger activated)
+Setting up python3-software-properties (0.96.24.32.13) ...
+Setting up initramfs-tools-bin (0.130ubuntu3.9) ...
+Setting up libnetplan0:amd64 (0.99-0ubuntu3~18.04.3) ...
+Setting up libsasl2-modules:amd64 (2.1.27~101-g0780600+dfsg-3ubuntu2.1) ...
+Setting up ca-certificates (20190110~18.04.1) ...
+Updating certificates in /etc/ssl/certs...
+2 added, 8 removed; done.
+Setting up amd64-microcode (3.20191021.1+really3.20181128.1~ubuntu0.18.04.1) ...
+update-initramfs: deferring update (trigger activated)
+amd64-microcode: microcode will be updated at next boot
+Setting up linux-firmware (1.173.18) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-66-generic
+update-initramfs: Generating /boot/initrd.img-4.15.0-65-generic
+Setting up liblwres160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up libpcap0.8:amd64 (1.8.1-6ubuntu1.18.04.1) ...
+Setting up software-properties-common (0.96.24.32.13) ...
+Setting up vim-tiny (2:8.0.1453-1ubuntu1.3) ...
+Setting up libisc169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up kmod (24-1ubuntu3.4) ...
+Installing new version of config file /etc/modprobe.d/blacklist-framebuffer.conf ...
+Setting up libisccc160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-headers-4.15.0-106-generic (4.15.0-106.107) ...
+Setting up libpam-systemd:amd64 (237-3ubuntu10.41) ...
+Setting up grub-efi-amd64-bin (2.02-2ubuntu8.15) ...
+Setting up libbinutils:amd64 (2.30-21ubuntu1~18.04.3) ...
+Setting up initramfs-tools-core (0.130ubuntu3.9) ...
+Setting up libisc-export169:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up grub2-common (2.02-2ubuntu8.15) ...
+Setting up initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: deferring update (trigger activated)
+Setting up netplan.io (0.99-0ubuntu3~18.04.3) ...
+Setting up file (1:5.32-2ubuntu0.4) ...
+Setting up python3-apport (2.20.9-0ubuntu7.15) ...
+Setting up tcpdump (4.9.3-0ubuntu0.18.04.1) ...
+Setting up libdrm2:amd64 (2.4.99-1ubuntu1~18.04.2) ...
+Setting up libpython3.6-minimal:amd64 (3.6.9-1~18.04ubuntu1) ...
+Setting up nplan (0.99-0ubuntu3~18.04.3) ...
+Setting up linux-image-4.15.0-106-generic (4.15.0-106.107) ...
+I: /vmlinuz.old is now a symlink to boot/vmlinuz-4.15.0-66-generic
+I: /initrd.img.old is now a symlink to boot/initrd.img-4.15.0-66-generic
+I: /vmlinuz is now a symlink to boot/vmlinuz-4.15.0-106-generic
+I: /initrd.img is now a symlink to boot/initrd.img-4.15.0-106-generic
+Setting up libdns-export1100 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up apport (2.20.9-0ubuntu7.15) ...
+Installing new version of config file /etc/init.d/apport ...
+apport-autoreport.service is a disabled or a static unit, not starting it.
+Setting up ubuntu-minimal (1.417.4) ...
+Setting up libdns1100:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-headers-generic (4.15.0.106.94) ...
+Setting up binutils-x86-64-linux-gnu (2.30-21ubuntu1~18.04.3) ...
+Setting up libpython3.6-stdlib:amd64 (3.6.9-1~18.04ubuntu1) ...
+Setting up grub-efi-amd64 (2.02-2ubuntu8.15) ...
+Sourcing file `/etc/default/grub'
+Sourcing file `/etc/default/grub.d/50-cloudimg-settings.cfg'
+Sourcing file `/etc/default/grub.d/90-autopkgtest.cfg'
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-4.15.0-106-generic
+Found linux image: /boot/vmlinuz-4.15.0-66-generic
+Found initrd image: /boot/initrd.img-4.15.0-66-generic
+Found linux image: /boot/vmlinuz-4.15.0-65-generic
+Found initrd image: /boot/initrd.img-4.15.0-65-generic
+Found Ubuntu 18.04.3 LTS (18.04) on /dev/vdb1
+done
+Setting up linux-modules-extra-4.15.0-106-generic (4.15.0-106.107) ...
+Setting up python3.6-minimal (3.6.9-1~18.04ubuntu1) ...
+Setting up grub-efi-amd64-signed (1.93.16+2.02-2ubuntu8.15) ...
+Setting up libisccfg160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-image-virtual (4.15.0.106.94) ...
+Setting up linux-headers-virtual (4.15.0.106.94) ...
+Setting up linux-virtual (4.15.0.106.94) ...
+Setting up binutils (2.30-21ubuntu1~18.04.3) ...
+Setting up linux-image-generic (4.15.0.106.94) ...
+Setting up python3.6 (3.6.9-1~18.04ubuntu1) ...
+Setting up libirs160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up libbind9-160:amd64 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up linux-generic (4.15.0.106.94) ...
+Setting up bind9-host (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up dnsutils (1:9.11.3+dfsg-1ubuntu1.12) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for mime-support (3.60ubuntu1) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for plymouth-theme-ubuntu-text (0.9.3-1ubuntu7.18.04.2) ...
+update-initramfs: deferring update (trigger activated)
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for ca-certificates (20190110~18.04.1) ...
+Updating certificates in /etc/ssl/certs...
+0 added, 0 removed; done.
+Running hooks in /etc/ca-certificates/update.d...
+done.
+Processing triggers for initramfs-tools (0.130ubuntu3.9) ...
+update-initramfs: Generating /boot/initrd.img-4.15.0-66-generic
+Processing triggers for linux-image-4.15.0-106-generic (4.15.0-106.107) ...
+/etc/kernel/postinst.d/initramfs-tools:
+update-initramfs: Generating /boot/initrd.img-4.15.0-106-generic
+/etc/kernel/postinst.d/x-grub-legacy-ec2:
+Searching for GRUB installation directory ... found: /boot/grub
+Searching for default file ... found: /boot/grub/default
+Testing for an existing GRUB menu.lst file ... found: /boot/grub/menu.lst
+Searching for splash image ... none found, skipping ...
+Found kernel: /boot/vmlinuz-4.15.0-65-generic
+Found kernel: /boot/vmlinuz-4.15.0-106-generic
+Found kernel: /boot/vmlinuz-4.15.0-66-generic
+Found kernel: /boot/vmlinuz-4.15.0-65-generic
+Updating /boot/grub/menu.lst ... done
+
+/etc/kernel/postinst.d/zz-update-grub:
+Sourcing file `/etc/default/grub'
+Sourcing file `/etc/default/grub.d/50-cloudimg-settings.cfg'
+Sourcing file `/etc/default/grub.d/90-autopkgtest.cfg'
+Generating grub configuration file ...
+Found linux image: /boot/vmlinuz-4.15.0-106-generic
+Found initrd image: /boot/initrd.img-4.15.0-106-generic
+Found linux image: /boot/vmlinuz-4.15.0-66-generic
+Found initrd image: /boot/initrd.img-4.15.0-66-generic
+Found linux image: /boot/vmlinuz-4.15.0-65-generic
+Found initrd image: /boot/initrd.img-4.15.0-65-generic
+Found Ubuntu 18.04.3 LTS (18.04) on /dev/vdb1
+done
+Processing triggers for shim-signed (1.37~18.04.3+15+1533136590.3beb971-0ubuntu1) ...
+W: APT had planned for dpkg to do more than it reported back (611 vs 614).
+   Affected packages: libblkid1:amd64
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', 'export http_proxy=http://squid.internal:3128; export https_proxy=http://squid.internal:3128; apt-get update'], kind install, sout raw, serr raw, env ['AUTOPKGTEST_IS_SETUP_COMMAND=1', 'AUTOPKGTEST_NORMAL_USER=ubuntu', 'ADT_NORMAL_USER=ubuntu', 'DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
+Reading package lists...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['bash', '-ec', '[ ! -e /run/autopkgtest_no_reboot.stamp ] || exit 0;for d in /boot /etc/init /etc/init.d /etc/systemd/system /lib/systemd/system; do s=/tmp/autopkgtest.Ihmrn9/${d//\\//_}.stamp;  [ ! -d $d ] || [ `stat -c %Y $d` = `stat -c %Y $s` ]; done'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest [03:29:37]: rebooting testbed after setup commands that affected boot
+autopkgtest: DBG: sending command to testbed: reboot
+autopkgtest-virt-qemu: DBG: executing reboot
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec for d in /var/cache /home; do if [ -w $d ]; then   tar --warning=none --create --absolute-names     -f $d/autopkgtest-tmpdir.tar '/tmp/autopkgtest.Ihmrn9';   rm -f /run/autopkgtest-reboot-prepare-mark;   exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: saved current downtmp, rebooting
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -c (sleep 3; reboot) >/dev/null 2>&1 &
+autopkgtest-virt-qemu: DBG: expect: " login: "
+[[0;32m  OK  [0m] Stopped target Graphical Interface.
+[[0;32m  OK  [0m] Stopped target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Stopped target Timers.
+[[0;32m  OK  [0m] Stopped Discard unused blocks once a week.
+[[0;32m  OK  [0m] Closed Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Stopped Message of the Day.
+[[0;32m  OK  [0m] Stopped Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Stopped Daily apt download activities.
+[[0;32m  OK  [0m] Stopped target System Time Synchronized.
+         Stopping Daemon for generating UUIDs...
+[[0;32m  OK  [0m] Stopped target Multi-User System.
+         Stopping LSB: Record successful boot for GRUB...
+         Stopping Login Service...
+         Stopping Dispatcher daemon for systemd-networkd...
+         Stopping OpenBSD Secure Shell server...
+         Stopping LSB: automatic crash report generation...
+         Stopping Deferred execution scheduler...
+         Stopping autopkgtest root shell on ttyS1...
+         Stopping Regular background program processing daemon...
+[[0;32m  OK  [0m] Stopped target Login Prompts.
+         Stopping Serial Getty on ttyS0...
+         Stopping Getty on tty1...
+         Stopping System Logging Service...
+         Stopping D-Bus System Message Bus...
+[[0;32m  OK  [0m] Stopped Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Stopped autopkgtest root shell on ttyS1.
+[[0;32m  OK  [0m] Stopped Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Stopped Deferred execution scheduler.
+[[0;32m  OK  [0m] Stopped System Logging Service.
+[[0;32m  OK  [0m] Stopped Regular background program processing daemon.
+[[0;32m  OK  [0m] Stopped Login Service.
+[[0;32m  OK  [0m] Stopped OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Stopped Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Stopped Getty on tty1.
+[[0;32m  OK  [0m] Stopped Daemon for generating UUIDs.
+[[0;32m  OK  [0m] Stopped D-Bus System Message Bus.
+[[0;32m  OK  [0m] Stopped LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Removed slice system-getty.slice.
+[[0;32m  OK  [0m] Removed slice system-serial\x2dgetty.slice.
+         Stopping Permit User Sessions...
+[[0;32m  OK  [0m] Stopped LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Stopped Permit User Sessions.
+[[0;32m  OK  [0m] Stopped target Basic System.
+[[0;32m  OK  [0m] Stopped target Slices.
+[[0;32m  OK  [0m] Removed slice User and Session Slice.
+[[0;32m  OK  [0m] Stopped target Sockets.
+[[0;32m  OK  [0m] Closed UUID daemon activation socket.
+[[0;32m  OK  [0m] Closed Syslog Socket.
+[[0;32m  OK  [0m] Closed D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Closed ACPID Listen Socket.
+[[0;32m  OK  [0m] Stopped target Paths.
+[[0;32m  OK  [0m] Stopped ACPI Events Check.
+[[0;32m  OK  [0m] Stopped target System Initialization.
+         Stopping Network Time Synchronization...
+[[0;32m  OK  [0m] Stopped target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Stopped Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Stopped Dispatch Password Requests to Console Directory Watch.
+         Stopping Update UTMP about System Boot/Shutdown...
+         Stopping Load/Save Random Seed...
+[[0;32m  OK  [0m] Stopped target Swap.
+[[0;32m  OK  [0m] Stopped target Network.
+         Stopping Network Name Resolution...
+[[0;32m  OK  [0m] Stopped target Remote File Systems.
+[[0;32m  OK  [0m] Stopped Network Time Synchronization.
+[[0;32m  OK  [0m] Stopped Network Name Resolution.
+[[0;32m  OK  [0m] Stopped Load/Save Random Seed.
+[[0;32m  OK  [0m] Stopped Update UTMP about System Boot/Shutdown.
+         Stopping Network Service...
+[[0;32m  OK  [0m] Stopped Create Volatile Files and Directories.
+[[0;32m  OK  [0m] Stopped target Local File Systems.
+         Unmounting /run/autopkgtest/shared...
+         Unmounting /boot/efi...
+[[0;32m  OK  [0m] Stopped Network Service.
+[[0;32m  OK  [0m] Stopped Apply Kernel Variables.
+[[0;32m  OK  [0m] Stopped Load Kernel Modules.
+[[0;32m  OK  [0m] Unmounted /run/autopkgtest/shared.
+[[0;32m  OK  [0m] Unmounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Unmount All Filesystems.
+[[0;32m  OK  [0m] Stopped target Local File Systems (Pre).
+[[0;32m  OK  [0m] Stopped Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Stopped Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Reached target Shutdown.
+[[0;32m  OK  [0m] Reached target Final Step.
+         Starting Reboot...
+[  152.764967] reboot: Restarting system
+[    0.000000] Linux version 4.15.0-106-generic (buildd@lcy01-amd64-016) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #107-Ubuntu SMP Thu Jun 4 11:27:52 UTC 2020 (Ubuntu 4.15.0-106.107-generic 4.15.18)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-106-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Centaur CentaurHauls
+[    0.000000] x86/fpu: x87 FPU will use FXSAVE
+[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffddfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffde000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000feffc000-0x00000000feffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.8 present.
+[    0.000000] DMI: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.2-1ubuntu1 04/01/2014
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] e820: last_pfn = 0xbffde max_arch_pfn = 0x400000000
+[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- UC  
+[    0.000000] found SMP MP-table at [mem 0x000f6a80-0x000f6a8f]
+[    0.000000] Scanning 1 areas for low memory corruption
+[    0.000000] RAMDISK: [mem 0x3338b000-0x359bcfff]
+[    0.000000] ACPI: Early table checksum verification disabled
+[    0.000000] ACPI: RSDP 0x00000000000F68A0 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x00000000BFFE15FC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x00000000BFFE1458 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x00000000BFFE0040 001418 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x00000000BFFE0000 000040
+[    0.000000] ACPI: APIC 0x00000000BFFE154C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x00000000BFFE15C4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.000000] No NUMA configuration found
+[    0.000000] Faking a node at [mem 0x0000000000000000-0x00000000bffddfff]
+[    0.000000] NODE_DATA(0) allocated [mem 0xbffb3000-0xbffddfff]
+[    0.000000] kvm-clock: cpu 0, msr 0:bff32001, primary cpu clock
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: using sched offset of 165925944638 cycles
+[    0.000000] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000bffddfff]
+[    0.000000]   Normal   empty
+[    0.000000]   Device   empty
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.000000]   node   0: [mem 0x0000000000100000-0x00000000bffddfff]
+[    0.000000] Reserved but unavailable: 98 pages
+[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x00000000bffddfff]
+[    0.000000] ACPI: PM-Timer IO Port: 0x608
+[    0.000000] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.000000] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.000000] Using ACPI (MADT) for SMP configuration information
+[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.000000] smpboot: Allowing 1 CPUs, 0 hotplug CPUs
+[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.000000] PM: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.000000] PM: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.000000] e820: [mem 0xc0000000-0xfeffbfff] available for PCI devices
+[    0.000000] Booting paravirtualized kernel on KVM
+[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.000000] random: get_random_bytes called from start_kernel+0x99/0x4fd with crng_init=0
+[    0.000000] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:1 nr_cpu_ids:1 nr_node_ids:1
+[    0.000000] percpu: Embedded 45 pages/cpu s147456 r8192 d28672 u2097152
+[    0.000000] KVM setup async PF for cpu 0
+[    0.000000] kvm-stealtime: cpu 0, msr bfa23040
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 773991
+[    0.000000] Policy zone: DMA32
+[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-4.15.0-106-generic root=UUID=0205a10c-1f07-4ea3-9ced-7c64c860f94e ro console=ttyS0
+[    0.000000] AGP: Checking aperture...
+[    0.000000] AGP: No AGP bridge found
+[    0.000000] Memory: 3027636K/3145200K available (12300K kernel code, 2481K rwdata, 4272K rodata, 2436K init, 2720K bss, 117564K reserved, 0K cma-reserved)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
+[    0.000000] Kernel/User page tables isolation: enabled
+[    0.000000] ftrace: allocating 39378 entries in 154 pages
+[    0.004000] Hierarchical RCU implementation.
+[    0.004000] 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=1.
+[    0.004000] 	Tasks RCU enabled.
+[    0.004000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
+[    0.004000] NR_IRQS: 524544, nr_irqs: 256, preallocated irqs: 16
+[    0.004000] Console: colour VGA+ 80x25
+[    0.004000] console [ttyS0] enabled
+[    0.004000] ACPI: Core revision 20170831
+[    0.004000] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.004000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+[    0.004006] APIC: Switch to symmetric I/O mode setup
+[    0.005012] x2apic enabled
+[    0.005678] Switched APIC routing to physical x2apic.
+[    0.007783] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.008000] tsc: Detected 2397.222 MHz processor
+[    0.008000] Calibrating delay loop (skipped) preset value.. 4794.44 BogoMIPS (lpj=9588888)
+[    0.008000] pid_max: default: 32768 minimum: 301
+[    0.008000] Security Framework initialized
+[    0.008000] Yama: becoming mindful.
+[    0.008024] AppArmor: AppArmor initialized
+[    0.009236] Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.010540] Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes)
+[    0.011528] Mount-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.012013] Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes)
+[    0.013259] Last level iTLB entries: 4KB 0, 2MB 0, 4MB 0
+[    0.014050] Last level dTLB entries: 4KB 0, 2MB 0, 4MB 0, 1GB 0
+[    0.014927] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.016003] Spectre V2 : Mitigation: Full generic retpoline
+[    0.016732] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.017836] Speculative Store Bypass: Vulnerable
+[    0.018454] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.027294] Freeing SMP alternatives memory: 36K
+[    0.137691] smpboot: CPU0: Intel Common KVM processor (family: 0xf, model: 0x6, stepping: 0x1)
+[    0.138918] Performance Events: unsupported Netburst CPU model 6 no PMU driver, software events only.
+[    0.140000] Hierarchical SRCU implementation.
+[    0.140000] NMI watchdog: Perf event create on CPU 0 failed with -2
+[    0.140001] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.140836] smp: Bringing up secondary CPUs ...
+[    0.141436] smp: Brought up 1 node, 1 CPU
+[    0.141923] smpboot: Max logical packages: 1
+[    0.142439] smpboot: Total of 1 processors activated (4794.44 BogoMIPS)
+[    0.143408] devtmpfs: initialized
+[    0.144047] x86/mm: Memory block size: 128MB
+[    0.144849] evm: security.selinux
+[    0.145263] evm: security.SMACK64
+[    0.145669] evm: security.SMACK64EXEC
+[    0.146117] evm: security.SMACK64TRANSMUTE
+[    0.146613] evm: security.SMACK64MMAP
+[    0.147058] evm: security.apparmor
+[    0.147472] evm: security.ima
+[    0.148003] evm: security.capability
+[    0.148637] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.149992] futex hash table entries: 256 (order: 2, 16384 bytes)
+[    0.150888] pinctrl core: initialized pinctrl subsystem
+[    0.151733] RTC time:  3:29:53, date: 06/16/20
+[    0.152077] NET: Registered protocol family 16
+[    0.152752] audit: initializing netlink subsys (disabled)
+[    0.153571] cpuidle: using governor ladder
+[    0.154128] cpuidle: using governor menu
+[    0.154705] ACPI: bus type PCI registered
+[    0.155262] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.156107] PCI: Using configuration type 1 for base access
+[    0.156913] audit: type=2000 audit(1592278193.049:1): state=initialized audit_enabled=0 res=1
+[    0.158875] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.160160] ACPI: Added _OSI(Module Device)
+[    0.160737] ACPI: Added _OSI(Processor Device)
+[    0.161336] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.161970] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.162751] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.163404] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.164008] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.165332] ACPI: Interpreter enabled
+[    0.165847] ACPI: (supports S0 S3 S4 S5)
+[    0.166380] ACPI: Using IOAPIC for interrupt routing
+[    0.167097] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.168136] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    0.172300] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.173174] acpi PNP0A03:00: _OSC: OS supports [ASPM ClockPM Segments MSI]
+[    0.174132] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
+[    0.175045] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.176245] acpiphp: Slot [3] registered
+[    0.176816] acpiphp: Slot [4] registered
+[    0.177386] acpiphp: Slot [5] registered
+[    0.177949] acpiphp: Slot [6] registered
+[    0.178521] acpiphp: Slot [7] registered
+[    0.179123] acpiphp: Slot [8] registered
+[    0.180037] acpiphp: Slot [9] registered
+[    0.180656] acpiphp: Slot [10] registered
+[    0.181235] acpiphp: Slot [11] registered
+[    0.181753] acpiphp: Slot [12] registered
+[    0.182356] acpiphp: Slot [13] registered
+[    0.182901] acpiphp: Slot [14] registered
+[    0.183418] acpiphp: Slot [15] registered
+[    0.184033] acpiphp: Slot [16] registered
+[    0.184549] acpiphp: Slot [17] registered
+[    0.185065] acpiphp: Slot [18] registered
+[    0.185605] acpiphp: Slot [19] registered
+[    0.186247] acpiphp: Slot [20] registered
+[    0.186802] acpiphp: Slot [21] registered
+[    0.187429] acpiphp: Slot [22] registered
+[    0.188037] acpiphp: Slot [23] registered
+[    0.188702] acpiphp: Slot [24] registered
+[    0.189327] acpiphp: Slot [25] registered
+[    0.189849] acpiphp: Slot [26] registered
+[    0.190478] acpiphp: Slot [27] registered
+[    0.191088] acpiphp: Slot [28] registered
+[    0.191654] acpiphp: Slot [29] registered
+[    0.192035] acpiphp: Slot [30] registered
+[    0.192592] acpiphp: Slot [31] registered
+[    0.193119] PCI host bridge to bus 0000:00
+[    0.193649] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.194521] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.195439] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.196002] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    0.196917] pci_bus 0000:00: root bus resource [mem 0x100000000-0x17fffffff window]
+[    0.197844] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.203059] pci 0000:00:01.1: legacy IDE quirk: reg 0x10: [io  0x01f0-0x01f7]
+[    0.204002] pci 0000:00:01.1: legacy IDE quirk: reg 0x14: [io  0x03f6]
+[    0.204845] pci 0000:00:01.1: legacy IDE quirk: reg 0x18: [io  0x0170-0x0177]
+[    0.205789] pci 0000:00:01.1: legacy IDE quirk: reg 0x1c: [io  0x0376]
+[    0.207342] pci 0000:00:01.3: quirk: [io  0x0600-0x063f] claimed by PIIX4 ACPI
+[    0.208010] pci 0000:00:01.3: quirk: [io  0x0700-0x070f] claimed by PIIX4 SMB
+[    0.249154] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    0.250000] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    0.250775] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    0.251568] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    0.252051] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    0.253042] SCSI subsystem initialized
+[    0.253620] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.254375] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.255432] pci 0000:00:02.0: vgaarb: bridge control possible
+[    0.256002] vgaarb: loaded
+[    0.256370] ACPI: bus type USB registered
+[    0.256867] usbcore: registered new interface driver usbfs
+[    0.257577] usbcore: registered new interface driver hub
+[    0.258223] usbcore: registered new device driver usb
+[    0.258866] EDAC MC: Ver: 3.0.0
+[    0.260152] PCI: Using ACPI for IRQ routing
+[    0.260968] NetLabel: Initializing
+[    0.261462] NetLabel:  domain hash size = 128
+[    0.262024] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.262795] NetLabel:  unlabeled traffic allowed by default
+[    0.264105] HPET: 3 timers in total, 0 timers will be used for per-cpu timer
+[    0.265093] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0
+[    0.265721] hpet0: 3 comparators, 64-bit 100.000000 MHz counter
+[    0.271138] clocksource: Switched to clocksource kvm-clock
+[    0.277040] VFS: Disk quotas dquot_6.6.0
+[    0.277607] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.278564] AppArmor: AppArmor Filesystem Enabled
+[    0.279171] pnp: PnP ACPI init
+[    0.279970] pnp: PnP ACPI: found 7 devices
+[    0.285831] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.286994] NET: Registered protocol family 2
+[    0.287649] TCP established hash table entries: 32768 (order: 6, 262144 bytes)
+[    0.288640] TCP bind hash table entries: 32768 (order: 7, 524288 bytes)
+[    0.289581] TCP: Hash tables configured (established 32768 bind 32768)
+[    0.290415] UDP hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.291221] UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes)
+[    0.292059] NET: Registered protocol family 1
+[    0.292616] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    0.293429] pci 0000:00:01.0: PIIX3: Enabling Passive Release
+[    0.294179] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    0.294961] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.296054] Unpacking initramfs...
+[    0.720635] Freeing initrd memory: 39112K
+[    0.721331] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x228df7309b5, max_idle_ns: 440795314334 ns
+[    0.722744] Scanning for low memory corruption every 60 seconds
+[    0.723884] Initialise system trusted keyrings
+[    0.724466] Key type blacklist registered
+[    0.725042] workingset: timestamp_bits=36 max_order=20 bucket_order=0
+[    0.726565] zbud: loaded
+[    0.727645] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    0.728406] fuse init (API version 7.26)
+[    0.729542] Key type asymmetric registered
+[    0.730021] Asymmetric key parser 'x509' registered
+[    0.730591] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+[    0.731464] io scheduler noop registered
+[    0.731948] io scheduler deadline registered
+[    0.732520] io scheduler cfq registered (default)
+[    0.733255] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    0.734113] ACPI: Power Button [PWRF]
+[    0.751658] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    0.770847] ACPI: PCI Interrupt Link [LNKD] enabled at IRQ 10
+[    0.792053] ACPI: PCI Interrupt Link [LNKA] enabled at IRQ 10
+[    0.811614] ACPI: PCI Interrupt Link [LNKB] enabled at IRQ 11
+[    0.813450] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    0.838694] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    0.863615] 00:06: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    0.865662] Linux agpgart interface v0.103
+[    0.867176] loop: module loaded
+[    0.868261] scsi host0: ata_piix
+[    0.868766] scsi host1: ata_piix
+[    0.869233] ata1: PATA max MWDMA2 cmd 0x1f0 ctl 0x3f6 bmdma 0xc0c0 irq 14
+[    0.870043] ata2: PATA max MWDMA2 cmd 0x170 ctl 0x376 bmdma 0xc0c8 irq 15
+[    0.871169] libphy: Fixed MDIO Bus: probed
+[    0.871697] tun: Universal TUN/TAP device driver, 1.6
+[    0.872376] PPP generic driver version 2.4.2
+[    0.872961] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    0.873797] ehci-pci: EHCI PCI platform driver
+[    0.874354] ehci-platform: EHCI generic platform driver
+[    0.874986] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    0.875724] ohci-pci: OHCI PCI platform driver
+[    0.876534] ohci-platform: OHCI generic platform driver
+[    0.877269] uhci_hcd: USB Universal Host Controller Interface driver
+[    0.878111] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    0.879840] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    0.880468] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    0.881205] mousedev: PS/2 mouse device common for all mice
+[    0.882201] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input1
+[    0.883538] rtc_cmos 00:00: RTC can wake from S4
+[    0.884400] rtc_cmos 00:00: rtc core: registered rtc_cmos as rtc0
+[    0.885364] rtc_cmos 00:00: alarms up to one day, y3k, 114 bytes nvram, hpet irqs
+[    0.886283] i2c /dev entries driver
+[    0.886760] device-mapper: uevent: version 1.0.3
+[    0.887360] device-mapper: ioctl: 4.37.0-ioctl (2017-09-20) initialised: dm-devel@redhat.com
+[    0.888378] ledtrig-cpu: registered to indicate activity on CPUs
+[    0.889361] NET: Registered protocol family 10
+[    0.892556] Segment Routing with IPv6
+[    0.893103] NET: Registered protocol family 17
+[    0.893669] Key type dns_resolver registered
+[    0.894322] mce: Using 10 MCE banks
+[    0.894782] RAS: Correctable Errors collector initialized.
+[    0.895446] sched_clock: Marking stable (892005864, 0)->(1100254380, -208248516)
+[    0.896415] registered taskstats version 1
+[    0.896963] Loading compiled-in X.509 certificates
+[    0.899367] Loaded X.509 cert 'Build time autogenerated kernel key: b1772ce3e036cbf6bf2b7e9ed9be0f8806d61091'
+[    0.900786] zswap: loaded using pool lzo/zbud
+[    0.903768] Key type big_key registered
+[    0.904297] Key type trusted registered
+[    0.905941] Key type encrypted registered
+[    0.906415] AppArmor: AppArmor sha1 policy hashing enabled
+[    0.907037] ima: No TPM chip found, activating TPM-bypass! (rc=-19)
+[    0.907827] ima: Allocated hash algorithm: sha1
+[    0.908514] evm: HMAC attrs: 0x1
+[    0.909375]   Magic number: 8:443:462
+[    0.909908] rtc_cmos 00:00: setting system clock to 2020-06-16 03:29:54 UTC (1592278194)
+[    0.910913] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
+[    0.911645] EDD information not available.
+[    1.037447] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
+[    1.040140] ata2.00: configured for MWDMA2
+[    1.042221] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
+[    1.069069] sr 1:0:0:0: [sr0] scsi3-mmc drive: 4x/4x cd/rw xa/form2 tray
+[    1.071147] cdrom: Uniform CD-ROM driver Revision: 3.20
+[    1.073514] sr 1:0:0:0: Attached scsi generic sg0 type 5
+[    1.079660] Freeing unused kernel image memory: 2436K
+[    1.088017] Write protecting the kernel read-only data: 20480k
+[    1.089196] Freeing unused kernel image memory: 2008K
+[    1.090149] Freeing unused kernel image memory: 1872K
+[    1.098134] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.099245] x86/mm: Checking user space page tables
+[    1.108639] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+Loading, please wait...
+starting version 237
+[    1.191295] Floppy drive(s): fd0 is 2.88M AMI BIOS
+[    1.200559] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
+[    1.210332]  vda: vda1 vda14 vda15
+[    1.213036] FDC 0 is a S82078B
+[    1.215290] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input4
+[    1.216603] input: VirtualPS/2 VMware VMMouse as /devices/platform/i8042/serio1/input/input3
+[    1.257818] virtio_net virtio0 ens3: renamed from eth0
+[    1.259841] virtio_net virtio1 ens4: renamed from eth1
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... [    1.340069] raid6: sse2x1   gen() 10314 MB/s
+[    1.388120] raid6: sse2x1   xor()  7429 MB/s
+[    1.436112] raid6: sse2x2   gen() 12884 MB/s
+[    1.484049] raid6: sse2x2   xor()  8174 MB/s
+[    1.532005] raid6: sse2x4   gen() 15691 MB/s
+[    1.580052] raid6: sse2x4   xor()  9484 MB/s
+[    1.580610] raid6: using algorithm sse2x4 gen() 15691 MB/s
+[    1.581319] raid6: .... xor() 9484 MB/s, rmw enabled
+[    1.581880] raid6: using intx1 recovery algorithm
+[    1.585851] xor: measuring software checksum speed
+[    1.624005]    prefetch64-sse: 19680.000 MB/sec
+[    1.664089]    generic_sse: 18091.000 MB/sec
+[    1.664627] xor: using function: prefetch64-sse (19680.000 MB/sec)
+[    1.682707] Btrfs loaded, crc32c=crc32c-generic
+Scanning for Btrfs filesystems
+[    1.749193] random: fast init done
+[    1.832149] print_req_error: I/O error, dev fd0, sector 0
+[    1.833872] floppy: error 10 while reading block 0
+done.
+[    1.841843] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    1.844284] random: wait-for-root: uninitialized urandom read (16 bytes read)
+[    1.845746] random: wait-for-root: uninitialized urandom read (16 bytes read)
+Warning: fsck not present, so skipping root file system
+[    1.859907] EXT4-fs (vda1): mounted filesystem with ordered data mode. Opts: (null)
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... done.
+[    2.060810] ip_tables: (C) 2000-2006 Netfilter Core Team
+[    2.069761] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    2.073190] systemd[1]: Detected virtualization kvm.
+[    2.074004] systemd[1]: Detected architecture x86-64.
+
+Welcome to [1mUbuntu 18.04.4 LTS[0m!
+
+[    2.077314] systemd[1]: Set hostname to <autopkgtest>.
+[    2.178354] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
+[[0;32m  OK  [0m] Set up automount Arbitrary Executabâ¦rmats File System Automount Point.
+[    2.181454] systemd[1]: Created slice User and Session Slice.
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[    2.183403] systemd[1]: Reached target Swap.
+[[0;32m  OK  [0m] Reached target Swap.
+[    2.185047] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[    2.187447] systemd[1]: Reached target Remote File Systems.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[    2.189504] systemd[1]: Created slice System Slice.
+[[0;32m  OK  [0m] Created slice System Slice.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Mounting Huge Pages File System...
+         Starting Create list of required stâ¦ce nodes for the current kernel...
+         Starting Set the console keyboard layout...
+         Starting Remount Root and Kernel File Systems...
+         Starting Uncomplicated firewall...[    2.216045] EXT4-fs (vda1): re-mounted. Opts: (null)
+
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+         Starting udev Coldplug all Devices...
+         Starting Load Kernel Modules...
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+         Mounting POSIX Message Queue File System...
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+         Mounting Kernel Debug File System...
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+         Starting Journal Service...
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+[[0;32m  OK  [0m] Started Create list of required staâ¦vice nodes for the current kernel.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+[[0;32m  OK  [0m] Started Uncomplicated firewall.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+         Mounting Kernel Configuration File System...
+         Starting Apply Kernel Variables...
+         Mounting FUSE Control File System...
+         Starting Load/Save Random Seed...
+         Starting Create Static Device Nodes in /dev...
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started Journal Service.
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Found device /dev/disk/by-label/UEFI.
+[[0;32m  OK  [0m] Found device /dev/ttyS0.
+[[0;32m  OK  [0m] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
+[[0;32m  OK  [0m] Started Set the console keyboard layout.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+         Mounting /boot/efi...
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Reached target Local Encrypted Volumes.
+[[0;32m  OK  [0m] Mounted /boot/efi.
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Set console font and keymap...
+         Starting AppArmor initialization...
+         Starting Tell Plymouth To Write Out Runtime Data...
+         Starting Create Volatile Files and Directories...
+[[0;32m  OK  [0m] Started Set console font and keymap.
+[[0;32m  OK  [0m] Started Tell Plymouth To Write Out Runtime Data.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Update UTMP about System Boot/Shutdown...
+         Starting Network Name Resolution...
+         Starting Network Time Synchronization...
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Reached target Network.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Started AppArmor initialization.
+[[0;32m  OK  [0m] Started Entropy daemon using the HAVEGE algorithm.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on ACPID Listen Socket.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+[[0;32m  OK  [0m] Started ACPI Events Check.
+[[0;32m  OK  [0m] Reached target Paths.
+[[0;32m  OK  [0m] Listening on UUID daemon activation socket.
+[[0;32m  OK  [0m] Started Message of the Day.
+[[0;32m  OK  [0m] Started Discard unused blocks once a week.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+[[0;32m  OK  [0m] Started Deferred execution scheduler.
+[[0;32m  OK  [0m] Started Regular background program processing daemon.
+         Starting LSB: Record successful boot for GRUB...
+         Starting LSB: automatic crash report generation...
+[[0;32m  OK  [0m] Started autopkgtest root shell on ttyS1.
+         Starting Dispatcher daemon for systemd-networkd...
+         Starting OpenBSD Secure Shell server...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+         Starting System Logging Service...
+         Starting Login Service...
+         Starting Thermal Daemon Service...
+         Starting Permit User Sessions...
+[[0;32m  OK  [0m] Started irqbalance daemon.
+[[0;32m  OK  [0m] Started Daily apt download activities.
+[[0;32m  OK  [0m] Started Daily apt upgrade and clean activities.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Thermal Daemon Service.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started OpenBSD Secure Shell server.
+[[0;32m  OK  [0m] Started LSB: Record successful boot for GRUB.
+[[0;32m  OK  [0m] Started LSB: automatic crash report generation.
+[[0;32m  OK  [0m] Started Login Service.
+         Starting Hold until boot process finishes up...
+         Starting Terminate Plymouth Boot Screen...
+[[0;32m  OK  [0m] Started Hold until boot process finishes up.
+         Starting Set console scheme...
+[[0;32m  OK  [0m] Started Serial Getty on ttyS0.
+[[0;32m  OK  [0m] Started Terminate Plymouth Boot Screen.
+[[0;32m  OK  [0m] Started Set console scheme.
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Started Dispatcher daemon for systemd-networkd.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+[[0;32m  OK  [0m] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+
+Ubuntu 18.04.4 LTS autopkgtest ttyS0
+
+autopkgtest login: autopkgtest-virt-qemu: DBG: expect: found ""login prompt on ttyS0""
+autopkgtest-virt-qemu: DBG: expect: "ok"
+autopkgtest-virt-qemu: DBG: expect: found ""b'ok'""
+autopkgtest-virt-qemu: DBG: setup_shell(): there already is a shell on ttyS1
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "# "
+autopkgtest-virt-qemu: DBG: expect: found ""b'# '""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "(qemu)"
+autopkgtest-virt-qemu: DBG: expect: found ""b'(qemu)'""
+autopkgtest-virt-qemu: DBG: expect: "#"
+autopkgtest-virt-qemu: DBG: expect: found ""b'#'""
+autopkgtest-virt-qemu: DBG: execute-timeout: /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec for d in /var/cache /home; do if [ -e $d/autopkgtest-tmpdir.tar ]; then  tar --warning=none --extract --absolute-names      -f $d/autopkgtest-tmpdir.tar; rm $d/autopkgtest-tmpdir.tar; exit 0; fi; done; exit 1
+autopkgtest-virt-qemu: DBG: cmd_reboot: restored downtmp after reboot
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--print-architecture'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [03:30:05]: testbed dpkg architecture: amd64
+autopkgtest: DBG: testbed command ['which', 'eatmydata'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed has eatmydata
+autopkgtest: DBG: testbed command ['which', 'dpkg-query'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', "dpkg-query --show -f '${Package}\\t${Version}\\n' > /tmp/autopkgtest.Ihmrn9/testbed-packages"], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/testbed-packages /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/testbed-packages'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/testbed-packages'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/testbed-packages
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed supports reboot, creating /tmp/autopkgtest-reboot
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\np=$PPID; while true; do read _ c _ pp _ < /proc/$p/stat;  [ $pp -ne $test_script_pid ] || break; p=$pp; done\\nkill -KILL $p\\n\' > /tmp/autopkgtest-reboot;chmod 755 /tmp/autopkgtest-reboot;[ -L /sbin/autopkgtest-reboot ] || ln -s   /tmp/autopkgtest-reboot /sbin/autopkgtest-reboot 2>/dev/null || true'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ecC', '[ ! -e /tmp/autopkgtest-reboot-prepare ] || exit 0; /bin/echo -e \'#!/bin/sh -e\\n[ -n "$1" ] || { echo "Usage: $0 <mark>" >&2; exit 1; }\\necho "$1" > /run/autopkgtest-reboot-prepare-mark\\ntest_script_pid=$(cat /tmp/autopkgtest_script_pid)\\nkill -KILL $test_script_pid\\nwhile [ -e /run/autopkgtest-reboot-prepare-mark ]; do sleep 0.5; done\\n \'> /tmp/autopkgtest-reboot-prepare;chmod 755 /tmp/autopkgtest-reboot-prepare;'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['uname', '-srv'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Binaries: publish
+autopkgtest: DBG: testbed command ['rm', '-rf', '/tmp/autopkgtest.Ihmrn9/binaries'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.Ihmrn9'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/ /tmp/autopkgtest.Ihmrn9/binaries/
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/ /tmp/autopkgtest.Ihmrn9/binaries/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/', '--warning=none', '-c', '.', '-f', '-'], ['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'if ! test -d /tmp/autopkgtest.Ihmrn9/binaries/; then mkdir -- /tmp/autopkgtest.Ihmrn9/binaries/; fi; cd /tmp/autopkgtest.Ihmrn9/binaries/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/binaries/ --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec if ! test -d /tmp/autopkgtest.Ihmrn9/binaries/; then mkdir -- /tmp/autopkgtest.Ihmrn9/binaries/; fi; cd /tmp/autopkgtest.Ihmrn9/binaries/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.Ihmrn9/binaries'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '\n  printf \'Package: *\\nPin: origin ""\\nPin-Priority: 1002\\n\' > /etc/apt/preferences.d/90autopkgtest\n  echo "deb [trusted=yes] file:///tmp/autopkgtest.Ihmrn9/binaries /" >/etc/apt/sources.list.d/autopkgtest.list\n  if [ "x`ls /var/lib/dpkg/updates`" != x ]; then\n    echo >&2 "/var/lib/dpkg/updates contains some files, aargh"; exit 1\n  fi\n  apt-get --quiet --no-list-cleanup -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/autopkgtest.list -o Dir::Etc::sourceparts=/dev/null update 2>&1\n  cp /var/lib/dpkg/status /tmp/autopkgtest.Ihmrn9/apt-update.out\n  '], kind install, sout raw, serr pipe, env ['DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Get:1 file:/tmp/autopkgtest.Ihmrn9/binaries  InRelease
+Ign:1 file:/tmp/autopkgtest.Ihmrn9/binaries  InRelease
+Get:2 file:/tmp/autopkgtest.Ihmrn9/binaries  Release [816 B]
+Get:2 file:/tmp/autopkgtest.Ihmrn9/binaries  Release [816 B]
+Get:3 file:/tmp/autopkgtest.Ihmrn9/binaries  Release.gpg
+Ign:3 file:/tmp/autopkgtest.Ihmrn9/binaries  Release.gpg
+Get:4 file:/tmp/autopkgtest.Ihmrn9/binaries  Packages [583 B]
+Reading package lists...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/apt-update.out /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/apt-update.out
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/apt-update.out /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/apt-update.out
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/apt-update.out'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/apt-update.out'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/apt-update.out
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: Binaries: publish reinstall checking...
+autopkgtest: DBG: Binaries: publish done
+autopkgtest: DBG: install_deps: deps_new=['maas', 'maas-dhcp', 'maas-dns', 'maas-cli', 'python3-mock', 'python3-nose', 'python3-setuptools', 'python3-yaml', 'devscripts', 'build-essential', 'pep8', 'pyflakes', 'fakeroot', 'debhelper', 'python3-oauthlib', 'python3-testtools'], recommends=False
+autopkgtest: DBG: install-deps: satisfying maas, maas-dhcp, maas-dns, maas-cli, python3-mock, python3-nose, python3-setuptools, python3-yaml, devscripts, build-essential, pep8, pyflakes, fakeroot, debhelper, python3-oauthlib, python3-testtools
+autopkgtest: DBG: install-deps: architecture resolved: maas, maas-dhcp, maas-dns, maas-cli, python3-mock, python3-nose, python3-setuptools, python3-yaml, devscripts, build-essential, pep8, pyflakes, fakeroot, debhelper, python3-oauthlib, python3-testtools
+autopkgtest: DBG: testbed command ['test', '-w', '/var/lib/dpkg/status'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: can use apt-get on testbed: True
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.Ihmrn9'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/autopkgtest-satdep.deb /tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/autopkgtest-satdep.deb /tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['cat'], ['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cat >/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/autopkgtest-satdep.deb'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< cat
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cat >/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--unpack', '/tmp/autopkgtest.Ihmrn9/autopkgtest-satdep.deb'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['/bin/sh', '-ec', '/usr/bin/eatmydata apt-get install --assume-yes --fix-broken -o APT::Status-Fd=3 -o APT::Install-Recommends=False -o Dpkg::Options::=--force-confnew -o Debug::pkgProblemResolver=true 3>&2 2>&1'], kind install, sout raw, serr pipe, env ['DEBIAN_FRONTEND=noninteractive', 'APT_LISTBUGS_FRONTEND=none', 'APT_LISTCHANGES_FRONTEND=none']
+Reading package lists...
+Building dependency tree...
+Reading state information...
+Correcting dependencies...Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+ Done
+Starting pkgProblemResolver with broken count: 0
+Starting 2 pkgProblemResolver with broken count: 0
+Done
+The following packages were automatically installed and are no longer required:
+  linux-headers-4.15.0-65 linux-headers-4.15.0-65-generic
+  linux-image-4.15.0-65-generic linux-modules-4.15.0-65-generic
+  python3-configobj
+Use 'apt autoremove' to remove them.
+The following additional packages will be installed:
+  archdetect-deb authbind autoconf automake autopoint autotools-dev
+  avahi-daemon avahi-utils bind9 bind9utils build-essential chrony cpp cpp-7
+  curtin-common dbconfig-common dbconfig-pgsql debhelper devscripts
+  dh-autoreconf dh-strip-nondeterminism distro-info docutils-common fakeroot
+  formencode-i18n freeipmi-common freeipmi-tools g++ g++-7 gcc gcc-7
+  gcc-7-base gettext ieee-data intltool-debian isc-dhcp-server
+  libarchive-zip-perl libasan4 libatomic1 libavahi-client3
+  libavahi-common-data libavahi-common3 libavahi-core7 libc-dev-bin libc6-dev
+  libcc1-0 libcilkrts5 libcroco3 libcurl3-gnutls libdaemon0 libdbi-perl
+  libdebian-installer4 libecap3 libfakeroot libfile-homedir-perl
+  libfile-stripnondeterminism-perl libfile-which-perl libfreeipmi16
+  libgcc-7-dev libgomp1 libipmiconsole2 libipmidetect0 libirs-export160
+  libisccfg-export160 libisl19 libitm1 libjs-angularjs libjs-jquery
+  libjs-sphinxdoc libjs-underscore liblsan0 libltdl7 libmpc3 libmpx2 libnspr4
+  libnss3 libpq5 libprotobuf10 libpython-stdlib libpython2.7-minimal
+  libpython2.7-stdlib libquadmath0 libsodium23 libstdc++-7-dev
+  libtimedate-perl libtool libtsan0 libubsan0 libuv1 libvirt-clients libvirt0
+  libxslt1.1 libyajl2 linux-libc-dev m4 maas maas-cli maas-common maas-dhcp
+  maas-dns maas-proxy maas-rack-controller maas-region-api
+  maas-region-controller pep8 po-debconf postgresql postgresql-10
+  postgresql-client postgresql-client-10 postgresql-client-common
+  postgresql-common pxelinux pycodestyle pyflakes python
+  python-babel-localedata python-django-common python-minimal
+  python-pkg-resources python-pyflakes python2.7 python2.7-minimal
+  python3-alabaster python3-attr python3-automat python3-babel python3-bson
+  python3-constantly python3-convoy python3-crochet python3-curtin
+  python3-distro-info python3-distutils python3-django python3-django-maas
+  python3-django-piston3 python3-djorm-ext-pgarray python3-dnspython
+  python3-docutils python3-extras python3-fixtures python3-formencode
+  python3-hyperlink python3-imagesize python3-incremental python3-iso8601
+  python3-lib2to3 python3-linecache2 python3-lxml python3-maas-client
+  python3-maas-provisioningserver python3-macaroonbakery python3-mimeparse
+  python3-mock python3-nacl python3-netaddr python3-nose python3-oauth
+  python3-paramiko python3-pbr python3-petname python3-pexpect python3-ply
+  python3-prettytable python3-protobuf python3-psycopg2 python3-ptyprocess
+  python3-pyasn1 python3-pyasn1-modules python3-pycodestyle python3-pygments
+  python3-pymacaroons python3-pyparsing python3-pyvmomi python3-rfc3339
+  python3-roman python3-seamicroclient python3-service-identity
+  python3-setuptools python3-simplejson python3-simplestreams python3-sphinx
+  python3-tempita python3-testtools python3-traceback2 python3-twisted
+  python3-twisted-bin python3-txtftp python3-tz python3-unittest2
+  python3-uvloop python3-zope.interface sgml-base sphinx-common squid
+  squid-common squid-langpack ssl-cert syslinux-common xml-core
+Suggested packages:
+  autoconf-archive gnu-standards autoconf-doc avahi-autoipd bind9-doc
+  resolvconf cpp-doc gcc-7-locales dh-make dwz adequate autopkgtest
+  bls-standalone bsd-mailx | mailx check-all-the-things cvs-buildpackage
+  devscripts-el diffoscope disorderfs dose-extra duck faketime gnuplot
+  how-can-i-help libauthen-sasl-perl libfile-desktopentry-perl
+  libnet-smtps-perl libterm-size-perl libyaml-syck-perl mozilla-devscripts
+  mutt piuparts quilt ratt reprotest svn-buildpackage w3m debian-keyring
+  equivs liblwp-protocol-https-perl libsoap-lite-perl shunit2
+  freeipmi-ipmidetect freeipmi-bmc-watchdog g++-multilib g++-7-multilib
+  gcc-7-doc libstdc++6-7-dbg gcc-multilib manpages-dev flex bison gdb gcc-doc
+  gcc-7-multilib libgcc1-dbg libgomp1-dbg libitm1-dbg libatomic1-dbg
+  libasan4-dbg liblsan0-dbg libtsan0-dbg libubsan0-dbg libcilkrts5-dbg
+  libmpx2-dbg libquadmath0-dbg gettext-doc libasprintf-dev libgettextpo-dev
+  isc-dhcp-server-ldap policycoreutils glibc-doc libclone-perl libmldbm-perl
+  libnet-daemon-perl libsql-statement-perl libstdc++-7-doc libtool-doc
+  gfortran | fortran95-compiler gcj-jdk libvirt-daemon m4-doc amtterm ipmitool
+  nmap wsmancli libmail-box-perl postgresql-doc locales-all postgresql-doc-10
+  libjson-perl tftpd-hpa python-doc python-tk python-setuptools python2.7-doc
+  binfmt-support python-attr-doc bpython3 geoip-database-contrib ipython3
+  libgdal1 python-django-doc python3-bcrypt python3-flup python3-memcache
+  python3-pil python3-pymysql python3-sqlite docutils-doc fonts-linuxlibertine
+  | ttf-linux-libertine texlive-lang-french texlive-latex-base
+  texlive-latex-recommended python3-egenix-mxdatetime python3-lxml-dbg
+  python-lxml-doc python-mock-doc python-nacl-doc python-netaddr-docs
+  python-nose-doc python3-gssapi python-pexpect-doc python-ply-doc
+  python-psycopg2-doc ttf-bitstream-vera python-pyparsing-doc
+  python-pyvmomi-doc python-setuptools-doc python3-sphinx-rtd-theme
+  libjs-mathjax dvipng texlive-latex-extra texlive-fonts-recommended
+  texlive-generic-extra latexmk imagemagick-6.q16 sphinx-doc
+  python-testtools-doc python3-tk python3-gtk2 python3-glade2 python3-qt4
+  python3-wxgtk2.8 python3-twisted-bin-dbg sgml-base-doc squidclient squid-cgi
+  squid-purge smbclient winbindd openssl-blacklist
+Recommended packages:
+  libnss-mdns dctrl-tools dput | dupload libdistro-info-perl
+  libencode-locale-perl libgit-wrapper-perl liblist-compare-perl liburi-perl
+  libwww-perl licensecheck lintian patchutils python3-debian python3-magic
+  python3-unidiff python3-xdg unzip wdiff manpages manpages-dev
+  libarchive-cpio-perl javascript-common libltdl-dev lvm2
+  libmail-sendmail-perl sysstat pyflakes3 python3-bson-ext python3-sqlparse
+  libpaper-utils python3-pil python3-click python3-bs4 python3-html5lib
+  python3-pam
+The following NEW packages will be installed:
+  archdetect-deb authbind autoconf automake autopoint autotools-dev
+  avahi-daemon avahi-utils bind9 bind9utils build-essential chrony cpp cpp-7
+  curtin-common dbconfig-common dbconfig-pgsql debhelper devscripts
+  dh-autoreconf dh-strip-nondeterminism distro-info docutils-common fakeroot
+  formencode-i18n freeipmi-common freeipmi-tools g++ g++-7 gcc gcc-7
+  gcc-7-base gettext ieee-data intltool-debian isc-dhcp-server
+  libarchive-zip-perl libasan4 libatomic1 libavahi-client3
+  libavahi-common-data libavahi-common3 libavahi-core7 libc-dev-bin libc6-dev
+  libcc1-0 libcilkrts5 libcroco3 libcurl3-gnutls libdaemon0 libdbi-perl
+  libdebian-installer4 libecap3 libfakeroot libfile-homedir-perl
+  libfile-stripnondeterminism-perl libfile-which-perl libfreeipmi16
+  libgcc-7-dev libgomp1 libipmiconsole2 libipmidetect0 libirs-export160
+  libisccfg-export160 libisl19 libitm1 libjs-angularjs libjs-jquery
+  libjs-sphinxdoc libjs-underscore liblsan0 libltdl7 libmpc3 libmpx2 libnspr4
+  libnss3 libpq5 libprotobuf10 libpython-stdlib libpython2.7-minimal
+  libpython2.7-stdlib libquadmath0 libsodium23 libstdc++-7-dev
+  libtimedate-perl libtool libtsan0 libubsan0 libuv1 libvirt-clients libvirt0
+  libxslt1.1 libyajl2 linux-libc-dev m4 maas maas-cli maas-common maas-dhcp
+  maas-dns maas-proxy maas-rack-controller maas-region-api
+  maas-region-controller pep8 po-debconf postgresql postgresql-10
+  postgresql-client postgresql-client-10 postgresql-client-common
+  postgresql-common pxelinux pycodestyle pyflakes python
+  python-babel-localedata python-django-common python-minimal
+  python-pkg-resources python-pyflakes python2.7 python2.7-minimal
+  python3-alabaster python3-attr python3-automat python3-babel python3-bson
+  python3-constantly python3-convoy python3-crochet python3-curtin
+  python3-distro-info python3-distutils python3-django python3-django-maas
+  python3-django-piston3 python3-djorm-ext-pgarray python3-dnspython
+  python3-docutils python3-extras python3-fixtures python3-formencode
+  python3-hyperlink python3-imagesize python3-incremental python3-iso8601
+  python3-lib2to3 python3-linecache2 python3-lxml python3-maas-client
+  python3-maas-provisioningserver python3-macaroonbakery python3-mimeparse
+  python3-mock python3-nacl python3-netaddr python3-nose python3-oauth
+  python3-paramiko python3-pbr python3-petname python3-pexpect python3-ply
+  python3-prettytable python3-protobuf python3-psycopg2 python3-ptyprocess
+  python3-pyasn1 python3-pyasn1-modules python3-pycodestyle python3-pygments
+  python3-pymacaroons python3-pyparsing python3-pyvmomi python3-rfc3339
+  python3-roman python3-seamicroclient python3-service-identity
+  python3-setuptools python3-simplejson python3-simplestreams python3-sphinx
+  python3-tempita python3-testtools python3-traceback2 python3-twisted
+  python3-twisted-bin python3-txtftp python3-tz python3-unittest2
+  python3-uvloop python3-zope.interface sgml-base sphinx-common squid
+  squid-common squid-langpack ssl-cert syslinux-common xml-core
+0 upgraded, 201 newly installed, 0 to remove and 0 not upgraded.
+1 not fully installed or removed.
+Need to get 88.6 MB of archives.
+After this operation, 380 MB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 authbind amd64 2.1.2 [17.9 kB]
+Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-common-data amd64 0.7-3.1ubuntu1.2 [22.1 kB]
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-common3 amd64 0.7-3.1ubuntu1.2 [21.6 kB]
+Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-client3 amd64 0.7-3.1ubuntu1.2 [25.2 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libavahi-core7 amd64 0.7-3.1ubuntu1.2 [81.1 kB]
+Get:6 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdaemon0 amd64 0.14-6 [16.6 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 avahi-daemon amd64 0.7-3.1ubuntu1.2 [62.3 kB]
+Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 avahi-utils amd64 0.7-3.1ubuntu1.2 [24.8 kB]
+Get:9 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-ply all 3.11-1 [46.6 kB]
+Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bind9utils amd64 1:9.11.3+dfsg-1ubuntu1.12 [216 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 distro-info amd64 0.18ubuntu0.18.04.1 [19.9 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 freeipmi-common amd64 1.4.11-1.1ubuntu4.1 [174 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libfreeipmi16 amd64 1.4.11-1.1ubuntu4.1 [826 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libipmiconsole2 amd64 1.4.11-1.1ubuntu4.1 [83.9 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libipmidetect0 amd64 1.4.11-1.1ubuntu4.1 [25.6 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 freeipmi-tools amd64 1.4.11-1.1ubuntu4.1 [622 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl3-gnutls amd64 7.58.0-2ubuntu3.8 [213 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic/main amd64 libyajl2 amd64 2.1.0-2build1 [20.0 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libvirt0 amd64 4.0.0-1ubuntu8.17 [1,249 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libvirt-clients amd64 4.0.0-1ubuntu8.17 [596 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic/main amd64 libsodium23 amd64 1.0.16-2 [143 kB]
+Get:22 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-nacl amd64 1.1.2-1build1 [27.9 kB]
+Get:23 http://archive.ubuntu.com/ubuntu bionic/main amd64 libprotobuf10 amd64 3.0.0-9.1ubuntu1 [651 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-protobuf amd64 3.0.0-9.1ubuntu1 [262 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pymacaroons all 0.13.0-1 [13.1 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-tz all 2018.3-2 [25.1 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-rfc3339 all 1.0-4 [6,356 B]
+Get:28 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-macaroonbakery all 1.1.3-1 [62.3 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-oauth all 1.0.1-5 [8,238 B]
+Get:30 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-tempita all 0.5.2-2 [13.9 kB]
+Get:31 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-maas-client all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [32.6 kB]
+Get:32 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-cli all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [2,636 B]
+Get:33 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdebian-installer4 amd64 0.110ubuntu2 [21.6 kB]
+Get:34 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 archdetect-deb amd64 1.117ubuntu6.18.04.1 [6,192 B]
+Get:35 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-attr all 17.4.0-2 [23.8 kB]
+Get:36 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-bson amd64 3.6.1+dfsg1-1 [31.8 kB]
+Get:37 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-automat all 0.6.0-1 [25.2 kB]
+Get:38 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-constantly all 15.1.0-1 [8,030 B]
+Get:39 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-hyperlink all 17.3.1-2 [27.6 kB]
+Get:40 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-incremental all 16.10.1-3 [14.5 kB]
+Get:41 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-zope.interface amd64 4.3.2-1build2 [82.4 kB]
+Get:42 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-twisted-bin amd64 17.9.0-2ubuntu0.1 [11.4 kB]
+Get:43 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyasn1 all 0.4.2-3 [46.8 kB]
+Get:44 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyasn1-modules all 0.2.1-0.2 [32.9 kB]
+Get:45 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-service-identity all 16.0.0-2 [9,388 B]
+Get:46 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-twisted all 17.9.0-2ubuntu0.1 [1,919 kB]
+Get:47 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-crochet all 1.4.0-0ubuntu2 [20.9 kB]
+Get:48 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 curtin-common all 19.3-26-g82f23e3d-0ubuntu1~18.04.1 [20.3 kB]
+Get:49 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-curtin all 19.3-26-g82f23e3d-0ubuntu1~18.04.1 [144 kB]
+Get:50 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-distro-info all 0.18ubuntu0.18.04.1 [9,296 B]
+Get:51 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-dnspython all 1.15.0-1 [85.0 kB]
+Get:52 http://archive.ubuntu.com/ubuntu bionic/main amd64 formencode-i18n all 1.3.0-0ubuntu5 [3,382 B]
+Get:53 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-formencode all 1.3.0-0ubuntu5 [69.2 kB]
+Get:54 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libxslt1.1 amd64 1.1.29-5ubuntu0.2 [150 kB]
+Get:55 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-lxml amd64 4.2.1-1ubuntu0.1 [1,091 kB]
+Get:56 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-paramiko all 2.0.0-1ubuntu1.2 [110 kB]
+Get:57 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-ptyprocess all 0.5.2-1 [12.7 kB]
+Get:58 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pexpect all 4.2.1-1 [42.4 kB]
+Get:59 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyparsing all 2.2.0+dfsg1-2 [52.2 kB]
+Get:60 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pyvmomi all 6.5.0.2017.5-0ubuntu1 [169 kB]
+Get:61 http://archive.ubuntu.com/ubuntu bionic/main amd64 python-babel-localedata all 2.4.0+dfsg.1-2ubuntu1 [3,412 kB]
+Get:62 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-babel all 2.4.0+dfsg.1-2ubuntu1 [79.9 kB]
+Get:63 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pbr all 3.1.1-3ubuntu3 [53.8 kB]
+Get:64 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-prettytable all 0.7.2-3 [19.7 kB]
+Get:65 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-simplejson amd64 3.13.2-1 [49.6 kB]
+Get:66 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-iso8601 all 0.1.11-1 [9,876 B]
+Get:67 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-seamicroclient all 0.4.0-1ubuntu1 [27.4 kB]
+Get:68 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-simplestreams all 0.1.0~bzr460-0ubuntu1.1 [22.3 kB]
+Get:69 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-txtftp all 0.1~bzr47-0ubuntu2 [17.6 kB]
+Get:70 http://archive.ubuntu.com/ubuntu bionic/main amd64 libuv1 amd64 1.18.0-3 [64.4 kB]
+Get:71 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-uvloop amd64 0.8.1+ds1-1ubuntu0.1 [420 kB]
+Get:72 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-maas-provisioningserver all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [274 kB]
+Get:73 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-common all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [6,988 B]
+Get:74 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libisccfg-export160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [45.5 kB]
+Get:75 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libirs-export160 amd64 1:9.11.3+dfsg-1ubuntu1.12 [18.4 kB]
+Get:76 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 isc-dhcp-server amd64 4.3.5-3ubuntu7.1 [446 kB]
+Get:77 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-dhcp all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,912 B]
+Get:78 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnspr4 amd64 2:4.18-1ubuntu1 [112 kB]
+Get:79 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libnss3 amd64 2:3.35-2ubuntu2.7 [1,135 kB]
+Get:80 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 chrony amd64 3.2-4ubuntu4.4 [203 kB]
+Get:81 http://archive.ubuntu.com/ubuntu bionic/main amd64 pxelinux all 3:6.03+dfsg1-2 [187 kB]
+Get:82 http://archive.ubuntu.com/ubuntu bionic/main amd64 ieee-data all 20180204.1 [1,539 kB]
+Get:83 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-netaddr all 0.7.19-1 [213 kB]
+Get:84 http://archive.ubuntu.com/ubuntu bionic/main amd64 syslinux-common all 3:6.03+dfsg1-2 [1,171 kB]
+Get:85 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-rack-controller all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [10.6 kB]
+Get:86 http://archive.ubuntu.com/ubuntu bionic/main amd64 dbconfig-common all 2.0.9 [601 kB]
+Get:87 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpq5 amd64 10.12-0ubuntu0.18.04.1 [107 kB]
+Get:88 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-client-common all 190ubuntu0.1 [29.6 kB]
+Get:89 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-client-10 amd64 10.12-0ubuntu0.18.04.1 [937 kB]
+Get:90 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-client all 10+190ubuntu0.1 [5,896 B]
+Get:91 http://archive.ubuntu.com/ubuntu bionic/main amd64 dbconfig-pgsql all 2.0.9 [1,010 B]
+Get:92 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 bind9 amd64 1:9.11.3+dfsg-1ubuntu1.12 [398 kB]
+Get:93 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-angularjs all 1.5.10-1 [506 kB]
+Get:94 http://archive.ubuntu.com/ubuntu bionic/main amd64 libecap3 amd64 1.0.1-3.2 [16.6 kB]
+Get:95 http://archive.ubuntu.com/ubuntu bionic/main amd64 libltdl7 amd64 2.4.6-2 [38.8 kB]
+Get:96 http://archive.ubuntu.com/ubuntu bionic/main amd64 squid-langpack all 20170901-1 [137 kB]
+Get:97 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 squid-common all 3.5.27-1ubuntu1.6 [177 kB]
+Get:98 http://archive.ubuntu.com/ubuntu bionic/main amd64 libdbi-perl amd64 1.640-1 [724 kB]
+Get:99 http://archive.ubuntu.com/ubuntu bionic/main amd64 ssl-cert all 1.0.39 [17.0 kB]
+Get:100 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 squid amd64 3.5.27-1ubuntu1.6 [2,218 kB]
+Get:101 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-proxy all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,668 B]
+Get:102 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python-django-common all 1:1.11.11-1ubuntu1.9 [1,522 kB]
+Get:103 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-django all 1:1.11.11-1ubuntu1.9 [900 kB]
+Get:104 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-convoy all 0.2.1+bzr39-1 [9,478 B]
+Get:105 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-psycopg2 amd64 2.7.4-1 [152 kB]
+Get:106 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-lib2to3 all 3.6.9-1~18.04 [77.4 kB]
+Get:107 http://archive.ubuntu.com/ubuntu bionic/main amd64 sgml-base all 1.29 [12.3 kB]
+Get:108 http://archive.ubuntu.com/ubuntu bionic/main amd64 xml-core all 0.18 [21.3 kB]
+Get:109 http://archive.ubuntu.com/ubuntu bionic/main amd64 docutils-common all 0.14+dfsg-3 [156 kB]
+Get:110 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-roman all 2.0.0-3 [8,624 B]
+Get:111 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-docutils all 0.14+dfsg-3 [363 kB]
+Get:112 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-pygments all 2.2.0+dfsg-1 [574 kB]
+Get:113 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-alabaster all 0.7.8-1 [18.5 kB]
+Get:114 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-imagesize all 0.7.1-1 [3,926 B]
+Get:115 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-jquery all 3.2.1-1 [152 kB]
+Get:116 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-underscore all 1.8.3~dfsg-1 [59.9 kB]
+Get:117 http://archive.ubuntu.com/ubuntu bionic/main amd64 libjs-sphinxdoc all 1.6.7-1ubuntu1 [85.6 kB]
+Get:118 http://archive.ubuntu.com/ubuntu bionic/main amd64 sphinx-common all 1.6.7-1ubuntu1 [420 kB]
+Get:119 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-sphinx all 1.6.7-1ubuntu1 [459 kB]
+Get:120 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-django-maas all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,123 kB]
+Get:121 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-mimeparse all 0.1.4-3.1 [6,256 B]
+Get:122 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-django-piston3 amd64 0.3~rc2-3ubuntu5 [35.3 kB]
+Get:123 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-djorm-ext-pgarray all 1.2-0ubuntu2 [6,938 B]
+Get:124 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-petname all 2.2-0ubuntu1 [10.9 kB]
+Get:125 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-region-api all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [1,768 kB]
+Get:126 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-common all 190ubuntu0.1 [157 kB]
+Get:127 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql-10 amd64 10.12-0ubuntu0.18.04.1 [3,761 kB]
+Get:128 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 postgresql all 10+190ubuntu0.1 [5,884 B]
+Get:129 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas-region-controller all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [5,316 B]
+Get:130 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 maas all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [3,112 B]
+Get:131 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 maas-dns all 2.4.2-7034-g2f5deb8b8-0ubuntu1 [3,504 B]
+Get:132 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python3-mock all 2.0.0-3 [47.5 kB]
+Get:133 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python3-nose all 1.3.7-3 [115 kB]
+Get:134 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-distutils all 3.6.9-1~18.04 [144 kB]
+Get:135 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-setuptools all 39.0.1-2 [248 kB]
+Get:136 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-which-perl all 1.21-1 [11.8 kB]
+Get:137 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-homedir-perl all 1.002-1 [37.1 kB]
+Get:138 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 devscripts amd64 2.17.12ubuntu1.1 [870 kB]
+Get:139 http://archive.ubuntu.com/ubuntu bionic/main amd64 libc-dev-bin amd64 2.27-3ubuntu1 [71.8 kB]
+Get:140 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 linux-libc-dev amd64 4.15.0-106.107 [991 kB]
+Get:141 http://archive.ubuntu.com/ubuntu bionic/main amd64 libc6-dev amd64 2.27-3ubuntu1 [2,587 kB]
+Get:142 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7-base amd64 7.5.0-3ubuntu1~18.04 [18.3 kB]
+Get:143 http://archive.ubuntu.com/ubuntu bionic/main amd64 libisl19 amd64 0.19-1 [551 kB]
+Get:144 http://archive.ubuntu.com/ubuntu bionic/main amd64 libmpc3 amd64 1.1.0-1 [40.8 kB]
+Get:145 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp-7 amd64 7.5.0-3ubuntu1~18.04 [8,591 kB]
+Get:146 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 cpp amd64 4:7.4.0-1ubuntu2.3 [27.7 kB]
+Get:147 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcc1-0 amd64 8.4.0-1ubuntu1~18.04 [39.4 kB]
+Get:148 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgomp1 amd64 8.4.0-1ubuntu1~18.04 [76.5 kB]
+Get:149 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libitm1 amd64 8.4.0-1ubuntu1~18.04 [27.9 kB]
+Get:150 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libatomic1 amd64 8.4.0-1ubuntu1~18.04 [9,192 B]
+Get:151 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libasan4 amd64 7.5.0-3ubuntu1~18.04 [358 kB]
+Get:152 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 liblsan0 amd64 8.4.0-1ubuntu1~18.04 [133 kB]
+Get:153 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libtsan0 amd64 8.4.0-1ubuntu1~18.04 [288 kB]
+Get:154 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libubsan0 amd64 7.5.0-3ubuntu1~18.04 [126 kB]
+Get:155 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcilkrts5 amd64 7.5.0-3ubuntu1~18.04 [42.5 kB]
+Get:156 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmpx2 amd64 8.4.0-1ubuntu1~18.04 [11.6 kB]
+Get:157 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libquadmath0 amd64 8.4.0-1ubuntu1~18.04 [134 kB]
+Get:158 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libgcc-7-dev amd64 7.5.0-3ubuntu1~18.04 [2,378 kB]
+Get:159 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc-7 amd64 7.5.0-3ubuntu1~18.04 [9,381 kB]
+Get:160 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gcc amd64 4:7.4.0-1ubuntu2.3 [5,184 B]
+Get:161 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libstdc++-7-dev amd64 7.5.0-3ubuntu1~18.04 [1,471 kB]
+Get:162 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++-7 amd64 7.5.0-3ubuntu1~18.04 [9,697 kB]
+Get:163 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 g++ amd64 4:7.4.0-1ubuntu2.3 [1,568 B]
+Get:164 http://archive.ubuntu.com/ubuntu bionic/main amd64 build-essential amd64 12.4ubuntu1 [4,758 B]
+Get:165 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python3-pycodestyle all 2.3.1-2 [32.9 kB]
+Get:166 http://archive.ubuntu.com/ubuntu bionic/universe amd64 pycodestyle all 2.3.1-2 [4,978 B]
+Get:167 http://archive.ubuntu.com/ubuntu bionic/universe amd64 pep8 all 1.7.1-1ubuntu1 [5,700 B]
+Get:168 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython2.7-minimal amd64 2.7.17-1~18.04ubuntu1 [335 kB]
+Get:169 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python2.7-minimal amd64 2.7.17-1~18.04ubuntu1 [1,294 kB]
+Get:170 http://archive.ubuntu.com/ubuntu bionic/main amd64 python-minimal amd64 2.7.15~rc1-1 [28.1 kB]
+Get:171 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython2.7-stdlib amd64 2.7.17-1~18.04ubuntu1 [1,915 kB]
+Get:172 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python2.7 amd64 2.7.17-1~18.04ubuntu1 [248 kB]
+Get:173 http://archive.ubuntu.com/ubuntu bionic/main amd64 libpython-stdlib amd64 2.7.15~rc1-1 [7,620 B]
+Get:174 http://archive.ubuntu.com/ubuntu bionic/main amd64 python amd64 2.7.15~rc1-1 [140 kB]
+Get:175 http://archive.ubuntu.com/ubuntu bionic/main amd64 python-pkg-resources all 39.0.1-2 [128 kB]
+Get:176 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-pyflakes all 1.6.0-1 [41.7 kB]
+Get:177 http://archive.ubuntu.com/ubuntu bionic/universe amd64 pyflakes all 1.6.0-1 [3,296 B]
+Get:178 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfakeroot amd64 1.22-2ubuntu1 [25.9 kB]
+Get:179 http://archive.ubuntu.com/ubuntu bionic/main amd64 fakeroot amd64 1.22-2ubuntu1 [62.3 kB]
+Get:180 http://archive.ubuntu.com/ubuntu bionic/main amd64 autotools-dev all 20180224.1 [39.6 kB]
+Get:181 http://archive.ubuntu.com/ubuntu bionic/main amd64 m4 amd64 1.4.18-1 [197 kB]
+Get:182 http://archive.ubuntu.com/ubuntu bionic/main amd64 autoconf all 2.69-11 [322 kB]
+Get:183 http://archive.ubuntu.com/ubuntu bionic/main amd64 automake all 1:1.15.1-3ubuntu2 [509 kB]
+Get:184 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 autopoint all 0.19.8.1-6ubuntu0.3 [426 kB]
+Get:185 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtool all 2.4.6-2 [194 kB]
+Get:186 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-autoreconf all 17 [15.8 kB]
+Get:187 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libarchive-zip-perl all 1.60-1ubuntu0.1 [84.6 kB]
+Get:188 http://archive.ubuntu.com/ubuntu bionic/main amd64 libfile-stripnondeterminism-perl all 0.040-1.1~build1 [13.8 kB]
+Get:189 http://archive.ubuntu.com/ubuntu bionic/main amd64 libtimedate-perl all 2.3000-2 [37.5 kB]
+Get:190 http://archive.ubuntu.com/ubuntu bionic/main amd64 dh-strip-nondeterminism all 0.040-1.1~build1 [5,208 B]
+Get:191 http://archive.ubuntu.com/ubuntu bionic/main amd64 libcroco3 amd64 0.6.12-2 [81.3 kB]
+Get:192 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 gettext amd64 0.19.8.1-6ubuntu0.3 [1,293 kB]
+Get:193 http://archive.ubuntu.com/ubuntu bionic/main amd64 intltool-debian all 0.35.0+20060710.4 [24.9 kB]
+Get:194 http://archive.ubuntu.com/ubuntu bionic/main amd64 po-debconf all 1.0.20 [232 kB]
+Get:195 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 debhelper all 11.1.6ubuntu2 [902 kB]
+Get:196 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-extras all 1.0.0-3 [7,480 B]
+Get:197 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-fixtures all 3.0.0-2 [32.4 kB]
+Get:198 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-linecache2 all 1.0.0-3 [12.5 kB]
+Get:199 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-traceback2 all 1.4.0-5 [16.4 kB]
+Get:200 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-unittest2 all 1.1.0-6.1 [69.2 kB]
+Get:201 http://archive.ubuntu.com/ubuntu bionic/main amd64 python3-testtools all 2.3.0-3ubuntu2 [124 kB]
+Preconfiguring packages ...
+Fetched 88.6 MB in 4s (21.6 MB/s)
+Selecting previously unselected package authbind.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 126921 files and directories currently installed.)
+Preparing to unpack .../000-authbind_2.1.2_amd64.deb ...
+Unpacking authbind (2.1.2) ...
+Selecting previously unselected package libavahi-common-data:amd64.
+Preparing to unpack .../001-libavahi-common-data_0.7-3.1ubuntu1.2_amd64.deb ...
+Unpacking libavahi-common-data:amd64 (0.7-3.1ubuntu1.2) ...
+Selecting previously unselected package libavahi-common3:amd64.
+Preparing to unpack .../002-libavahi-common3_0.7-3.1ubuntu1.2_amd64.deb ...
+Unpacking libavahi-common3:amd64 (0.7-3.1ubuntu1.2) ...
+Selecting previously unselected package libavahi-client3:amd64.
+Preparing to unpack .../003-libavahi-client3_0.7-3.1ubuntu1.2_amd64.deb ...
+Unpacking libavahi-client3:amd64 (0.7-3.1ubuntu1.2) ...
+Selecting previously unselected package libavahi-core7:amd64.
+Preparing to unpack .../004-libavahi-core7_0.7-3.1ubuntu1.2_amd64.deb ...
+Unpacking libavahi-core7:amd64 (0.7-3.1ubuntu1.2) ...
+Selecting previously unselected package libdaemon0:amd64.
+Preparing to unpack .../005-libdaemon0_0.14-6_amd64.deb ...
+Unpacking libdaemon0:amd64 (0.14-6) ...
+Selecting previously unselected package avahi-daemon.
+Preparing to unpack .../006-avahi-daemon_0.7-3.1ubuntu1.2_amd64.deb ...
+Unpacking avahi-daemon (0.7-3.1ubuntu1.2) ...
+Selecting previously unselected package avahi-utils.
+Preparing to unpack .../007-avahi-utils_0.7-3.1ubuntu1.2_amd64.deb ...
+Unpacking avahi-utils (0.7-3.1ubuntu1.2) ...
+Selecting previously unselected package python3-ply.
+Preparing to unpack .../008-python3-ply_3.11-1_all.deb ...
+Unpacking python3-ply (3.11-1) ...
+Selecting previously unselected package bind9utils.
+Preparing to unpack .../009-bind9utils_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking bind9utils (1:9.11.3+dfsg-1ubuntu1.12) ...
+Selecting previously unselected package distro-info.
+Preparing to unpack .../010-distro-info_0.18ubuntu0.18.04.1_amd64.deb ...
+Unpacking distro-info (0.18ubuntu0.18.04.1) ...
+Selecting previously unselected package freeipmi-common.
+Preparing to unpack .../011-freeipmi-common_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking freeipmi-common (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libfreeipmi16.
+Preparing to unpack .../012-libfreeipmi16_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking libfreeipmi16 (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libipmiconsole2.
+Preparing to unpack .../013-libipmiconsole2_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking libipmiconsole2 (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libipmidetect0.
+Preparing to unpack .../014-libipmidetect0_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking libipmidetect0 (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package freeipmi-tools.
+Preparing to unpack .../015-freeipmi-tools_1.4.11-1.1ubuntu4.1_amd64.deb ...
+Unpacking freeipmi-tools (1.4.11-1.1ubuntu4.1) ...
+Selecting previously unselected package libcurl3-gnutls:amd64.
+Preparing to unpack .../016-libcurl3-gnutls_7.58.0-2ubuntu3.8_amd64.deb ...
+Unpacking libcurl3-gnutls:amd64 (7.58.0-2ubuntu3.8) ...
+Selecting previously unselected package libyajl2:amd64.
+Preparing to unpack .../017-libyajl2_2.1.0-2build1_amd64.deb ...
+Unpacking libyajl2:amd64 (2.1.0-2build1) ...
+Selecting previously unselected package libvirt0:amd64.
+Preparing to unpack .../018-libvirt0_4.0.0-1ubuntu8.17_amd64.deb ...
+Unpacking libvirt0:amd64 (4.0.0-1ubuntu8.17) ...
+Selecting previously unselected package libvirt-clients.
+Preparing to unpack .../019-libvirt-clients_4.0.0-1ubuntu8.17_amd64.deb ...
+Unpacking libvirt-clients (4.0.0-1ubuntu8.17) ...
+Selecting previously unselected package libsodium23:amd64.
+Preparing to unpack .../020-libsodium23_1.0.16-2_amd64.deb ...
+Unpacking libsodium23:amd64 (1.0.16-2) ...
+Selecting previously unselected package python3-nacl.
+Preparing to unpack .../021-python3-nacl_1.1.2-1build1_amd64.deb ...
+Unpacking python3-nacl (1.1.2-1build1) ...
+Selecting previously unselected package libprotobuf10:amd64.
+Preparing to unpack .../022-libprotobuf10_3.0.0-9.1ubuntu1_amd64.deb ...
+Unpacking libprotobuf10:amd64 (3.0.0-9.1ubuntu1) ...
+Selecting previously unselected package python3-protobuf.
+Preparing to unpack .../023-python3-protobuf_3.0.0-9.1ubuntu1_amd64.deb ...
+Unpacking python3-protobuf (3.0.0-9.1ubuntu1) ...
+Selecting previously unselected package python3-pymacaroons.
+Preparing to unpack .../024-python3-pymacaroons_0.13.0-1_all.deb ...
+Unpacking python3-pymacaroons (0.13.0-1) ...
+Selecting previously unselected package python3-tz.
+Preparing to unpack .../025-python3-tz_2018.3-2_all.deb ...
+Unpacking python3-tz (2018.3-2) ...
+Selecting previously unselected package python3-rfc3339.
+Preparing to unpack .../026-python3-rfc3339_1.0-4_all.deb ...
+Unpacking python3-rfc3339 (1.0-4) ...
+Selecting previously unselected package python3-macaroonbakery.
+Preparing to unpack .../027-python3-macaroonbakery_1.1.3-1_all.deb ...
+Unpacking python3-macaroonbakery (1.1.3-1) ...
+Selecting previously unselected package python3-oauth.
+Preparing to unpack .../028-python3-oauth_1.0.1-5_all.deb ...
+Unpacking python3-oauth (1.0.1-5) ...
+Selecting previously unselected package python3-tempita.
+Preparing to unpack .../029-python3-tempita_0.5.2-2_all.deb ...
+Unpacking python3-tempita (0.5.2-2) ...
+Selecting previously unselected package python3-maas-client.
+Preparing to unpack .../030-python3-maas-client_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking python3-maas-client (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas-cli.
+Preparing to unpack .../031-maas-cli_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-cli (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package libdebian-installer4:amd64.
+Preparing to unpack .../032-libdebian-installer4_0.110ubuntu2_amd64.deb ...
+Unpacking libdebian-installer4:amd64 (0.110ubuntu2) ...
+Selecting previously unselected package archdetect-deb.
+Preparing to unpack .../033-archdetect-deb_1.117ubuntu6.18.04.1_amd64.deb ...
+Unpacking archdetect-deb (1.117ubuntu6.18.04.1) ...
+Selecting previously unselected package python3-attr.
+Preparing to unpack .../034-python3-attr_17.4.0-2_all.deb ...
+Unpacking python3-attr (17.4.0-2) ...
+Selecting previously unselected package python3-bson.
+Preparing to unpack .../035-python3-bson_3.6.1+dfsg1-1_amd64.deb ...
+Unpacking python3-bson (3.6.1+dfsg1-1) ...
+Selecting previously unselected package python3-automat.
+Preparing to unpack .../036-python3-automat_0.6.0-1_all.deb ...
+Unpacking python3-automat (0.6.0-1) ...
+Selecting previously unselected package python3-constantly.
+Preparing to unpack .../037-python3-constantly_15.1.0-1_all.deb ...
+Unpacking python3-constantly (15.1.0-1) ...
+Selecting previously unselected package python3-hyperlink.
+Preparing to unpack .../038-python3-hyperlink_17.3.1-2_all.deb ...
+Unpacking python3-hyperlink (17.3.1-2) ...
+Selecting previously unselected package python3-incremental.
+Preparing to unpack .../039-python3-incremental_16.10.1-3_all.deb ...
+Unpacking python3-incremental (16.10.1-3) ...
+Selecting previously unselected package python3-zope.interface.
+Preparing to unpack .../040-python3-zope.interface_4.3.2-1build2_amd64.deb ...
+Unpacking python3-zope.interface (4.3.2-1build2) ...
+Selecting previously unselected package python3-twisted-bin:amd64.
+Preparing to unpack .../041-python3-twisted-bin_17.9.0-2ubuntu0.1_amd64.deb ...
+Unpacking python3-twisted-bin:amd64 (17.9.0-2ubuntu0.1) ...
+Selecting previously unselected package python3-pyasn1.
+Preparing to unpack .../042-python3-pyasn1_0.4.2-3_all.deb ...
+Unpacking python3-pyasn1 (0.4.2-3) ...
+Selecting previously unselected package python3-pyasn1-modules.
+Preparing to unpack .../043-python3-pyasn1-modules_0.2.1-0.2_all.deb ...
+Unpacking python3-pyasn1-modules (0.2.1-0.2) ...
+Selecting previously unselected package python3-service-identity.
+Preparing to unpack .../044-python3-service-identity_16.0.0-2_all.deb ...
+Unpacking python3-service-identity (16.0.0-2) ...
+Selecting previously unselected package python3-twisted.
+Preparing to unpack .../045-python3-twisted_17.9.0-2ubuntu0.1_all.deb ...
+Unpacking python3-twisted (17.9.0-2ubuntu0.1) ...
+Selecting previously unselected package python3-crochet.
+Preparing to unpack .../046-python3-crochet_1.4.0-0ubuntu2_all.deb ...
+Unpacking python3-crochet (1.4.0-0ubuntu2) ...
+Selecting previously unselected package curtin-common.
+Preparing to unpack .../047-curtin-common_19.3-26-g82f23e3d-0ubuntu1~18.04.1_all.deb ...
+Unpacking curtin-common (19.3-26-g82f23e3d-0ubuntu1~18.04.1) ...
+Selecting previously unselected package python3-curtin.
+Preparing to unpack .../048-python3-curtin_19.3-26-g82f23e3d-0ubuntu1~18.04.1_all.deb ...
+Unpacking python3-curtin (19.3-26-g82f23e3d-0ubuntu1~18.04.1) ...
+Selecting previously unselected package python3-distro-info.
+Preparing to unpack .../049-python3-distro-info_0.18ubuntu0.18.04.1_all.deb ...
+Unpacking python3-distro-info (0.18ubuntu0.18.04.1) ...
+Selecting previously unselected package python3-dnspython.
+Preparing to unpack .../050-python3-dnspython_1.15.0-1_all.deb ...
+Unpacking python3-dnspython (1.15.0-1) ...
+Selecting previously unselected package formencode-i18n.
+Preparing to unpack .../051-formencode-i18n_1.3.0-0ubuntu5_all.deb ...
+Unpacking formencode-i18n (1.3.0-0ubuntu5) ...
+Selecting previously unselected package python3-formencode.
+Preparing to unpack .../052-python3-formencode_1.3.0-0ubuntu5_all.deb ...
+Unpacking python3-formencode (1.3.0-0ubuntu5) ...
+Selecting previously unselected package libxslt1.1:amd64.
+Preparing to unpack .../053-libxslt1.1_1.1.29-5ubuntu0.2_amd64.deb ...
+Unpacking libxslt1.1:amd64 (1.1.29-5ubuntu0.2) ...
+Selecting previously unselected package python3-lxml:amd64.
+Preparing to unpack .../054-python3-lxml_4.2.1-1ubuntu0.1_amd64.deb ...
+Unpacking python3-lxml:amd64 (4.2.1-1ubuntu0.1) ...
+Selecting previously unselected package python3-paramiko.
+Preparing to unpack .../055-python3-paramiko_2.0.0-1ubuntu1.2_all.deb ...
+Unpacking python3-paramiko (2.0.0-1ubuntu1.2) ...
+Selecting previously unselected package python3-ptyprocess.
+Preparing to unpack .../056-python3-ptyprocess_0.5.2-1_all.deb ...
+Unpacking python3-ptyprocess (0.5.2-1) ...
+Selecting previously unselected package python3-pexpect.
+Preparing to unpack .../057-python3-pexpect_4.2.1-1_all.deb ...
+Unpacking python3-pexpect (4.2.1-1) ...
+Selecting previously unselected package python3-pyparsing.
+Preparing to unpack .../058-python3-pyparsing_2.2.0+dfsg1-2_all.deb ...
+Unpacking python3-pyparsing (2.2.0+dfsg1-2) ...
+Selecting previously unselected package python3-pyvmomi.
+Preparing to unpack .../059-python3-pyvmomi_6.5.0.2017.5-0ubuntu1_all.deb ...
+Unpacking python3-pyvmomi (6.5.0.2017.5-0ubuntu1) ...
+Selecting previously unselected package python-babel-localedata.
+Preparing to unpack .../060-python-babel-localedata_2.4.0+dfsg.1-2ubuntu1_all.deb ...
+Unpacking python-babel-localedata (2.4.0+dfsg.1-2ubuntu1) ...
+Selecting previously unselected package python3-babel.
+Preparing to unpack .../061-python3-babel_2.4.0+dfsg.1-2ubuntu1_all.deb ...
+Unpacking python3-babel (2.4.0+dfsg.1-2ubuntu1) ...
+Selecting previously unselected package python3-pbr.
+Preparing to unpack .../062-python3-pbr_3.1.1-3ubuntu3_all.deb ...
+Unpacking python3-pbr (3.1.1-3ubuntu3) ...
+Selecting previously unselected package python3-prettytable.
+Preparing to unpack .../063-python3-prettytable_0.7.2-3_all.deb ...
+Unpacking python3-prettytable (0.7.2-3) ...
+Selecting previously unselected package python3-simplejson.
+Preparing to unpack .../064-python3-simplejson_3.13.2-1_amd64.deb ...
+Unpacking python3-simplejson (3.13.2-1) ...
+Selecting previously unselected package python3-iso8601.
+Preparing to unpack .../065-python3-iso8601_0.1.11-1_all.deb ...
+Unpacking python3-iso8601 (0.1.11-1) ...
+Selecting previously unselected package python3-seamicroclient.
+Preparing to unpack .../066-python3-seamicroclient_0.4.0-1ubuntu1_all.deb ...
+Unpacking python3-seamicroclient (0.4.0-1ubuntu1) ...
+Selecting previously unselected package python3-simplestreams.
+Preparing to unpack .../067-python3-simplestreams_0.1.0~bzr460-0ubuntu1.1_all.deb ...
+Unpacking python3-simplestreams (0.1.0~bzr460-0ubuntu1.1) ...
+Selecting previously unselected package python3-txtftp.
+Preparing to unpack .../068-python3-txtftp_0.1~bzr47-0ubuntu2_all.deb ...
+Unpacking python3-txtftp (0.1~bzr47-0ubuntu2) ...
+Selecting previously unselected package libuv1:amd64.
+Preparing to unpack .../069-libuv1_1.18.0-3_amd64.deb ...
+Unpacking libuv1:amd64 (1.18.0-3) ...
+Selecting previously unselected package python3-uvloop.
+Preparing to unpack .../070-python3-uvloop_0.8.1+ds1-1ubuntu0.1_amd64.deb ...
+Unpacking python3-uvloop (0.8.1+ds1-1ubuntu0.1) ...
+Selecting previously unselected package python3-maas-provisioningserver.
+Preparing to unpack .../071-python3-maas-provisioningserver_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking python3-maas-provisioningserver (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas-common.
+Preparing to unpack .../072-maas-common_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-common (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package libisccfg-export160.
+Preparing to unpack .../073-libisccfg-export160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libisccfg-export160 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Selecting previously unselected package libirs-export160.
+Preparing to unpack .../074-libirs-export160_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking libirs-export160 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Selecting previously unselected package isc-dhcp-server.
+Preparing to unpack .../075-isc-dhcp-server_4.3.5-3ubuntu7.1_amd64.deb ...
+Unpacking isc-dhcp-server (4.3.5-3ubuntu7.1) ...
+Selecting previously unselected package maas-dhcp.
+Preparing to unpack .../076-maas-dhcp_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-dhcp (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package libnspr4:amd64.
+Preparing to unpack .../077-libnspr4_2%3a4.18-1ubuntu1_amd64.deb ...
+Unpacking libnspr4:amd64 (2:4.18-1ubuntu1) ...
+Selecting previously unselected package libnss3:amd64.
+Preparing to unpack .../078-libnss3_2%3a3.35-2ubuntu2.7_amd64.deb ...
+Unpacking libnss3:amd64 (2:3.35-2ubuntu2.7) ...
+Selecting previously unselected package chrony.
+Preparing to unpack .../079-chrony_3.2-4ubuntu4.4_amd64.deb ...
+Unpacking chrony (3.2-4ubuntu4.4) ...
+Selecting previously unselected package pxelinux.
+Preparing to unpack .../080-pxelinux_3%3a6.03+dfsg1-2_all.deb ...
+Unpacking pxelinux (3:6.03+dfsg1-2) ...
+Selecting previously unselected package ieee-data.
+Preparing to unpack .../081-ieee-data_20180204.1_all.deb ...
+Unpacking ieee-data (20180204.1) ...
+Selecting previously unselected package python3-netaddr.
+Preparing to unpack .../082-python3-netaddr_0.7.19-1_all.deb ...
+Unpacking python3-netaddr (0.7.19-1) ...
+Selecting previously unselected package syslinux-common.
+Preparing to unpack .../083-syslinux-common_3%3a6.03+dfsg1-2_all.deb ...
+Unpacking syslinux-common (3:6.03+dfsg1-2) ...
+Selecting previously unselected package maas-rack-controller.
+Preparing to unpack .../084-maas-rack-controller_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-rack-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package dbconfig-common.
+Preparing to unpack .../085-dbconfig-common_2.0.9_all.deb ...
+Unpacking dbconfig-common (2.0.9) ...
+Selecting previously unselected package libpq5:amd64.
+Preparing to unpack .../086-libpq5_10.12-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking libpq5:amd64 (10.12-0ubuntu0.18.04.1) ...
+Selecting previously unselected package postgresql-client-common.
+Preparing to unpack .../087-postgresql-client-common_190ubuntu0.1_all.deb ...
+Unpacking postgresql-client-common (190ubuntu0.1) ...
+Selecting previously unselected package postgresql-client-10.
+Preparing to unpack .../088-postgresql-client-10_10.12-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking postgresql-client-10 (10.12-0ubuntu0.18.04.1) ...
+Selecting previously unselected package postgresql-client.
+Preparing to unpack .../089-postgresql-client_10+190ubuntu0.1_all.deb ...
+Unpacking postgresql-client (10+190ubuntu0.1) ...
+Selecting previously unselected package dbconfig-pgsql.
+Preparing to unpack .../090-dbconfig-pgsql_2.0.9_all.deb ...
+Unpacking dbconfig-pgsql (2.0.9) ...
+Selecting previously unselected package bind9.
+Preparing to unpack .../091-bind9_1%3a9.11.3+dfsg-1ubuntu1.12_amd64.deb ...
+Unpacking bind9 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Selecting previously unselected package libjs-angularjs.
+Preparing to unpack .../092-libjs-angularjs_1.5.10-1_all.deb ...
+Unpacking libjs-angularjs (1.5.10-1) ...
+Selecting previously unselected package libecap3:amd64.
+Preparing to unpack .../093-libecap3_1.0.1-3.2_amd64.deb ...
+Unpacking libecap3:amd64 (1.0.1-3.2) ...
+Selecting previously unselected package libltdl7:amd64.
+Preparing to unpack .../094-libltdl7_2.4.6-2_amd64.deb ...
+Unpacking libltdl7:amd64 (2.4.6-2) ...
+Selecting previously unselected package squid-langpack.
+Preparing to unpack .../095-squid-langpack_20170901-1_all.deb ...
+Unpacking squid-langpack (20170901-1) ...
+Selecting previously unselected package squid-common.
+Preparing to unpack .../096-squid-common_3.5.27-1ubuntu1.6_all.deb ...
+Unpacking squid-common (3.5.27-1ubuntu1.6) ...
+Selecting previously unselected package libdbi-perl.
+Preparing to unpack .../097-libdbi-perl_1.640-1_amd64.deb ...
+Unpacking libdbi-perl (1.640-1) ...
+Selecting previously unselected package ssl-cert.
+Preparing to unpack .../098-ssl-cert_1.0.39_all.deb ...
+Unpacking ssl-cert (1.0.39) ...
+Selecting previously unselected package squid.
+Preparing to unpack .../099-squid_3.5.27-1ubuntu1.6_amd64.deb ...
+Unpacking squid (3.5.27-1ubuntu1.6) ...
+Selecting previously unselected package maas-proxy.
+Preparing to unpack .../100-maas-proxy_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-proxy (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package python-django-common.
+Preparing to unpack .../101-python-django-common_1%3a1.11.11-1ubuntu1.9_all.deb ...
+Unpacking python-django-common (1:1.11.11-1ubuntu1.9) ...
+Selecting previously unselected package python3-django.
+Preparing to unpack .../102-python3-django_1%3a1.11.11-1ubuntu1.9_all.deb ...
+Unpacking python3-django (1:1.11.11-1ubuntu1.9) ...
+Selecting previously unselected package python3-convoy.
+Preparing to unpack .../103-python3-convoy_0.2.1+bzr39-1_all.deb ...
+Unpacking python3-convoy (0.2.1+bzr39-1) ...
+Selecting previously unselected package python3-psycopg2.
+Preparing to unpack .../104-python3-psycopg2_2.7.4-1_amd64.deb ...
+Unpacking python3-psycopg2 (2.7.4-1) ...
+Selecting previously unselected package python3-lib2to3.
+Preparing to unpack .../105-python3-lib2to3_3.6.9-1~18.04_all.deb ...
+Unpacking python3-lib2to3 (3.6.9-1~18.04) ...
+Selecting previously unselected package sgml-base.
+Preparing to unpack .../106-sgml-base_1.29_all.deb ...
+Unpacking sgml-base (1.29) ...
+Selecting previously unselected package xml-core.
+Preparing to unpack .../107-xml-core_0.18_all.deb ...
+Unpacking xml-core (0.18) ...
+Selecting previously unselected package docutils-common.
+Preparing to unpack .../108-docutils-common_0.14+dfsg-3_all.deb ...
+Unpacking docutils-common (0.14+dfsg-3) ...
+Selecting previously unselected package python3-roman.
+Preparing to unpack .../109-python3-roman_2.0.0-3_all.deb ...
+Unpacking python3-roman (2.0.0-3) ...
+Selecting previously unselected package python3-docutils.
+Preparing to unpack .../110-python3-docutils_0.14+dfsg-3_all.deb ...
+Unpacking python3-docutils (0.14+dfsg-3) ...
+Selecting previously unselected package python3-pygments.
+Preparing to unpack .../111-python3-pygments_2.2.0+dfsg-1_all.deb ...
+Unpacking python3-pygments (2.2.0+dfsg-1) ...
+Selecting previously unselected package python3-alabaster.
+Preparing to unpack .../112-python3-alabaster_0.7.8-1_all.deb ...
+Unpacking python3-alabaster (0.7.8-1) ...
+Selecting previously unselected package python3-imagesize.
+Preparing to unpack .../113-python3-imagesize_0.7.1-1_all.deb ...
+Unpacking python3-imagesize (0.7.1-1) ...
+Selecting previously unselected package libjs-jquery.
+Preparing to unpack .../114-libjs-jquery_3.2.1-1_all.deb ...
+Unpacking libjs-jquery (3.2.1-1) ...
+Selecting previously unselected package libjs-underscore.
+Preparing to unpack .../115-libjs-underscore_1.8.3~dfsg-1_all.deb ...
+Unpacking libjs-underscore (1.8.3~dfsg-1) ...
+Selecting previously unselected package libjs-sphinxdoc.
+Preparing to unpack .../116-libjs-sphinxdoc_1.6.7-1ubuntu1_all.deb ...
+Unpacking libjs-sphinxdoc (1.6.7-1ubuntu1) ...
+Selecting previously unselected package sphinx-common.
+Preparing to unpack .../117-sphinx-common_1.6.7-1ubuntu1_all.deb ...
+Unpacking sphinx-common (1.6.7-1ubuntu1) ...
+Selecting previously unselected package python3-sphinx.
+Preparing to unpack .../118-python3-sphinx_1.6.7-1ubuntu1_all.deb ...
+Unpacking python3-sphinx (1.6.7-1ubuntu1) ...
+Selecting previously unselected package python3-django-maas.
+Preparing to unpack .../119-python3-django-maas_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking python3-django-maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package python3-mimeparse.
+Preparing to unpack .../120-python3-mimeparse_0.1.4-3.1_all.deb ...
+Unpacking python3-mimeparse (0.1.4-3.1) ...
+Selecting previously unselected package python3-django-piston3.
+Preparing to unpack .../121-python3-django-piston3_0.3~rc2-3ubuntu5_amd64.deb ...
+Unpacking python3-django-piston3 (0.3~rc2-3ubuntu5) ...
+Selecting previously unselected package python3-djorm-ext-pgarray.
+Preparing to unpack .../122-python3-djorm-ext-pgarray_1.2-0ubuntu2_all.deb ...
+Unpacking python3-djorm-ext-pgarray (1.2-0ubuntu2) ...
+Selecting previously unselected package python3-petname.
+Preparing to unpack .../123-python3-petname_2.2-0ubuntu1_all.deb ...
+Unpacking python3-petname (2.2-0ubuntu1) ...
+Selecting previously unselected package maas-region-api.
+Preparing to unpack .../124-maas-region-api_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-region-api (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package postgresql-common.
+Preparing to unpack .../125-postgresql-common_190ubuntu0.1_all.deb ...
+Adding 'diversion of /usr/bin/pg_config to /usr/bin/pg_config.libpq-dev by postgresql-common'
+Unpacking postgresql-common (190ubuntu0.1) ...
+Selecting previously unselected package postgresql-10.
+Preparing to unpack .../126-postgresql-10_10.12-0ubuntu0.18.04.1_amd64.deb ...
+Unpacking postgresql-10 (10.12-0ubuntu0.18.04.1) ...
+Selecting previously unselected package postgresql.
+Preparing to unpack .../127-postgresql_10+190ubuntu0.1_all.deb ...
+Unpacking postgresql (10+190ubuntu0.1) ...
+Selecting previously unselected package maas-region-controller.
+Preparing to unpack .../128-maas-region-controller_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-region-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas.
+Preparing to unpack .../129-maas_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package maas-dns.
+Preparing to unpack .../130-maas-dns_2.4.2-7034-g2f5deb8b8-0ubuntu1_all.deb ...
+Unpacking maas-dns (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Selecting previously unselected package python3-mock.
+Preparing to unpack .../131-python3-mock_2.0.0-3_all.deb ...
+Unpacking python3-mock (2.0.0-3) ...
+Selecting previously unselected package python3-nose.
+Preparing to unpack .../132-python3-nose_1.3.7-3_all.deb ...
+Unpacking python3-nose (1.3.7-3) ...
+Selecting previously unselected package python3-distutils.
+Preparing to unpack .../133-python3-distutils_3.6.9-1~18.04_all.deb ...
+Unpacking python3-distutils (3.6.9-1~18.04) ...
+Selecting previously unselected package python3-setuptools.
+Preparing to unpack .../134-python3-setuptools_39.0.1-2_all.deb ...
+Unpacking python3-setuptools (39.0.1-2) ...
+Selecting previously unselected package libfile-which-perl.
+Preparing to unpack .../135-libfile-which-perl_1.21-1_all.deb ...
+Unpacking libfile-which-perl (1.21-1) ...
+Selecting previously unselected package libfile-homedir-perl.
+Preparing to unpack .../136-libfile-homedir-perl_1.002-1_all.deb ...
+Unpacking libfile-homedir-perl (1.002-1) ...
+Selecting previously unselected package devscripts.
+Preparing to unpack .../137-devscripts_2.17.12ubuntu1.1_amd64.deb ...
+Unpacking devscripts (2.17.12ubuntu1.1) ...
+Selecting previously unselected package libc-dev-bin.
+Preparing to unpack .../138-libc-dev-bin_2.27-3ubuntu1_amd64.deb ...
+Unpacking libc-dev-bin (2.27-3ubuntu1) ...
+Selecting previously unselected package linux-libc-dev:amd64.
+Preparing to unpack .../139-linux-libc-dev_4.15.0-106.107_amd64.deb ...
+Unpacking linux-libc-dev:amd64 (4.15.0-106.107) ...
+Selecting previously unselected package libc6-dev:amd64.
+Preparing to unpack .../140-libc6-dev_2.27-3ubuntu1_amd64.deb ...
+Unpacking libc6-dev:amd64 (2.27-3ubuntu1) ...
+Selecting previously unselected package gcc-7-base:amd64.
+Preparing to unpack .../141-gcc-7-base_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libisl19:amd64.
+Preparing to unpack .../142-libisl19_0.19-1_amd64.deb ...
+Unpacking libisl19:amd64 (0.19-1) ...
+Selecting previously unselected package libmpc3:amd64.
+Preparing to unpack .../143-libmpc3_1.1.0-1_amd64.deb ...
+Unpacking libmpc3:amd64 (1.1.0-1) ...
+Selecting previously unselected package cpp-7.
+Preparing to unpack .../144-cpp-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package cpp.
+Preparing to unpack .../145-cpp_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking cpp (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libcc1-0:amd64.
+Preparing to unpack .../146-libcc1-0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgomp1:amd64.
+Preparing to unpack .../147-libgomp1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libitm1:amd64.
+Preparing to unpack .../148-libitm1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libatomic1:amd64.
+Preparing to unpack .../149-libatomic1_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libasan4:amd64.
+Preparing to unpack .../150-libasan4_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package liblsan0:amd64.
+Preparing to unpack .../151-liblsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libtsan0:amd64.
+Preparing to unpack .../152-libtsan0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libubsan0:amd64.
+Preparing to unpack .../153-libubsan0_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libcilkrts5:amd64.
+Preparing to unpack .../154-libcilkrts5_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package libmpx2:amd64.
+Preparing to unpack .../155-libmpx2_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libquadmath0:amd64.
+Preparing to unpack .../156-libquadmath0_8.4.0-1ubuntu1~18.04_amd64.deb ...
+Unpacking libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Selecting previously unselected package libgcc-7-dev:amd64.
+Preparing to unpack .../157-libgcc-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc-7.
+Preparing to unpack .../158-gcc-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package gcc.
+Preparing to unpack .../159-gcc_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking gcc (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package libstdc++-7-dev:amd64.
+Preparing to unpack .../160-libstdc++-7-dev_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++-7.
+Preparing to unpack .../161-g++-7_7.5.0-3ubuntu1~18.04_amd64.deb ...
+Unpacking g++-7 (7.5.0-3ubuntu1~18.04) ...
+Selecting previously unselected package g++.
+Preparing to unpack .../162-g++_4%3a7.4.0-1ubuntu2.3_amd64.deb ...
+Unpacking g++ (4:7.4.0-1ubuntu2.3) ...
+Selecting previously unselected package build-essential.
+Preparing to unpack .../163-build-essential_12.4ubuntu1_amd64.deb ...
+Unpacking build-essential (12.4ubuntu1) ...
+Selecting previously unselected package python3-pycodestyle.
+Preparing to unpack .../164-python3-pycodestyle_2.3.1-2_all.deb ...
+Unpacking python3-pycodestyle (2.3.1-2) ...
+Selecting previously unselected package pycodestyle.
+Preparing to unpack .../165-pycodestyle_2.3.1-2_all.deb ...
+Unpacking pycodestyle (2.3.1-2) ...
+Selecting previously unselected package pep8.
+Preparing to unpack .../166-pep8_1.7.1-1ubuntu1_all.deb ...
+Unpacking pep8 (1.7.1-1ubuntu1) ...
+Selecting previously unselected package libpython2.7-minimal:amd64.
+Preparing to unpack .../167-libpython2.7-minimal_2.7.17-1~18.04ubuntu1_amd64.deb ...
+Unpacking libpython2.7-minimal:amd64 (2.7.17-1~18.04ubuntu1) ...
+Selecting previously unselected package python2.7-minimal.
+Preparing to unpack .../168-python2.7-minimal_2.7.17-1~18.04ubuntu1_amd64.deb ...
+Unpacking python2.7-minimal (2.7.17-1~18.04ubuntu1) ...
+Selecting previously unselected package python-minimal.
+Preparing to unpack .../169-python-minimal_2.7.15~rc1-1_amd64.deb ...
+Unpacking python-minimal (2.7.15~rc1-1) ...
+Selecting previously unselected package libpython2.7-stdlib:amd64.
+Preparing to unpack .../170-libpython2.7-stdlib_2.7.17-1~18.04ubuntu1_amd64.deb ...
+Unpacking libpython2.7-stdlib:amd64 (2.7.17-1~18.04ubuntu1) ...
+Selecting previously unselected package python2.7.
+Preparing to unpack .../171-python2.7_2.7.17-1~18.04ubuntu1_amd64.deb ...
+Unpacking python2.7 (2.7.17-1~18.04ubuntu1) ...
+Selecting previously unselected package libpython-stdlib:amd64.
+Preparing to unpack .../172-libpython-stdlib_2.7.15~rc1-1_amd64.deb ...
+Unpacking libpython-stdlib:amd64 (2.7.15~rc1-1) ...
+Setting up libpython2.7-minimal:amd64 (2.7.17-1~18.04ubuntu1) ...
+Setting up python2.7-minimal (2.7.17-1~18.04ubuntu1) ...
+Setting up python-minimal (2.7.15~rc1-1) ...
+Selecting previously unselected package python.
+(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 152471 files and directories currently installed.)
+Preparing to unpack .../00-python_2.7.15~rc1-1_amd64.deb ...
+Unpacking python (2.7.15~rc1-1) ...
+Selecting previously unselected package python-pkg-resources.
+Preparing to unpack .../01-python-pkg-resources_39.0.1-2_all.deb ...
+Unpacking python-pkg-resources (39.0.1-2) ...
+Selecting previously unselected package python-pyflakes.
+Preparing to unpack .../02-python-pyflakes_1.6.0-1_all.deb ...
+Unpacking python-pyflakes (1.6.0-1) ...
+Selecting previously unselected package pyflakes.
+Preparing to unpack .../03-pyflakes_1.6.0-1_all.deb ...
+Unpacking pyflakes (1.6.0-1) ...
+Selecting previously unselected package libfakeroot:amd64.
+Preparing to unpack .../04-libfakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking libfakeroot:amd64 (1.22-2ubuntu1) ...
+Selecting previously unselected package fakeroot.
+Preparing to unpack .../05-fakeroot_1.22-2ubuntu1_amd64.deb ...
+Unpacking fakeroot (1.22-2ubuntu1) ...
+Selecting previously unselected package autotools-dev.
+Preparing to unpack .../06-autotools-dev_20180224.1_all.deb ...
+Unpacking autotools-dev (20180224.1) ...
+Selecting previously unselected package m4.
+Preparing to unpack .../07-m4_1.4.18-1_amd64.deb ...
+Unpacking m4 (1.4.18-1) ...
+Selecting previously unselected package autoconf.
+Preparing to unpack .../08-autoconf_2.69-11_all.deb ...
+Unpacking autoconf (2.69-11) ...
+Selecting previously unselected package automake.
+Preparing to unpack .../09-automake_1%3a1.15.1-3ubuntu2_all.deb ...
+Unpacking automake (1:1.15.1-3ubuntu2) ...
+Selecting previously unselected package autopoint.
+Preparing to unpack .../10-autopoint_0.19.8.1-6ubuntu0.3_all.deb ...
+Unpacking autopoint (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package libtool.
+Preparing to unpack .../11-libtool_2.4.6-2_all.deb ...
+Unpacking libtool (2.4.6-2) ...
+Selecting previously unselected package dh-autoreconf.
+Preparing to unpack .../12-dh-autoreconf_17_all.deb ...
+Unpacking dh-autoreconf (17) ...
+Selecting previously unselected package libarchive-zip-perl.
+Preparing to unpack .../13-libarchive-zip-perl_1.60-1ubuntu0.1_all.deb ...
+Unpacking libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Selecting previously unselected package libfile-stripnondeterminism-perl.
+Preparing to unpack .../14-libfile-stripnondeterminism-perl_0.040-1.1~build1_all.deb ...
+Unpacking libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Selecting previously unselected package libtimedate-perl.
+Preparing to unpack .../15-libtimedate-perl_2.3000-2_all.deb ...
+Unpacking libtimedate-perl (2.3000-2) ...
+Selecting previously unselected package dh-strip-nondeterminism.
+Preparing to unpack .../16-dh-strip-nondeterminism_0.040-1.1~build1_all.deb ...
+Unpacking dh-strip-nondeterminism (0.040-1.1~build1) ...
+Selecting previously unselected package libcroco3:amd64.
+Preparing to unpack .../17-libcroco3_0.6.12-2_amd64.deb ...
+Unpacking libcroco3:amd64 (0.6.12-2) ...
+Selecting previously unselected package gettext.
+Preparing to unpack .../18-gettext_0.19.8.1-6ubuntu0.3_amd64.deb ...
+Unpacking gettext (0.19.8.1-6ubuntu0.3) ...
+Selecting previously unselected package intltool-debian.
+Preparing to unpack .../19-intltool-debian_0.35.0+20060710.4_all.deb ...
+Unpacking intltool-debian (0.35.0+20060710.4) ...
+Selecting previously unselected package po-debconf.
+Preparing to unpack .../20-po-debconf_1.0.20_all.deb ...
+Unpacking po-debconf (1.0.20) ...
+Selecting previously unselected package debhelper.
+Preparing to unpack .../21-debhelper_11.1.6ubuntu2_all.deb ...
+Unpacking debhelper (11.1.6ubuntu2) ...
+Selecting previously unselected package python3-extras.
+Preparing to unpack .../22-python3-extras_1.0.0-3_all.deb ...
+Unpacking python3-extras (1.0.0-3) ...
+Selecting previously unselected package python3-fixtures.
+Preparing to unpack .../23-python3-fixtures_3.0.0-2_all.deb ...
+Unpacking python3-fixtures (3.0.0-2) ...
+Selecting previously unselected package python3-linecache2.
+Preparing to unpack .../24-python3-linecache2_1.0.0-3_all.deb ...
+Unpacking python3-linecache2 (1.0.0-3) ...
+Selecting previously unselected package python3-traceback2.
+Preparing to unpack .../25-python3-traceback2_1.4.0-5_all.deb ...
+Unpacking python3-traceback2 (1.4.0-5) ...
+Selecting previously unselected package python3-unittest2.
+Preparing to unpack .../26-python3-unittest2_1.1.0-6.1_all.deb ...
+Unpacking python3-unittest2 (1.1.0-6.1) ...
+Selecting previously unselected package python3-testtools.
+Preparing to unpack .../27-python3-testtools_2.3.0-3ubuntu2_all.deb ...
+Unpacking python3-testtools (2.3.0-3ubuntu2) ...
+Setting up libquadmath0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libgomp1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libjs-jquery (3.2.1-1) ...
+Setting up distro-info (0.18ubuntu0.18.04.1) ...
+Setting up libatomic1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-incremental (16.10.1-3) ...
+Setting up python3-dnspython (1.15.0-1) ...
+Setting up python3-pbr (3.1.1-3ubuntu3) ...
+update-alternatives: using /usr/bin/python3-pbr to provide /usr/bin/pbr (pbr) in auto mode
+Setting up python3-distro-info (0.18ubuntu0.18.04.1) ...
+Setting up python3-linecache2 (1.0.0-3) ...
+Setting up libdaemon0:amd64 (0.14-6) ...
+Setting up libcc1-0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-roman (2.0.0-3) ...
+Setting up python3-imagesize (0.7.1-1) ...
+Setting up libarchive-zip-perl (1.60-1ubuntu0.1) ...
+Setting up libjs-underscore (1.8.3~dfsg-1) ...
+Setting up ieee-data (20180204.1) ...
+Setting up libfile-which-perl (1.21-1) ...
+Setting up python3-pyvmomi (6.5.0.2017.5-0ubuntu1) ...
+Setting up python3-mock (2.0.0-3) ...
+Setting up libtimedate-perl (2.3000-2) ...
+Setting up python3-twisted-bin:amd64 (17.9.0-2ubuntu0.1) ...
+Setting up libuv1:amd64 (1.18.0-3) ...
+Setting up python3-tempita (0.5.2-2) ...
+Setting up libcurl3-gnutls:amd64 (7.58.0-2ubuntu3.8) ...
+Setting up libfile-homedir-perl (1.002-1) ...
+Setting up python3-constantly (15.1.0-1) ...
+Setting up libtsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-alabaster (0.7.8-1) ...
+Setting up python3-iso8601 (0.1.11-1) ...
+Setting up libdebian-installer4:amd64 (0.110ubuntu2) ...
+Setting up python3-simplejson (3.13.2-1) ...
+Setting up archdetect-deb (1.117ubuntu6.18.04.1) ...
+Setting up python3-oauth (1.0.1-5) ...
+Setting up linux-libc-dev:amd64 (4.15.0-106.107) ...
+Setting up pxelinux (3:6.03+dfsg1-2) ...
+Setting up libisccfg-export160 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up python3-pyparsing (2.2.0+dfsg1-2) ...
+Setting up formencode-i18n (1.3.0-0ubuntu5) ...
+Setting up libjs-sphinxdoc (1.6.7-1ubuntu1) ...
+Setting up ssl-cert (1.0.39) ...
+Setting up python3-extras (1.0.0-3) ...
+Setting up devscripts (2.17.12ubuntu1.1) ...
+Setting up libecap3:amd64 (1.0.1-3.2) ...
+Setting up python3-petname (2.2-0ubuntu1) ...
+Setting up python3-zope.interface (4.3.2-1build2) ...
+Setting up m4 (1.4.18-1) ...
+Setting up sgml-base (1.29) ...
+Setting up syslinux-common (3:6.03+dfsg1-2) ...
+Setting up libnspr4:amd64 (2:4.18-1ubuntu1) ...
+Setting up python3-simplestreams (0.1.0~bzr460-0ubuntu1.1) ...
+Setting up python3-djorm-ext-pgarray (1.2-0ubuntu2) ...
+Setting up python3-traceback2 (1.4.0-5) ...
+Setting up liblsan0:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libcroco3:amd64 (0.6.12-2) ...
+Setting up libjs-angularjs (1.5.10-1) ...
+Setting up python3-convoy (0.2.1+bzr39-1) ...
+Setting up libxslt1.1:amd64 (1.1.29-5ubuntu0.2) ...
+Setting up libprotobuf10:amd64 (3.0.0-9.1ubuntu1) ...
+Setting up gcc-7-base:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-prettytable (0.7.2-3) ...
+Setting up libsodium23:amd64 (1.0.16-2) ...
+Setting up libyajl2:amd64 (2.1.0-2build1) ...
+Setting up libmpx2:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up python3-pyasn1 (0.4.2-3) ...
+Setting up authbind (2.1.2) ...
+Setting up python3-protobuf (3.0.0-9.1ubuntu1) ...
+Setting up python3-pycodestyle (2.3.1-2) ...
+Setting up libpq5:amd64 (10.12-0ubuntu0.18.04.1) ...
+Setting up autotools-dev (20180224.1) ...
+Setting up python3-nose (1.3.7-3) ...
+Setting up python3-unittest2 (1.1.0-6.1) ...
+update-alternatives: using /usr/bin/python3-unit2 to provide /usr/bin/unit2 (unit2) in auto mode
+Setting up postgresql-client-common (190ubuntu0.1) ...
+Setting up libfakeroot:amd64 (1.22-2ubuntu1) ...
+Setting up python-babel-localedata (2.4.0+dfsg.1-2ubuntu1) ...
+Setting up libltdl7:amd64 (2.4.6-2) ...
+Setting up postgresql-common (190ubuntu0.1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Adding user postgres to group ssl-cert
+
+Creating config file /etc/postgresql-common/createcluster.conf with new version
+Building PostgreSQL dictionaries from installed myspell/hunspell packages...
+Removing obsolete dictionary files:
+Created symlink /etc/systemd/system/multi-user.target.wants/postgresql.service â /lib/systemd/system/postgresql.service.
+Setting up squid-langpack (20170901-1) ...
+Setting up sphinx-common (1.6.7-1ubuntu1) ...
+Setting up python3-pyasn1-modules (0.2.1-0.2) ...
+Setting up python3-nacl (1.1.2-1build1) ...
+Setting up squid-common (3.5.27-1ubuntu1.6) ...
+Setting up python3-attr (17.4.0-2) ...
+Setting up python3-mimeparse (0.1.4-3.1) ...
+Setting up libmpc3:amd64 (1.1.0-1) ...
+Setting up python3-ply (3.11-1) ...
+Setting up libirs-export160 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up libc-dev-bin (2.27-3ubuntu1) ...
+Setting up freeipmi-common (1.4.11-1.1ubuntu4.1) ...
+Setting up python3-service-identity (16.0.0-2) ...
+Setting up libfreeipmi16 (1.4.11-1.1ubuntu4.1) ...
+Setting up xml-core (0.18) ...
+Setting up isc-dhcp-server (4.3.5-3ubuntu7.1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Generating /etc/default/isc-dhcp-server...
+Created symlink /etc/systemd/system/multi-user.target.wants/isc-dhcp-server.service â /lib/systemd/system/isc-dhcp-server.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/isc-dhcp-server6.service â /lib/systemd/system/isc-dhcp-server6.service.
+Setting up curtin-common (19.3-26-g82f23e3d-0ubuntu1~18.04.1) ...
+Setting up python3-lib2to3 (3.6.9-1~18.04) ...
+Setting up python3-hyperlink (17.3.1-2) ...
+Setting up python-django-common (1:1.11.11-1ubuntu1.9) ...
+Setting up python3-netaddr (0.7.19-1) ...
+Setting up python3-automat (0.6.0-1) ...
+Setting up dbconfig-common (2.0.9) ...
+
+Creating config file /etc/dbconfig-common/config with new version
+Setting up libc6-dev:amd64 (2.27-3ubuntu1) ...
+Setting up python3-ptyprocess (0.5.2-1) ...
+Setting up python3-curtin (19.3-26-g82f23e3d-0ubuntu1~18.04.1) ...
+Setting up python3-tz (2018.3-2) ...
+Setting up python3-distutils (3.6.9-1~18.04) ...
+Setting up libdbi-perl (1.640-1) ...
+Setting up libitm1:amd64 (8.4.0-1ubuntu1~18.04) ...
+Setting up libpython2.7-stdlib:amd64 (2.7.17-1~18.04ubuntu1) ...
+Setting up autopoint (0.19.8.1-6ubuntu0.3) ...
+Setting up python3-bson (3.6.1+dfsg1-1) ...
+Setting up libipmiconsole2 (1.4.11-1.1ubuntu4.1) ...
+Setting up libavahi-common-data:amd64 (0.7-3.1ubuntu1.2) ...
+Setting up postgresql-client-10 (10.12-0ubuntu0.18.04.1) ...
+update-alternatives: using /usr/share/postgresql/10/man/man1/psql.1.gz to provide /usr/share/man/man1/psql.1.gz (psql.1.gz) in auto mode
+Setting up libfile-stripnondeterminism-perl (0.040-1.1~build1) ...
+Setting up libisl19:amd64 (0.19-1) ...
+Setting up python3-pygments (2.2.0+dfsg-1) ...
+Setting up bind9utils (1:9.11.3+dfsg-1ubuntu1.12) ...
+Setting up python3-formencode (1.3.0-0ubuntu5) ...
+Setting up postgresql-client (10+190ubuntu0.1) ...
+Setting up python3-paramiko (2.0.0-1ubuntu1.2) ...
+Setting up libipmidetect0 (1.4.11-1.1ubuntu4.1) ...
+Setting up python3-uvloop (0.8.1+ds1-1ubuntu0.1) ...
+Setting up pycodestyle (2.3.1-2) ...
+Setting up python3-rfc3339 (1.0-4) ...
+Setting up libasan4:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-lxml:amd64 (4.2.1-1ubuntu0.1) ...
+Setting up maas-dhcp (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-dhcpd.service â /lib/systemd/system/maas-dhcpd.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-dhcpd6.service â /lib/systemd/system/maas-dhcpd6.service.
+Setting up gettext (0.19.8.1-6ubuntu0.3) ...
+Setting up libcilkrts5:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up squid (3.5.27-1ubuntu1.6) ...
+Setcap worked! /usr/lib/squid/pinger is not suid!
+Skipping profile in /etc/apparmor.d/disable: usr.sbin.squid
+Setting up libubsan0:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up bind9 (1:9.11.3+dfsg-1ubuntu1.12) ...
+Adding group `bind' (GID 117) ...
+Done.
+Adding system user `bind' (UID 111) ...
+Adding new user `bind' (UID 111) with group `bind' ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Not creating home directory `/var/cache/bind'.
+wrote key file "/etc/bind/rndc.key"
+Created symlink /etc/systemd/system/multi-user.target.wants/bind9.service â /lib/systemd/system/bind9.service.
+bind9-pkcs11.service is a disabled or a static unit, not starting it.
+bind9-resolvconf.service is a disabled or a static unit, not starting it.
+Setting up python2.7 (2.7.17-1~18.04ubuntu1) ...
+Setting up python3-pymacaroons (0.13.0-1) ...
+Setting up libnss3:amd64 (2:3.35-2ubuntu2.7) ...
+Setting up pep8 (1.7.1-1ubuntu1) ...
+Setting up python3-django (1:1.11.11-1ubuntu1.9) ...
+Setting up autoconf (2.69-11) ...
+Setting up postgresql-10 (10.12-0ubuntu0.18.04.1) ...
+Creating new PostgreSQL cluster 10/main ...
+/usr/lib/postgresql/10/bin/initdb -D /var/lib/postgresql/10/main --auth-local peer --auth-host md5
+The files belonging to this database system will be owned by user "postgres".
+This user must also own the server process.
+
+The database cluster will be initialized with locale "en_US.UTF-8".
+The default database encoding has accordingly been set to "UTF8".
+The default text search configuration will be set to "english".
+
+Data page checksums are disabled.
+
+fixing permissions on existing directory /var/lib/postgresql/10/main ... ok
+creating subdirectories ... ok
+selecting default max_connections ... 100
+selecting default shared_buffers ... 128MB
+selecting default timezone ... Etc/UTC
+selecting dynamic shared memory implementation ... posix
+creating configuration files ... ok
+running bootstrap script ... ok
+performing post-bootstrap initialization ... ok
+syncing data to disk ... ok
+
+Success. You can now start the database server using:
+
+    /usr/lib/postgresql/10/bin/pg_ctl -D /var/lib/postgresql/10/main -l logfile start
+
+Ver Cluster Port Status Owner    Data directory              Log file
+[31m10  main    5432 down   postgres /var/lib/postgresql/10/main /var/log/postgresql/postgresql-10-main.log[0m
+update-alternatives: using /usr/share/postgresql/10/man/man1/postmaster.1.gz to provide /usr/share/man/man1/postmaster.1.gz (postmaster.1.gz) in auto mode
+Setting up fakeroot (1.22-2ubuntu1) ...
+update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
+Setting up libgcc-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up cpp-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-babel (2.4.0+dfsg.1-2ubuntu1) ...
+update-alternatives: using /usr/bin/pybabel-python3 to provide /usr/bin/pybabel (pybabel) in auto mode
+Setting up libstdc++-7-dev:amd64 (7.5.0-3ubuntu1~18.04) ...
+Setting up libpython-stdlib:amd64 (2.7.15~rc1-1) ...
+Setting up python3-macaroonbakery (1.1.3-1) ...
+Setting up intltool-debian (0.35.0+20060710.4) ...
+Setting up python3-psycopg2 (2.7.4-1) ...
+Setting up freeipmi-tools (1.4.11-1.1ubuntu4.1) ...
+Setting up python3-pexpect (4.2.1-1) ...
+Setting up postgresql (10+190ubuntu0.1) ...
+Setting up automake (1:1.15.1-3ubuntu2) ...
+update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
+Setting up python3-seamicroclient (0.4.0-1ubuntu1) ...
+Setting up libavahi-common3:amd64 (0.7-3.1ubuntu1.2) ...
+Setting up python3-twisted (17.9.0-2ubuntu0.1) ...
+Setting up python3-setuptools (39.0.1-2) ...
+Setting up dbconfig-pgsql (2.0.9) ...
+Setting up python3-django-piston3 (0.3~rc2-3ubuntu5) ...
+Setting up python (2.7.15~rc1-1) ...
+Setting up libavahi-core7:amd64 (0.7-3.1ubuntu1.2) ...
+Setting up python3-txtftp (0.1~bzr47-0ubuntu2) ...
+Setting up cpp (4:7.4.0-1ubuntu2.3) ...
+Setting up maas-proxy (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-proxy.service â /lib/systemd/system/maas-proxy.service.
+Setting up python3-maas-client (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up po-debconf (1.0.20) ...
+Setting up gcc-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up chrony (3.2-4ubuntu4.4) ...
+Creating '_chrony' system user/group for the chronyd daemonâ¦
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+
+Creating config file /etc/chrony/chrony.conf with new version
+
+Creating config file /etc/chrony/chrony.keys with new version
+Created symlink /etc/systemd/system/chronyd.service â /lib/systemd/system/chrony.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/chrony.service â /lib/systemd/system/chrony.service.
+Setting up g++-7 (7.5.0-3ubuntu1~18.04) ...
+Setting up python3-crochet (1.4.0-0ubuntu2) ...
+Setting up gcc (4:7.4.0-1ubuntu2.3) ...
+Setting up python3-maas-provisioningserver (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up python-pkg-resources (39.0.1-2) ...
+Setting up avahi-daemon (0.7-3.1ubuntu1.2) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Created symlink /etc/systemd/system/dbus-org.freedesktop.Avahi.service â /lib/systemd/system/avahi-daemon.service.
+Created symlink /etc/systemd/system/multi-user.target.wants/avahi-daemon.service â /lib/systemd/system/avahi-daemon.service.
+Created symlink /etc/systemd/system/sockets.target.wants/avahi-daemon.socket â /lib/systemd/system/avahi-daemon.socket.
+Setting up maas-cli (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up python-pyflakes (1.6.0-1) ...
+Setting up g++ (4:7.4.0-1ubuntu2.3) ...
+update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
+Setting up libavahi-client3:amd64 (0.7-3.1ubuntu1.2) ...
+Setting up libtool (2.4.6-2) ...
+Setting up build-essential (12.4ubuntu1) ...
+Setting up libvirt0:amd64 (4.0.0-1ubuntu8.17) ...
+Setting up pyflakes (1.6.0-1) ...
+Setting up avahi-utils (0.7-3.1ubuntu1.2) ...
+Setting up libvirt-clients (4.0.0-1ubuntu8.17) ...
+Setting up maas-common (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+adduser: Warning: The home directory `/var/lib/maas' does not belong to the user you are currently creating.
+Setting up maas-rack-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-rackd.service â /lib/systemd/system/maas-rackd.service.
+Setting up python3-fixtures (3.0.0-2) ...
+Setting up dh-autoreconf (17) ...
+Setting up python3-testtools (2.3.0-3ubuntu2) ...
+Setting up dh-strip-nondeterminism (0.040-1.1~build1) ...
+Setting up debhelper (11.1.6ubuntu2) ...
+Processing triggers for ufw (0.36-0ubuntu0.18.04.1) ...
+Processing triggers for mime-support (3.60ubuntu1) ...
+Processing triggers for install-info (6.5.0.dfsg.1-2) ...
+Processing triggers for libc-bin (2.27-3ubuntu1) ...
+Processing triggers for systemd (237-3ubuntu10.41) ...
+Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
+Processing triggers for shared-mime-info (1.9-2) ...
+Processing triggers for dbus (1.12.2-1ubuntu1.1) ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+Processing triggers for sgml-base (1.29) ...
+Setting up docutils-common (0.14+dfsg-3) ...
+Processing triggers for sgml-base (1.29) ...
+Setting up python3-docutils (0.14+dfsg-3) ...
+update-alternatives: using /usr/share/docutils/scripts/python3/rst-buildhtml to provide /usr/bin/rst-buildhtml (rst-buildhtml) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2html to provide /usr/bin/rst2html (rst2html) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2html4 to provide /usr/bin/rst2html4 (rst2html4) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2html5 to provide /usr/bin/rst2html5 (rst2html5) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2latex to provide /usr/bin/rst2latex (rst2latex) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2man to provide /usr/bin/rst2man (rst2man) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2odt to provide /usr/bin/rst2odt (rst2odt) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2odt_prepstyles to provide /usr/bin/rst2odt_prepstyles (rst2odt_prepstyles) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2pseudoxml to provide /usr/bin/rst2pseudoxml (rst2pseudoxml) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2s5 to provide /usr/bin/rst2s5 (rst2s5) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2xetex to provide /usr/bin/rst2xetex (rst2xetex) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rst2xml to provide /usr/bin/rst2xml (rst2xml) in auto mode
+update-alternatives: using /usr/share/docutils/scripts/python3/rstpep2html to provide /usr/bin/rstpep2html (rstpep2html) in auto mode
+Setting up python3-sphinx (1.6.7-1ubuntu1) ...
+Setting up python3-django-maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up maas-region-api (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Created symlink /etc/systemd/system/multi-user.target.wants/maas-regiond.service â /lib/systemd/system/maas-regiond.service.
+Setting up maas-dns (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up maas-region-controller (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+dbconfig-common: writing config to /etc/dbconfig-common/maas-region-controller.conf
+
+Creating config file /etc/dbconfig-common/maas-region-controller.conf with new version
+creating postgres user maas:  success.
+verifying creation of user: success.
+creating database maasdb: success.
+verifying database maasdb exists: success.
+dbconfig-common: flushing administrative password
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+[36;1mOperations to perform:[0m
+[1m  Apply all migrations: [0mauth, contenttypes, maasserver, metadataserver, piston3, sessions, sites
+[36;1mRunning migrations:[0m
+  Applying contenttypes.0001_initial...[32;1m OK[0m
+  Applying auth.0001_initial...[32;1m OK[0m
+  Applying auth.0002_auto_20151119_1629...[32;1m OK[0m
+  Applying auth.0003_django_1_11_update...[32;1m OK[0m
+  Applying auth.0004_user_email_allow_null...[32;1m OK[0m
+  Applying contenttypes.0002_remove_content_type_name...[32;1m OK[0m
+  Applying piston3.0001_initial...[32;1m OK[0m
+  Applying maasserver.0001_initial...[32;1m OK[0m
+  Applying metadataserver.0001_initial...[32;1m OK[0m
+  Applying maasserver.0002_remove_candidate_name_model...[32;1m OK[0m
+  Applying maasserver.0003_add_node_type_to_node...[32;1m OK[0m
+  Applying maasserver.0004_migrate_installable_to_node_type...[32;1m OK[0m
+  Applying maasserver.0005_delete_installable_from_node...[32;1m OK[0m
+  Applying maasserver.0006_add_lease_time_to_staticipaddress...[32;1m OK[0m
+  Applying maasserver.0007_create_node_proxy_models...[32;1m OK[0m
+  Applying maasserver.0008_use_new_arrayfield...[32;1m OK[0m
+  Applying maasserver.0009_remove_routers_field_from_node...[32;1m OK[0m
+  Applying maasserver.0010_add_dns_models...[32;1m OK[0m
+  Applying maasserver.0011_domain_data...[32;1m OK[0m
+  Applying maasserver.0012_drop_dns_fields...[32;1m OK[0m
+  Applying maasserver.0013_remove_boot_type_from_node...[32;1m OK[0m
+  Applying maasserver.0014_add_region_models...[32;1m OK[0m
+  Applying maasserver.0015_add_bmc_model...[32;1m OK[0m
+  Applying maasserver.0016_migrate_power_data_node_to_bmc...[32;1m OK[0m
+  Applying maasserver.0017_remove_node_power_type...[32;1m OK[0m
+  Applying maasserver.0018_add_dnsdata...[32;1m OK[0m
+  Applying maasserver.0019_add_iprange...[32;1m OK[0m
+  Applying maasserver.0020_nodegroup_to_rackcontroller...[32;1m OK[0m
+  Applying maasserver.0021_nodegroupinterface_to_iprange...[32;1m OK[0m
+  Applying maasserver.0022_extract_ip_for_bmcs...[32;1m OK[0m
+  Applying maasserver.0023_add_ttl_field...[32;1m OK[0m
+  Applying maasserver.0024_remove_nodegroupinterface...[32;1m OK[0m
+  Applying maasserver.0025_create_node_system_id_sequence...[32;1m OK[0m
+  Applying maasserver.0026_create_zone_serial_sequence...[32;1m OK[0m
+  Applying maasserver.0027_replace_static_range_with_admin_reserved_ranges...[32;1m OK[0m
+  Applying maasserver.0028_update_default_vlan_on_interface_and_subnet...[32;1m OK[0m
+  Applying maasserver.0029_add_rdns_mode...[32;1m OK[0m
+  Applying maasserver.0030_drop_all_old_funcs...[32;1m OK[0m
+  Applying maasserver.0031_add_region_rack_rpc_conn_model...[32;1m OK[0m
+  Applying maasserver.0032_loosen_vlan...[32;1m OK[0m
+  Applying maasserver.0033_iprange_minor_changes...[32;1m OK[0m
+  Applying maasserver.0034_rename_mount_params_as_mount_options...[32;1m OK[0m
+  Applying maasserver.0035_convert_ether_wake_to_manual_power_type...[32;1m OK[0m
+  Applying maasserver.0036_add_service_model...[32;1m OK[0m
+  Applying maasserver.0037_node_last_image_sync...[32;1m OK[0m
+  Applying maasserver.0038_filesystem_ramfs_tmpfs_support...[32;1m OK[0m
+  Applying maasserver.0039_create_template_and_versionedtextfile_models...[32;1m OK[0m
+  Applying maasserver.0040_fix_id_seq...[32;1m OK[0m
+  Applying maasserver.0041_change_bmc_on_delete_to_set_null...[32;1m OK[0m
+  Applying maasserver.0042_add_routable_rack_controllers_to_bmc...[32;1m OK[0m
+  Applying maasserver.0043_dhcpsnippet...[32;1m OK[0m
+  Applying maasserver.0044_remove_di_bootresourcefiles...[32;1m OK[0m
+  Applying maasserver.0045_add_node_to_filesystem...[32;1m OK[0m
+  Applying maasserver.0046_add_bridge_interface_type...[32;1m OK[0m
+  Applying maasserver.0047_fix_spelling_of_degraded...[32;1m OK[0m
+  Applying maasserver.0048_add_subnet_allow_proxy...[32;1m OK[0m
+  Applying maasserver.0049_add_external_dhcp_present_to_vlan...[32;1m OK[0m
+  Applying maasserver.0050_modify_external_dhcp_on_vlan...[32;1m OK[0m
+  Applying maasserver.0051_space_fabric_unique...[32;1m OK[0m
+  Applying maasserver.0052_add_codename_title_eol_to_bootresourcecache...[32;1m OK[0m
+  Applying maasserver.0053_add_ownerdata_model...[32;1m OK[0m
+  Applying maasserver.0054_controller...[32;1m OK[0m
+  Applying maasserver.0055_dns_publications...[32;1m OK[0m
+  Applying maasserver.0056_zone_serial_ownership...[32;1m OK[0m
+  Applying maasserver.0057_initial_dns_publication...[32;1m OK[0m
+  Applying maasserver.0058_bigger_integer_for_dns_publication_serial...[32;1m OK[0m
+  Applying maasserver.0056_add_description_to_fabric_and_space...[32;1m OK[0m
+  Applying maasserver.0057_merge...[32;1m OK[0m
+  Applying maasserver.0059_merge...[32;1m OK[0m
+  Applying maasserver.0060_amt_remove_mac_address...[32;1m OK[0m
+  Applying maasserver.0061_maas_nodegroup_worker_to_maas...[32;1m OK[0m
+  Applying maasserver.0062_fix_bootsource_daily_label...[32;1m OK[0m
+  Applying maasserver.0063_remove_orphaned_bmcs_and_ips...[32;1m OK[0m
+  Applying maasserver.0064_remove_unneeded_event_triggers...[32;1m OK[0m
+  Applying maasserver.0065_larger_osystem_and_distro_series...[32;1m OK[0m
+  Applying maasserver.0066_allow_squashfs...[32;1m OK[0m
+  Applying maasserver.0067_add_size_to_largefile...[32;1m OK[0m
+  Applying maasserver.0068_drop_node_system_id_sequence...[32;1m OK[0m
+  Applying maasserver.0069_add_previous_node_status_to_node...[32;1m OK[0m
+  Applying maasserver.0070_allow_null_vlan_on_interface...[32;1m OK[0m
+  Applying maasserver.0071_ntp_server_to_ntp_servers...[32;1m OK[0m
+  Applying maasserver.0072_packagerepository...[32;1m OK[0m
+  Applying maasserver.0073_migrate_package_repositories...[32;1m OK[0m
+  Applying maasserver.0072_update_status_and_previous_status...[32;1m OK[0m
+  Applying maasserver.0074_merge...[32;1m OK[0m
+  Applying maasserver.0075_modify_packagerepository...[32;1m OK[0m
+  Applying maasserver.0076_interface_discovery_rescue_mode...[32;1m OK[0m
+  Applying maasserver.0077_static_routes...[32;1m OK[0m
+  Applying maasserver.0078_remove_packagerepository_description...[32;1m OK[0m
+  Applying maasserver.0079_add_keysource_model...[32;1m OK[0m
+  Applying maasserver.0080_change_packagerepository_url_type...[32;1m OK[0m
+  Applying maasserver.0081_allow_larger_bootsourcecache_fields...[32;1m OK[0m
+  Applying maasserver.0082_add_kflavor...[32;1m OK[0m
+  Applying maasserver.0083_device_discovery...[32;1m OK[0m
+  Applying maasserver.0084_add_default_user_to_node_model...[32;1m OK[0m
+  Applying maasserver.0085_no_intro_on_upgrade...[32;1m OK[0m
+  Applying maasserver.0086_remove_powerpc_from_ports_arches...[32;1m OK[0m
+  Applying maasserver.0087_add_completed_intro_to_userprofile...[32;1m OK[0m
+  Applying maasserver.0088_remove_node_disable_ipv4...[32;1m OK[0m
+  Applying maasserver.0089_active_discovery...[32;1m OK[0m
+  Applying maasserver.0090_bootloaders...[32;1m OK[0m
+  Applying maasserver.0091_v2_to_v3...[32;1m OK[0m
+  Applying maasserver.0092_rolling...[32;1m OK[0m
+  Applying maasserver.0093_add_rdns_model...[32;1m OK[0m
+  Applying maasserver.0094_add_unmanaged_subnets...[32;1m OK[0m
+  Applying maasserver.0095_vlan_relay_vlan...[32;1m OK[0m
+  Applying maasserver.0096_set_default_vlan_field...[32;1m OK[0m
+  Applying maasserver.0097_node_chassis_storage_hints...[32;1m OK[0m
+  Applying maasserver.0098_add_space_to_vlan...[32;1m OK[0m
+  Applying maasserver.0099_set_default_vlan_field...[32;1m OK[0m
+  Applying maasserver.0100_migrate_spaces_from_subnet_to_vlan...[32;1m OK[0m
+  Applying maasserver.0101_filesystem_btrfs_support...[32;1m OK[0m
+  Applying maasserver.0102_remove_space_from_subnet...[32;1m OK[0m
+  Applying maasserver.0103_notifications...[32;1m OK[0m
+  Applying maasserver.0104_notifications_dismissals...[32;1m OK[0m
+  Applying metadataserver.0002_script_models...[32;1m OK[0m
+  Applying maasserver.0105_add_script_sets_to_node_model...[32;1m OK[0m
+  Applying maasserver.0106_testing_status...[32;1m OK[0m
+  Applying maasserver.0107_chassis_to_pods...[32;1m OK[0m
+  Applying maasserver.0108_generate_bmc_names...[32;1m OK[0m
+  Applying maasserver.0109_bmc_names_unique...[32;1m OK[0m
+  Applying maasserver.0110_notification_category...[32;1m OK[0m
+  Applying maasserver.0111_remove_component_error...[32;1m OK[0m
+  Applying maasserver.0112_update_notification...[32;1m OK[0m
+  Applying maasserver.0113_set_filepath_limit_to_linux_max...[32;1m OK[0m
+  Applying maasserver.0114_node_dynamic_to_creation_type...[32;1m OK[0m
+  Applying maasserver.0115_additional_boot_resource_filetypes...[32;1m OK[0m
+  Applying maasserver.0116_add_disabled_components_for_mirrors...[32;1m OK[0m
+  Applying maasserver.0117_add_iscsi_block_device...[32;1m OK[0m
+  Applying maasserver.0118_add_iscsi_storage_pod...[32;1m OK[0m
+  Applying maasserver.0119_set_default_vlan_field...[32;1m OK[0m
+  Applying maasserver.0120_bootsourcecache_extra...[32;1m OK[0m
+  Applying maasserver.0121_relax_staticipaddress_unique_constraint...[32;1m OK[0m
+  Applying maasserver.0122_make_virtualblockdevice_uuid_editable...[32;1m OK[0m
+  Applying maasserver.0123_make_iprange_comment_default_to_empty_string...[32;1m OK[0m
+  Applying maasserver.0124_staticipaddress_address_family_index...[32;1m OK[0m
+  Applying maasserver.0125_add_switch_model...[32;1m OK[0m
+  Applying maasserver.0126_add_controllerinfo_model...[32;1m OK[0m
+  Applying maasserver.0127_nodemetadata...[32;1m OK[0m
+  Applying maasserver.0128_events_created_index...[32;1m OK[0m
+  Applying maasserver.0129_add_install_rackd_flag...[32;1m OK[0m
+  Applying maasserver.0130_node_locked_flag...[32;1m OK[0m
+  Applying maasserver.0131_update_event_model_for_audit_logs...[32;1m OK[0m
+  Applying maasserver.0132_consistent_model_name_validation...[32;1m OK[0m
+  Applying maasserver.0133_add_resourcepool_model...[32;1m OK[0m
+  Applying maasserver.0134_create_default_resourcepool...[32;1m OK[0m
+  Applying maasserver.0135_add_pool_reference_to_node...[32;1m OK[0m
+  Applying maasserver.0136_add_user_role_models...[32;1m OK[0m
+  Applying maasserver.0137_create_default_roles...[32;1m OK[0m
+  Applying maasserver.0138_add_ip_and_user_agent_to_event_model...[32;1m OK[0m
+  Applying maasserver.0139_add_endpoint_and_increase_user_agent_length_for_event...[32;1m OK[0m
+  Applying maasserver.0140_add_usergroup_model...[32;1m OK[0m
+  Applying maasserver.0141_add_default_usergroup...[32;1m OK[0m
+  Applying maasserver.0142_pod_default_resource_pool...[32;1m OK[0m
+  Applying maasserver.0143_blockdevice_firmware...[32;1m OK[0m
+  Applying maasserver.0144_filesystem_zfsroot_support...[32;1m OK[0m
+  Applying maasserver.0145_interface_firmware...[32;1m OK[0m
+  Applying maasserver.0146_add_rootkey...[32;1m OK[0m
+  Applying maasserver.0147_pod_zones...[32;1m OK[0m
+  Applying maasserver.0148_add_tags_on_pods...[32;1m OK[0m
+  Applying maasserver.0149_userprofile_auth_last_check...[32;1m OK[0m
+  Applying maasserver.0150_add_pod_commit_ratios...[32;1m OK[0m
+  Applying maasserver.0151_userprofile_is_local...[32;1m OK[0m
+  Applying maasserver.0152_add_usergroup_local...[32;1m OK[0m
+  Applying maasserver.0153_add_skip_bmc_config...[32;1m OK[0m
+  Applying maasserver.0154_link_usergroup_role...[32;1m OK[0m
+  Applying maasserver.0155_add_globaldefaults_model...[32;1m OK[0m
+  Applying maasserver.0156_drop_ssh_unique_key_index...[32;1m OK[0m
+  Applying maasserver.0157_drop_usergroup_and_role...[32;1m OK[0m
+  Applying maasserver.0158_pod_default_pool_to_pod...[32;1m OK[0m
+  Applying maasserver.0159_userprofile_auth_last_check_no_now_default...[32;1m OK[0m
+  Applying maasserver.0160_pool_only_for_machines...[32;1m OK[0m
+  Applying metadataserver.0003_remove_noderesult...[32;1m OK[0m
+  Applying metadataserver.0004_aborted_script_status...[32;1m OK[0m
+  Applying metadataserver.0005_store_powerstate_on_scriptset_creation...[32;1m OK[0m
+  Applying metadataserver.0006_scriptresult_combined_output...[32;1m OK[0m
+  Applying metadataserver.0007_migrate-commissioningscripts...[32;1m OK[0m
+  Applying metadataserver.0008_remove-commissioningscripts...[32;1m OK[0m
+  Applying metadataserver.0009_remove_noderesult_schema...[32;1m OK[0m
+  Applying metadataserver.0010_scriptresult_time_and_script_title...[32;1m OK[0m
+  Applying metadataserver.0011_script_metadata...[32;1m OK[0m
+  Applying metadataserver.0012_store_script_results...[32;1m OK[0m
+  Applying metadataserver.0013_scriptresult_physicalblockdevice...[32;1m OK[0m
+  Applying metadataserver.0014_rename_dhcp_unconfigured_ifaces...[32;1m OK[0m
+  Applying metadataserver.0015_migrate_storage_tests...[32;1m OK[0m
+  Applying metadataserver.0016_script_model_fw_update_and_hw_config...[32;1m OK[0m
+  Applying metadataserver.0017_store_requested_scripts...[32;1m OK[0m
+  Applying metadataserver.0018_script_result_skipped...[32;1m OK[0m
+  Applying piston3.0002_auto_20151209_1652...[32;1m OK[0m
+  Applying sessions.0001_initial...[32;1m OK[0m
+  Applying sites.0001_initial...[32;1m OK[0m
+  Applying sites.0002_alter_domain_unique...[32;1m OK[0m
+ERROR: ld.so: object 'libeatmydata.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+Setting up maas (2.4.2-7034-g2f5deb8b8-0ubuntu1) ...
+Setting up autopkgtest-satdep (0) ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--status', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-get', '--simulate', '--quiet', '-o', 'APT::Get::Show-User-Simulation-Note=False', '--auto-remove', 'purge', 'autopkgtest-satdep'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: Marking test dependencies as manually installed: maas maas-rack-controller maas-region-controller maas-region-api python3-maas-provisioningserver archdetect-deb authbind maas-common avahi-utils avahi-daemon bind9 bind9utils chrony python3-django-maas python3-curtin curtin-common dbconfig-pgsql dbconfig-common dh-autoreconf debhelper dh-strip-nondeterminism devscripts distro-info python3-sphinx python3-docutils docutils-common python3-formencode formencode-i18n freeipmi-tools libipmidetect0 freeipmi-common python3-netaddr ieee-data maas-dhcp isc-dhcp-server libfile-stripnondeterminism-perl libarchive-zip-perl libvirt-clients libvirt0 libavahi-client3 libavahi-core7 libavahi-common3 libavahi-common-data libcurl3-gnutls libdaemon0 maas-proxy squid libdbi-perl libdebian-installer4 libecap3 libfile-homedir-perl libfile-which-perl libipmiconsole2 libfreeipmi16 libirs-export160 libisccfg-export160 libjs-angularjs sphinx-common libjs-sphinxdoc libjs-jquery libjs-underscore libltdl7 libnss3 libnspr4 maas-cli python3-maas-client python3-macaroonbakery python3-protobuf libprotobuf10 pyflakes python-pyflakes python-pkg-resources python libpython-stdlib python2.7 libpython2.7-stdlib python-minimal python2.7-minimal libpython2.7-minimal python3-pymacaroons python3-nacl libsodium23 libtimedate-perl python3-uvloop libuv1 libyajl2 linux-headers-4.15.0-65-generic linux-headers-4.15.0-65 linux-image-4.15.0-65-generic linux-modules-4.15.0-65-generic maas-dns pep8 postgresql pxelinux pycodestyle python3-seamicroclient python3-babel python-babel-localedata python3-django-piston3 python3-django python-django-common python3-alabaster python3-txtftp python3-crochet python3-twisted python3-automat python3-service-identity python3-attr python3-bson python3-configobj python3-constantly python3-convoy python3-distro-info python3-djorm-ext-pgarray python3-dnspython python3-testtools python3-fixtures python3-extras python3-hyperlink python3-imagesize python3-incremental python3-iso8601 python3-unittest2 python3-traceback2 python3-linecache2 python3-lxml python3-mimeparse python3-mock python3-nose python3-oauth python3-paramiko python3-pbr python3-petname python3-pexpect python3-ply python3-prettytable python3-psycopg2 python3-ptyprocess python3-pyasn1-modules python3-pyasn1 python3-pycodestyle python3-pygments python3-pyparsing python3-pyvmomi python3-rfc3339 python3-roman python3-serial python3-simplejson python3-simplestreams python3-tempita python3-twisted-bin python3-tz python3-zope.interface xml-core sgml-base squid-common squid-langpack syslinux-common
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'maas', 'maas-rack-controller', 'maas-region-controller', 'maas-region-api', 'python3-maas-provisioningserver', 'archdetect-deb', 'authbind', 'maas-common', 'avahi-utils', 'avahi-daemon', 'bind9', 'bind9utils', 'chrony', 'python3-django-maas', 'python3-curtin', 'curtin-common', 'dbconfig-pgsql', 'dbconfig-common', 'dh-autoreconf', 'debhelper'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'dh-strip-nondeterminism', 'devscripts', 'distro-info', 'python3-sphinx', 'python3-docutils', 'docutils-common', 'python3-formencode', 'formencode-i18n', 'freeipmi-tools', 'libipmidetect0', 'freeipmi-common', 'python3-netaddr', 'ieee-data', 'maas-dhcp', 'isc-dhcp-server', 'libfile-stripnondeterminism-perl', 'libarchive-zip-perl', 'libvirt-clients', 'libvirt0', 'libavahi-client3'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'libavahi-core7', 'libavahi-common3', 'libavahi-common-data', 'libcurl3-gnutls', 'libdaemon0', 'maas-proxy', 'squid', 'libdbi-perl', 'libdebian-installer4', 'libecap3', 'libfile-homedir-perl', 'libfile-which-perl', 'libipmiconsole2', 'libfreeipmi16', 'libirs-export160', 'libisccfg-export160', 'libjs-angularjs', 'sphinx-common', 'libjs-sphinxdoc', 'libjs-jquery'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'libjs-underscore', 'libltdl7', 'libnss3', 'libnspr4', 'maas-cli', 'python3-maas-client', 'python3-macaroonbakery', 'python3-protobuf', 'libprotobuf10', 'pyflakes', 'python-pyflakes', 'python-pkg-resources', 'python', 'libpython-stdlib', 'python2.7', 'libpython2.7-stdlib', 'python-minimal', 'python2.7-minimal', 'libpython2.7-minimal', 'python3-pymacaroons'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python3-nacl', 'libsodium23', 'libtimedate-perl', 'python3-uvloop', 'libuv1', 'libyajl2', 'linux-headers-4.15.0-65-generic', 'linux-headers-4.15.0-65', 'linux-image-4.15.0-65-generic', 'linux-modules-4.15.0-65-generic', 'maas-dns', 'pep8', 'postgresql', 'pxelinux', 'pycodestyle', 'python3-seamicroclient', 'python3-babel', 'python-babel-localedata', 'python3-django-piston3', 'python3-django'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python-django-common', 'python3-alabaster', 'python3-txtftp', 'python3-crochet', 'python3-twisted', 'python3-automat', 'python3-service-identity', 'python3-attr', 'python3-bson', 'python3-configobj', 'python3-constantly', 'python3-convoy', 'python3-distro-info', 'python3-djorm-ext-pgarray', 'python3-dnspython', 'python3-testtools', 'python3-fixtures', 'python3-extras', 'python3-hyperlink', 'python3-imagesize'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python3-incremental', 'python3-iso8601', 'python3-unittest2', 'python3-traceback2', 'python3-linecache2', 'python3-lxml', 'python3-mimeparse', 'python3-mock', 'python3-nose', 'python3-oauth', 'python3-paramiko', 'python3-pbr', 'python3-petname', 'python3-pexpect', 'python3-ply', 'python3-prettytable', 'python3-psycopg2', 'python3-ptyprocess', 'python3-pyasn1-modules', 'python3-pyasn1'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['apt-mark', 'manual', '-qq', 'python3-pycodestyle', 'python3-pygments', 'python3-pyparsing', 'python3-pyvmomi', 'python3-rfc3339', 'python3-roman', 'python3-serial', 'python3-simplejson', 'python3-simplestreams', 'python3-tempita', 'python3-twisted-bin', 'python3-tz', 'python3-zope.interface', 'xml-core', 'sgml-base', 'squid-common', 'squid-langpack', 'syslinux-common'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['dpkg', '--purge', 'autopkgtest-satdep'], kind short, sout raw, serr raw, env []
+(Reading database ... 154084 files and directories currently installed.)
+Removing autopkgtest-satdep (0) ...
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', '[ -d /var/cache/apparmor -a -d /var/lib/apparmor/clicks -a ! -e /var/cache/apparmor/click-ap.rules ] && type aa-clickhook >/dev/null 2>&1'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest: DBG: testbed does not have AppArmor/click or already has Autopilot click rules, no need to adjust rules
+autopkgtest: DBG: testbed command ['which', 'dpkg-query'], kind short, sout pipe, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: testbed command ['sh', '-ec', "dpkg-query --show -f '${Package}\\t${Version}\\n' > /tmp/autopkgtest.Ihmrn9/maas-package-test-packages.all"], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-packages.all /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-packages.all
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-packages.all /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-packages.all
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/maas-package-test-packages.all'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-packages.all'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/maas-package-test-packages.all
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['test', '-e', '/tmp/autopkgtest.Ihmrn9/build.7ky/real-tree'], kind short, sout raw, serr raw, env []
+autopkgtest: DBG: testbed command exited with code 1
+autopkgtest: DBG: testbed command ['mkdir', '-p', '/tmp/autopkgtest.Ihmrn9/build.7ky'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: sending command to testbed: copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/
+autopkgtest-virt-qemu: DBG: executing copydown /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/', '--warning=none', '-c', '.', '-f', '-'], ['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'if ! test -d /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; then mkdir -- /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; fi; cd /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/tests-tree/ --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec if ! test -d /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; then mkdir -- /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; fi; cd /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/; tar --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['chown', '-R', 'ubuntu', '--', '/tmp/autopkgtest.Ihmrn9/build.7ky/real-tree'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [03:33:12]: test maas-package-test: [-----------------------
+autopkgtest: DBG: testbed command ['su', '-s', '/bin/bash', 'root', '-c', 'set -e; export USER=`id -nu`; . /etc/profile >/dev/null 2>&1 || true;  . ~/.profile >/dev/null 2>&1 || true; buildtree="/tmp/autopkgtest.Ihmrn9/build.7ky/real-tree"; mkdir -p -m 1777 -- "/tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts"; export AUTOPKGTEST_ARTIFACTS="/tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts"; export ADT_ARTIFACTS="$AUTOPKGTEST_ARTIFACTS"; mkdir -p -m 755 "/tmp/autopkgtest.Ihmrn9/autopkgtest_tmp"; export AUTOPKGTEST_TMP="/tmp/autopkgtest.Ihmrn9/autopkgtest_tmp"; export ADTTMP="$AUTOPKGTEST_TMP"; export DEBIAN_FRONTEND=noninteractive; export LANG=C.UTF-8; export DEB_BUILD_OPTIONS=parallel=1; unset LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE   LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS   LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL;rm -f /tmp/autopkgtest_script_pid; set -C; echo $$ > /tmp/autopkgtest_script_pid; set +C; trap "rm -f /tmp/autopkgtest_script_pid" EXIT INT QUIT PIPE; cd "$buildtree"; export AUTOPKGTEST_NORMAL_USER=ubuntu; export ADT_NORMAL_USER=ubuntu; export \'DEPLOYMENT_RELEASE=bionic\'; export \'TEST_JUJU=\'; export \'TEST_CENTOS=0\'; export \'TEST_RHEL=\'; export \'TEST_WINDOWS=\'; export \'TEST_CUSTOM_IMAGES=1\'; export \'USE_PPC_NODES=0\'; export \'USE_ARM64_NODES=0\'; export \'KEEP_CI_RUNNING=0\'; export \'PAUSE_CI=0\'; export \'TEST_PERFORMANCE=0\'; export \'DEBUG=\'; export \'SLAVE_NODE=HP-DL360-Gen9\'; chmod +x /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/debian/tests/maas-package-test; touch /tmp/autopkgtest.Ihmrn9/maas-package-test-stdout /tmp/autopkgtest.Ihmrn9/maas-package-test-stderr; /tmp/autopkgtest.Ihmrn9/build.7ky/real-tree/debian/tests/maas-package-test 2> >(tee -a /tmp/autopkgtest.Ihmrn9/maas-package-test-stderr >&2) > >(tee -a /tmp/autopkgtest.Ihmrn9/maas-package-test-stdout);'], kind test, sout raw, serr raw, env []
+MAAS ID: fk7t74
+maas-integration.TestMAASIntegration.test_setup_prometheus ... SKIP: Prometheus is only supported on MAAS 2.6+
+maas-integration.TestMAASIntegration.test_create_admin ... ok
+maas-integration.TestMAASIntegration.test_update_maas_url ... ok
+maas-integration.TestMAASIntegration.test_update_maas_url_rack ... ok
+maas-integration.TestMAASIntegration.test_check_initial_services_systemctl ... ok
+maas-integration.TestMAASIntegration.test_check_rpc_info ... ok
+maas-integration.TestMAASIntegration.test_update_preseed_arm ... SKIP: Don't test ARM nodes
+maas-integration.TestMAASIntegration.test_login_api ... ok
+maas-integration.TestMAASIntegration.test_maas_logged_in ... ok
+maas-integration.TestMAASIntegration.test_set_main_archive ... ok
+maas-integration.TestMAASIntegration.test_enable_prometheus_stats ... SKIP: Prometheus is only supported on MAAS 2.6+
+maas-integration.TestMAASIntegration.test_main_archive_in_enlist_userdata_package_mirrors_config ... SKIP: Cloud-init "package_mirror" config is used in MAAS 2.0 and earlier
+maas-integration.TestMAASIntegration.test_main_archive_in_enlist_userdata_apt_config ... ok
+maas-integration.TestMAASIntegration.test_set_http_proxy_and_use_peer_proxy ... ok
+maas-integration.TestMAASIntegration.test_add_ssh_key ... ok
+maas-integration.TestMAASIntegration.test_region_rack_connected ... ok
+maas-integration.TestMAASIntegration.test_stop_image_import ... ok
+maas-integration.TestMAASIntegration.test_set_custom_boot_source ... ok
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_xenial ... ok
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_ppc64el ... SKIP: Not testing PPC systems
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_arm64 ... SKIP: Not testing arm64 systems
+maas-integration.TestMAASIntegration.test_add_boot_source_selection_centos ... SKIP: Not testing CentOS
+maas-integration.TestMAASIntegration.test_start_image_import ... ok
+maas-integration.TestMAASIntegration.test_create_dynamic_range ... ok
+maas-integration.TestMAASIntegration.test_reserve_reserved_range ... ok
+maas-integration.TestMAASIntegration.test_reserve_bmc_range ... ok
+maas-integration.TestMAASIntegration.test_create_slave_device_and_link_subnet ... ok
+maas-integration.TestMAASIntegration.test_slave_device_interface_linked ... ok
+maas-integration.TestMAASIntegration.test_set_up_dhcp_vlan ... ok
+maas-integration.TestMAASIntegration.test_check_dhcp_service_systemctl ... ok
+maas-integration.TestMAASIntegration.test_use_internal_dns_for_proxy_on_managed_dhcp ... SKIP: Internal DNS (for proxy/metadata) is available on 2.5+ only.
+maas-integration.TestMAASIntegration.test_update_dns_config_systemctl ... ok
+maas-integration.TestMAASIntegration.test_add_new_zones ... ok
+maas-integration.TestMAASIntegration.test_list_zones ... ok
+maas-integration.TestMAASIntegration.test_delete_zone ... ok
+maas-integration.TestMAASIntegration.test_add_new_resource_pools ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_list_resource_pools ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_delete_resource_pools ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_add_new_spaces ... ok
+maas-integration.TestMAASIntegration.test_create_subnet ... ok
+maas-integration.TestMAASIntegration.test_list_spaces ... ok
+maas-integration.TestMAASIntegration.test_list_subnets ... ok
+maas-integration.TestMAASIntegration.test_delete_subnet ... ok
+maas-integration.TestMAASIntegration.test_delete_space ... ok
+maas-integration.TestMAASIntegration.test_add_new_fabrics ... ok
+maas-integration.TestMAASIntegration.test_add_vlan_to_fabric ... ok
+maas-integration.TestMAASIntegration.test_list_fabrics ... ok
+maas-integration.TestMAASIntegration.test_list_vlans ... ok
+maas-integration.TestMAASIntegration.test_delete_vlan ... ok
+maas-integration.TestMAASIntegration.test_delete_fabric ... ok
+maas-integration.TestMAASIntegration.test_tag_uefi ... ok
+maas-integration.TestMAASIntegration.test_region_imported_images ... ok
+maas-integration.TestMAASIntegration.test_rack_imported_images ... ok
+maas-integration.TestMAASIntegration.test_add_windows_boot_resource ... SKIP: Not testing Windows
+maas-integration.TestMAASIntegration.test_add_rhel_boot_resource ... SKIP: Not testing RHEL
+maas-integration.TestMAASIntegration.test_poweron_nodes_to_enlist ... ok
+maas-integration.TestMAASIntegration.test_check_machines_new ... qemu-system-x86_64: external icmpv6 not supported yet
+qemu-system-x86_64: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_check_enlisted_machines_commissioned ... SKIP: Commissioning during enlistment only supported in MAAS 2.5+
+maas-integration.TestMAASIntegration.test_assign_machines_to_test_zone ... ok
+maas-integration.TestMAASIntegration.test_assign_machines_to_test_resource_pool ... SKIP: Resource pools feature only available after 2.5
+maas-integration.TestMAASIntegration.test_set_machines_ipmi_config ... ok
+maas-integration.TestMAASIntegration.test_start_commissioning_machines ... ok
+maas-integration.TestMAASIntegration.test_check_nodes_ready ... qemu-system-x86_64: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_read_commissioning_results ... ok
+maas-integration.TestMAASIntegration.test_configure_juju ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_juju_bootstrap ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_apply_tag_to_all_machines ... ok
+maas-integration.TestMAASIntegration.test_check_tag_applied_to_all_machines ... ok
+maas-integration.TestMAASIntegration.test_juju_deploy_postgresql ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_juju_deploy_ubuntu_container ... SKIP: Not testing juju
+maas-integration.TestMAASIntegration.test_allocate_machines ... ok
+maas-integration.TestMAASIntegration.test_deploy_machine_with_centos ... SKIP: Not testing CentOS.
+maas-integration.TestMAASIntegration.test_deploy_machine_with_rhel ... SKIP: Not testing RHEL
+maas-integration.TestMAASIntegration.test_deploy_machine_with_windows ... SKIP: Not testing Windows
+maas-integration.TestMAASIntegration.test_deploy_machines ... ok
+maas-integration.TestMAASIntegration.test_machines_deployed ... qemu-system-x86_64: external icmpv6 not supported yet
+qemu-system-x86_64: external icmpv6 not supported yet
+qemu-system-x86_64: external icmpv6 not supported yet
+qemu-system-x86_64: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_compose_machines_per_pod ... SKIP: Not running test until LP: #1827149 is fixed.
+maas-integration.TestMAASIntegration.test_ip_addresses_not_in_dynamic_range ... ok
+maas-integration.TestMAASIntegration.test_ip_addresses_not_in_bmc_range ... ok
+maas-integration.TestMAASIntegration.test_ip_addresses_exist_as_dhcp_hostmaps ... ok
+maas-integration.TestMAASIntegration.test_ssh_to_machines ... ok
+maas-integration.TestMAASIntegration.test_enter_rescue_mode ... qemu-system-x86_64: external icmpv6 not supported yet
+qemu-system-x86_64: external icmpv6 not supported yet
+ok
+maas-integration.TestMAASIntegration.test_exit_rescue_mode ... ok
+maas-integration.TestMAASIntegration.test_release_machines ... ok
+maas-integration.TestMAASIntegration.test_machines_released_and_ready ... ok
+
+----------------------------------------------------------------------
+XML: /tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts/nosetests.xml
+----------------------------------------------------------------------
+Ran 85 tests in 3230.781s
+
+OK (SKIP=23)
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest [04:27:20]: test maas-package-test: -----------------------]
+autopkgtest: DBG: testbed executing test finished with exit status 0
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-stdout /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stdout
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-stdout /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stdout
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/maas-package-test-stdout'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stdout'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/maas-package-test-stdout
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-stderr /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stderr
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-stderr /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stderr
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cat </tmp/autopkgtest.Ihmrn9/maas-package-test-stderr'], ['cat'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedWriter name='/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/maas-package-test-stderr'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cat </tmp/autopkgtest.Ihmrn9/maas-package-test-stderr
+autopkgtest-virt-qemu: DBG:  +> cat
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest [04:27:21]: test maas-package-test:  - - - - - - - - - - results - - - - - - - - - -
+maas-package-test    PASS
+autopkgtest: DBG: sending command to testbed: copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/
+autopkgtest-virt-qemu: DBG: executing copyup /tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts/ /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/
+autopkgtest-virt-qemu: DBG: ['cmdls', "(['/tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd', 'sh', '-ec', 'cd /tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts/; tar --warning=none -c . -f -'], ['tar', '--directory', '/home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/', '--warning=none', '--preserve-permissions', '--extract', '--no-same-owner', '-f', '-'])"]
+autopkgtest-virt-qemu: DBG: ['srcstdin', "<_io.BufferedReader name='/dev/null'>", 'deststdout', "<_io.BufferedReader name='/dev/null'>", 'devnull_read', <_io.BufferedReader name='/dev/null'>]
+autopkgtest-virt-qemu: DBG:  +< /tmp/autopkgtest-virt-qemu.z3vh4zot/runcmd sh -ec cd /tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts/; tar --warning=none -c . -f -
+autopkgtest-virt-qemu: DBG:  +> tar --directory /home/ubuntu/workspace/SRU-proposed-cloudinit-sru-manual/results/artifacts/ --warning=none --preserve-permissions --extract --no-same-owner -f -
+autopkgtest-virt-qemu: DBG:  +>?
+autopkgtest-virt-qemu: DBG:  +<?
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: testbed command ['rm', '-rf', '/tmp/autopkgtest.Ihmrn9/maas-package-test-artifacts', '/tmp/autopkgtest.Ihmrn9/autopkgtest_tmp'], kind short, sout raw, serr pipe, env []
+autopkgtest: DBG: testbed command exited with code 0
+autopkgtest: DBG: no need to restore click AppArmor profiles
+autopkgtest: DBG: needs_reset, previously=False, requested by run_tests() line 169
+autopkgtest [04:27:24]: @@@@@@@@@@@@@@@@@@@@ summary
+maas-package-test    PASS
+autopkgtest: DBG: testbed stop
+autopkgtest: DBG: testbed close, scratch=/tmp/autopkgtest.Ihmrn9
+autopkgtest: DBG: sending command to testbed: close
+autopkgtest-virt-qemu: DBG: executing close
+autopkgtest-virt-qemu: DBG: cleanup...
+qemu-system-x86_64: terminating on signal 15 from pid 13444 (/usr/bin/python3)
+autopkgtest: DBG: got reply from testbed: ok
+autopkgtest: DBG: sending command to testbed: quit
+autopkgtest-virt-qemu: DBG: executing quit
+autopkgtest-virt-qemu: DBG: cleanup...
++ RET=0
++ '[' 0 -eq 2 ']'
++ exit 0
+Archiving artifacts
+IRC notifier plugin: Sending notification to: #redsquad
+IRC notifier plugin: [ERROR] not connected. Cannot send message to '#redsquad'
+Finished: SUCCESS


### PR DESCRIPTION
Also update ./bin/sru-get-logs to use maas new hostname
maas-integration-ci.internal in order to download
jenkins logs.


The logs were obtained by connecting to the vpn and running:
```
jenkins-get-job --url http://maas-integration-ci.internal:8080 --username $MAAS_JENKINS_USER --password <pwd> SRU-proposed-cloudinit-sru-manual -v -s;
```