### PR TITLE
Add manual test for redacted sensitive keys data

### DIFF
--- a/bugs/lp-1865947.txt
+++ b/bugs/lp-1865947.txt
@@ -1,0 +1,452 @@
+=== Begin SRU Template ===
+[Impact]
+Right now the sensitive_keys marked on instance-data.json are not being redacted. This means that
+are readable by non-root users. We are now redacting those keys and showing them non-redacted on
+instance-data-sensitive.json file, which is a file non-root users cannot read.
+
+[Test Case]
+
+```
+#!/bin/sh
+set -x
+# Manually deploy on a lxc container
+
+verify_redacted_instance() {
+    name=$1
+    series=$2
+
+    expected_output="redacted for non-root user"
+    sensitive_key=$(lxc exec $name -- cat /run/cloud-init/instance-data.json | jq -r [.sensitive_keys[]][0])
+    redacted_key=$(lxc exec $name -- cat /run/cloud-init/instance-data.json | jq -r [.$sensitive_key][])
+
+    if [ "$redacted_key" = "$expected_output" ]; then
+        echo "SUCCESS: $series have sensitive keys redacted in instance-data.json"
+    else
+        echo "FAILURE: $series have sensitive keys redacted in instance-data.json"
+    fi
+
+    expected_output="Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/"
+    sensitive_key=$(lxc exec $name -- cat /run/cloud-init/instance-data-sensitive.json | jq -r [.sensitive_keys[]][0])
+    not_redacted_key=$(lxc exec $name -- cat /run/cloud-init/instance-data-sensitive.json | jq -r [.$sensitive_key[]][0])
+
+    if [ "$not_redacted_key" = "$expected_output" ]; then
+        echo "SUCCESS: $series have sensitive keys not redacted in instance-data-sensitive.json"
+    else
+        echo "FAILURE: $series have sensitive keys redacted in instance-data-sensitive.json"
+    fi
+}
+
+for SERIES in focal; do
+   echo '=== BEGIN ' $SERIES
+   ref=$SERIES-proposed
+   name=test-$SERIES-proposed-bug
+   lxc delete $name --force 2> /dev/null
+   lxc-proposed-snapshot --proposed --upgrade cloud-init --publish $SERIES $ref
+   lxc init $ref $name
+   lxc start $name
+   lxc exec $name -- cloud-init status --wait --long
+
+   # verify_redacted_instance $name $SERIES
+done
+```
+
+[Regression Potential]
+Some users may be using the sensitive_keys data on instance-data.json to perform some validation.
+But since this is fixed, they will need to use instance-data-sensitive.json and get the right
+permissions to a user to read the file, we do not believe this may pose a problem.
+
+
+=== End cloud-init SRU Template ===
+
+=== Verification Log ===
+
++ for SERIES in bionic eoan focal xenial
++ echo '=== BEGIN ' bionic
+=== BEGIN  bionic
++ ref=bionic-proposed
++ name=test-bionic-proposed
++ lxc delete test-bionic-proposed --force
++ lxc-proposed-snapshot --proposed --upgrade cloud-init --publish bionic bionic-proposed
+Creating bionic-proposed-1059629271
+Get:1 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
+Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
+Get:4 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [673 kB]
+Get:5 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
+Get:6 http://security.ubuntu.com/ubuntu bionic-security/universe Translation-en [223 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:8 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [7808 B]
+Get:9 http://security.ubuntu.com/ubuntu bionic-security/multiverse Translation-en [2856 B]
+Get:10 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
+Get:11 http://archive.ubuntu.com/ubuntu bionic/universe Translation-en [4941 kB]
+Get:12 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
+Get:13 http://archive.ubuntu.com/ubuntu bionic/multiverse Translation-en [108 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [969 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1085 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [337 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [15.9 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Translation-en [6420 B]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [7516 B]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [4764 B]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [7484 B]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [4436 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 Packages [84.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-proposed/main Translation-en [32.0 kB]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-proposed/universe amd64 Packages [22.7 kB]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-proposed/universe Translation-en [12.4 kB]
+Fetched 17.8 MB in 19s (918 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init
+1 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
+Need to get 422 kB of archives.
+After this operation, 68.6 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~18.04.1 [422 kB]
+Preconfiguring packages ...
+Fetched 422 kB in 2s (249 kB/s)
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~18.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) over (19.4-33-gbb4131a2-0ubuntu1~18.04.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) ...
+Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl ...
+Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
+invoke-rc.d: could not determine current runlevel
++ lxc init bionic-proposed test-bionic-proposed
+Creating test-bionic-proposed
++ lxc exec test-bionic-proposed -- cloud-init status --wait --long
+...........................................................
+status: done
+time: Thu, 18 Jun 2020 20:02:24 +0000
+detail:
+DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
++ verify_redacted_instance test-bionic-proposed bionic
++ name=test-bionic-proposed
++ series=bionic
++ expected_output='redacted for non-root user'
+++ lxc exec test-bionic-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-bionic-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.merged_cfg][]'
++ redacted_key='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: bionic have sensitive keys redacted in instance-data.json'
+SUCCESS: bionic have sensitive keys redacted in instance-data.json
++ expected_output='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
+++ lxc exec test-bionic-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-bionic-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.merged_cfg[]][0]'
++ not_redacted_key='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
++ '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
++ echo 'SUCCESS: bionic have sensitive keys not redacted in instance-data-sensitive.json'
+SUCCESS: bionic have sensitive keys not redacted in instance-data-sensitive.json
++ for SERIES in bionic eoan focal xenial
++ echo '=== BEGIN ' eoan
+=== BEGIN  eoan
++ ref=eoan-proposed
++ name=test-eoan-proposed
++ lxc delete test-eoan-proposed --force
++ lxc-proposed-snapshot --proposed --upgrade cloud-init --publish eoan eoan-proposed
+Creating eoan-proposed-2277521367
+Get:1 http://security.ubuntu.com/ubuntu eoan-security InRelease [97.5 kB]
+Hit:2 http://archive.ubuntu.com/ubuntu eoan InRelease
+Get:3 http://archive.ubuntu.com/ubuntu eoan-updates InRelease [97.5 kB]
+Get:4 http://security.ubuntu.com/ubuntu eoan-security/main amd64 Packages [229 kB]
+Get:5 http://archive.ubuntu.com/ubuntu eoan-backports InRelease [88.8 kB]
+Get:6 http://security.ubuntu.com/ubuntu eoan-security/main Translation-en [80.2 kB]
+Get:7 http://archive.ubuntu.com/ubuntu eoan-proposed InRelease [107 kB]
+Get:8 http://security.ubuntu.com/ubuntu eoan-security/main amd64 c-n-f Metadata [5980 B]
+Get:9 http://security.ubuntu.com/ubuntu eoan-security/universe amd64 Packages [173 kB]
+Get:10 http://security.ubuntu.com/ubuntu eoan-security/universe Translation-en [62.7 kB]
+Get:11 http://security.ubuntu.com/ubuntu eoan-security/universe amd64 c-n-f Metadata [6648 B]
+Get:12 http://security.ubuntu.com/ubuntu eoan-security/multiverse amd64 Packages [1172 B]
+Get:13 http://security.ubuntu.com/ubuntu eoan-security/multiverse Translation-en [632 B]
+Get:14 http://security.ubuntu.com/ubuntu eoan-security/multiverse amd64 c-n-f Metadata [116 B]
+Get:15 http://archive.ubuntu.com/ubuntu eoan/universe amd64 Packages [8798 kB]
+Get:16 http://archive.ubuntu.com/ubuntu eoan/universe Translation-en [5198 kB]
+Get:17 http://archive.ubuntu.com/ubuntu eoan/universe amd64 c-n-f Metadata [271 kB]
+Get:18 http://archive.ubuntu.com/ubuntu eoan/multiverse amd64 Packages [153 kB]
+Get:19 http://archive.ubuntu.com/ubuntu eoan/multiverse Translation-en [111 kB]
+Get:20 http://archive.ubuntu.com/ubuntu eoan/multiverse amd64 c-n-f Metadata [9424 B]
+Get:21 http://archive.ubuntu.com/ubuntu eoan-updates/main amd64 Packages [309 kB]
+Get:22 http://archive.ubuntu.com/ubuntu eoan-updates/main Translation-en [113 kB]
+Get:23 http://archive.ubuntu.com/ubuntu eoan-updates/main amd64 c-n-f Metadata [9556 B]
+Get:24 http://archive.ubuntu.com/ubuntu eoan-updates/universe amd64 Packages [219 kB]
+Get:25 http://archive.ubuntu.com/ubuntu eoan-updates/universe Translation-en [85.7 kB]
+Get:26 http://archive.ubuntu.com/ubuntu eoan-updates/universe amd64 c-n-f Metadata [7812 B]
+Get:27 http://archive.ubuntu.com/ubuntu eoan-updates/multiverse amd64 Packages [6320 B]
+Get:28 http://archive.ubuntu.com/ubuntu eoan-updates/multiverse Translation-en [2596 B]
+Get:29 http://archive.ubuntu.com/ubuntu eoan-updates/multiverse amd64 c-n-f Metadata [280 B]
+Get:30 http://archive.ubuntu.com/ubuntu eoan-backports/main amd64 Packages [756 B]
+Get:31 http://archive.ubuntu.com/ubuntu eoan-backports/main Translation-en [324 B]
+Get:32 http://archive.ubuntu.com/ubuntu eoan-backports/main amd64 c-n-f Metadata [220 B]
+Get:33 http://archive.ubuntu.com/ubuntu eoan-backports/restricted amd64 c-n-f Metadata [116 B]
+Get:34 http://archive.ubuntu.com/ubuntu eoan-backports/universe amd64 Packages [3372 B]
+Get:35 http://archive.ubuntu.com/ubuntu eoan-backports/universe Translation-en [1608 B]
+Get:36 http://archive.ubuntu.com/ubuntu eoan-backports/universe amd64 c-n-f Metadata [212 B]
+Get:37 http://archive.ubuntu.com/ubuntu eoan-backports/multiverse amd64 c-n-f Metadata [116 B]
+Get:38 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 Packages [30.2 kB]
+Get:39 http://archive.ubuntu.com/ubuntu eoan-proposed/main Translation-en [14.0 kB]
+Get:40 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 c-n-f Metadata [1120 B]
+Get:41 http://archive.ubuntu.com/ubuntu eoan-proposed/universe amd64 Packages [19.2 kB]
+Get:42 http://archive.ubuntu.com/ubuntu eoan-proposed/universe Translation-en [13.1 kB]
+Get:43 http://archive.ubuntu.com/ubuntu eoan-proposed/universe amd64 c-n-f Metadata [1164 B]
+Fetched 16.3 MB in 18s (905 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init
+1 upgraded, 0 newly installed, 0 to remove and 18 not upgraded.
+Need to get 420 kB of archives.
+After this operation, 69.6 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~19.10.1 [420 kB]
+Preconfiguring packages ...
+Fetched 420 kB in 9s (48.8 kB/s)
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~19.10.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) over (19.4-33-gbb4131a2-0ubuntu1~19.10.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) ...
+Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl ...
+Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Processing triggers for rsyslog (8.1901.0-1ubuntu4) ...
+invoke-rc.d: could not determine current runlevel
++ lxc init eoan-proposed test-eoan-proposed
+Creating test-eoan-proposed
++ lxc exec test-eoan-proposed -- cloud-init status --wait --long
+..............................................................................................
+status: done
+time: Thu, 18 Jun 2020 20:04:28 +0000
+detail:
+DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
++ verify_redacted_instance test-eoan-proposed eoan
++ name=test-eoan-proposed
++ series=eoan
++ expected_output='redacted for non-root user'
+++ lxc exec test-eoan-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-eoan-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.merged_cfg][]'
++ redacted_key='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: eoan have sensitive keys redacted in instance-data.json'
+SUCCESS: eoan have sensitive keys redacted in instance-data.json
++ expected_output='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
+++ lxc exec test-eoan-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-eoan-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.merged_cfg[]][0]'
++ not_redacted_key='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
++ '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
++ echo 'SUCCESS: eoan have sensitive keys not redacted in instance-data-sensitive.json'
+SUCCESS: eoan have sensitive keys not redacted in instance-data-sensitive.json
++ for SERIES in bionic eoan focal xenial
++ echo '=== BEGIN ' focal
+=== BEGIN  focal
++ ref=focal-proposed
++ name=test-focal-proposed
++ lxc delete test-focal-proposed --force
++ lxc-proposed-snapshot --proposed --upgrade cloud-init --publish focal focal-proposed
+Creating focal-proposed-317672640
+Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [107 kB]
+Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
+Get:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease [107 kB]
+Get:4 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [106 kB]
+Get:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease [98.3 kB]
+Get:6 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [2764 B]
+Get:7 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [35.5 kB]
+Get:8 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [17.7 kB]
+Get:9 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [1612 B]
+Get:10 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [1172 B]
+Get:11 http://security.ubuntu.com/ubuntu focal-security/multiverse Translation-en [540 B]
+Get:12 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 c-n-f Metadata [116 B]
+Get:13 http://archive.ubuntu.com/ubuntu focal-proposed InRelease [265 kB]
+Get:14 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [8628 kB]
+Get:15 http://archive.ubuntu.com/ubuntu focal/universe Translation-en [5124 kB]
+Get:16 http://archive.ubuntu.com/ubuntu focal/universe amd64 c-n-f Metadata [265 kB]
+Get:17 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [144 kB]
+Get:18 http://archive.ubuntu.com/ubuntu focal/multiverse Translation-en [104 kB]
+Get:19 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 c-n-f Metadata [9136 B]
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [199 kB]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main Translation-en [78.8 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [5856 B]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [110 kB]
+Get:24 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [52.3 kB]
+Get:25 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [4112 B]
+Get:26 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [1172 B]
+Get:27 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [540 B]
+Get:28 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [116 B]
+Get:29 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [112 B]
+Get:30 http://archive.ubuntu.com/ubuntu focal-backports/restricted amd64 c-n-f Metadata [116 B]
+Get:31 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [2784 B]
+Get:32 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [1272 B]
+Get:33 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [192 B]
+Get:34 http://archive.ubuntu.com/ubuntu focal-backports/multiverse amd64 c-n-f Metadata [116 B]
+Get:35 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 Packages [45.0 kB]
+Get:36 http://archive.ubuntu.com/ubuntu focal-proposed/main Translation-en [22.8 kB]
+Get:37 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 c-n-f Metadata [1460 B]
+Get:38 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 Packages [23.6 kB]
+Get:39 http://archive.ubuntu.com/ubuntu focal-proposed/universe Translation-en [18.4 kB]
+Get:40 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 c-n-f Metadata [1608 B]
+Fetched 15.6 MB in 19s (820 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init
+1 upgraded, 0 newly installed, 0 to remove and 21 not upgraded.
+Need to get 416 kB of archives.
+After this operation, 52.2 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~20.04.1 [416 kB]
+Preconfiguring packages ...
+Fetched 416 kB in 2s (239 kB/s)
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~20.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) over (20.1-10-g71af48df-0ubuntu5) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) ...
+Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl ...
+Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Processing triggers for rsyslog (8.2001.0-1ubuntu1) ...
+invoke-rc.d: could not determine current runlevel
++ lxc init focal-proposed test-focal-proposed
+Creating test-focal-proposed
++ lxc exec test-focal-proposed -- cloud-init status --wait --long
+..................................................................................................
+status: done
+time: Thu, 18 Jun 2020 20:06:29 +0000
+detail:
+DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
++ verify_redacted_instance test-focal-proposed focal
++ name=test-focal-proposed
++ series=focal
++ expected_output='redacted for non-root user'
+++ lxc exec test-focal-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-focal-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.merged_cfg][]'
++ redacted_key='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: focal have sensitive keys redacted in instance-data.json'
+SUCCESS: focal have sensitive keys redacted in instance-data.json
++ expected_output='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
+++ lxc exec test-focal-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-focal-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.merged_cfg[]][0]'
++ not_redacted_key='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
++ '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
++ echo 'SUCCESS: focal have sensitive keys not redacted in instance-data-sensitive.json'
+SUCCESS: focal have sensitive keys not redacted in instance-data-sensitive.json
++ for SERIES in bionic eoan focal xenial
++ echo '=== BEGIN ' xenial
+=== BEGIN  xenial
++ ref=xenial-proposed
++ name=test-xenial-proposed
++ lxc delete test-xenial-proposed --force
++ lxc-proposed-snapshot --proposed --upgrade cloud-init --publish xenial xenial-proposed
+Creating xenial-proposed-122328625
+Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
+Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
+Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [883 kB]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
+Get:6 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [331 kB]
+Get:7 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [494 kB]
+Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [202 kB]
+Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6084 B]
+Get:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [2888 B]
+Get:11 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease [260 kB]
+Get:12 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7532 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial/universe Translation-en [4354 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [144 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial/multiverse Translation-en [106 kB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1161 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [437 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [799 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [334 kB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [17.1 kB]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [8632 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7280 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [4456 B]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8064 B]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [4328 B]
+Get:26 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 Packages [39.9 kB]
+Get:27 http://archive.ubuntu.com/ubuntu xenial-proposed/main Translation-en [16.6 kB]
+Get:28 http://archive.ubuntu.com/ubuntu xenial-proposed/universe amd64 Packages [8660 B]
+Get:29 http://archive.ubuntu.com/ubuntu xenial-proposed/universe Translation-en [6636 B]
+Fetched 17.5 MB in 23s (748 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+The following package was automatically installed and is no longer required:
+  libfreetype6
+Use 'apt autoremove' to remove it.
+The following packages will be upgraded:
+  cloud-init
+1 upgraded, 0 newly installed, 0 to remove and 14 not upgraded.
+Need to get 425 kB of archives.
+After this operation, 68.6 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~16.04.1 [425 kB]
+Preconfiguring packages ...
+Fetched 425 kB in 1s (238 kB/s)
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~16.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) over (19.4-33-gbb4131a2-0ubuntu1~16.04.1) ...
+Processing triggers for ureadahead (0.100.0-19.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) ...
+Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl ...
+Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
+Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
+Leaving 'diversion of /etc/init/ureadahead.conf to /etc/init/ureadahead.conf.disabled by cloud-init'
++ lxc init xenial-proposed test-xenial-proposed
+Creating test-xenial-proposed
++ lxc exec test-xenial-proposed -- cloud-init status --wait --long
+..........................
+status: done
+time: Thu, 18 Jun 2020 20:08:22 +0000
+detail:
+DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
++ verify_redacted_instance test-xenial-proposed xenial
++ name=test-xenial-proposed
++ series=xenial
++ expected_output='redacted for non-root user'
+++ lxc exec test-xenial-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-xenial-proposed -- cat /run/cloud-init/instance-data.json
+++ jq -r '[.merged_cfg][]'
++ redacted_key='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: xenial have sensitive keys redacted in instance-data.json'
+SUCCESS: xenial have sensitive keys redacted in instance-data.json
++ expected_output='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
+++ lxc exec test-xenial-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.sensitive_keys[]][0]'
++ sensitive_key=merged_cfg
+++ lxc exec test-xenial-proposed -- cat /run/cloud-init/instance-data-sensitive.json
+++ jq -r '[.merged_cfg[]][0]'
++ not_redacted_key='Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'
++ '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
++ echo 'SUCCESS: xenial have sensitive keys not redacted in instance-data-sensitive.json'
+SUCCESS: xenial have sensitive keys not redacted in instance-data-sensitive.json

--- a/bugs/lp-1865947.txt
+++ b/bugs/lp-1865947.txt
@@ -11,6 +11,13 @@ instance-data-sensitive.json file, which is a file non-root users cannot read.
 set -x
 # Manually deploy on a lxc container
 
+sshopts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+cat > userdata.yaml <<EOF
+#cloud-config
+ssh_import_id: [lamoura]
+EOF
+
 verify_redacted_instance() {
     name=$1
     series=$2
@@ -36,17 +43,42 @@ verify_redacted_instance() {
     fi
 }
 
-for SERIES in focal; do
-   echo '=== BEGIN ' $SERIES
-   ref=$SERIES-proposed
-   name=test-$SERIES-proposed-bug
+verify_non_root_user_redacted_instance() {
+   name=$1
+   series=$2
+
+   VM_IP=$(lxc ls -c4 $name --format=json | jq -r '.[]|.state.network.eth0.addresses[0].address')
+
+   expected_output="redacted for non-root user"
+   sensitive_key=$(ssh $sshopts ubuntu@$VM_IP -- cloud-init query --all | jq -r '.sensitive_keys[]')
+   actual_output=$(ssh $sshopts ubuntu@$VM_IP -- cloud-init query $sensitive_key)
+
+   if [ "$expected_output" = "$actual_output" ]; then
+       echo "SUCCESS: $series did not show merged_cfg for non-root user"
+   else
+       echo "FAILURE: $series did show merged_cfg for non-root user"
+   fi
+}
+
+verify() {
+   series=$1
+
+   ref=$series-proposed
+   name=test-$series-proposed
    lxc delete $name --force 2> /dev/null
-   lxc-proposed-snapshot --proposed --upgrade cloud-init --publish $SERIES $ref
-   lxc init $ref $name
+   lxc-proposed-snapshot --proposed --upgrade cloud-init --publish $series $ref
+   lxc init $ref $name -c user.user-data="$(cat userdata.yaml)"
    lxc start $name
    lxc exec $name -- cloud-init status --wait --long
 
-   # verify_redacted_instance $name $SERIES
+   verify_redacted_instance $name $series
+   verify_non_root_user_redacted_instance $name $series
+}
+
+for SERIES in bionic eoan focal xenial; do
+   echo '=== BEGIN ' $SERIES
+   verify $SERIES
+   echo '=== END ' $SERIES
 done
 ```
 
@@ -60,41 +92,48 @@ permissions to a user to read the file, we do not believe this may pose a proble
 
 === Verification Log ===
 
++ sshopts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR'
++ cat
 + for SERIES in bionic eoan focal xenial
 + echo '=== BEGIN ' bionic
 === BEGIN  bionic
++ verify bionic
++ series=bionic
 + ref=bionic-proposed
 + name=test-bionic-proposed
 + lxc delete test-bionic-proposed --force
 + lxc-proposed-snapshot --proposed --upgrade cloud-init --publish bionic bionic-proposed
-Creating bionic-proposed-1059629271
-Get:1 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
-Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease
+Creating bionic-proposed-237784592
+Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
+Get:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
 Get:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
-Get:4 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [673 kB]
+Get:4 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [748 kB]
 Get:5 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
-Get:6 http://security.ubuntu.com/ubuntu bionic-security/universe Translation-en [223 kB]
-Get:7 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
-Get:8 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [7808 B]
-Get:9 http://security.ubuntu.com/ubuntu bionic-security/multiverse Translation-en [2856 B]
-Get:10 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
-Get:11 http://archive.ubuntu.com/ubuntu bionic/universe Translation-en [4941 kB]
-Get:12 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
-Get:13 http://archive.ubuntu.com/ubuntu bionic/multiverse Translation-en [108 kB]
-Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [969 kB]
-Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1085 kB]
-Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [337 kB]
-Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [15.9 kB]
-Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Translation-en [6420 B]
-Get:19 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [7516 B]
-Get:20 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [4764 B]
-Get:21 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [7484 B]
-Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [4436 B]
-Get:23 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 Packages [84.1 kB]
-Get:24 http://archive.ubuntu.com/ubuntu bionic-proposed/main Translation-en [32.0 kB]
-Get:25 http://archive.ubuntu.com/ubuntu bionic-proposed/universe amd64 Packages [22.7 kB]
-Get:26 http://archive.ubuntu.com/ubuntu bionic-proposed/universe Translation-en [12.4 kB]
-Fetched 17.8 MB in 19s (918 kB/s)
+Get:6 http://archive.ubuntu.com/ubuntu bionic-proposed InRelease [242 kB]
+Get:7 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
+Get:8 http://security.ubuntu.com/ubuntu bionic-security/main Translation-en [237 kB]
+Get:9 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [673 kB]
+Get:10 http://security.ubuntu.com/ubuntu bionic-security/universe Translation-en [223 kB]
+Get:11 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [7808 B]
+Get:12 http://security.ubuntu.com/ubuntu bionic-security/multiverse Translation-en [2856 B]
+Get:13 http://archive.ubuntu.com/ubuntu bionic/universe Translation-en [4941 kB]
+Get:14 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
+Get:15 http://archive.ubuntu.com/ubuntu bionic/multiverse Translation-en [108 kB]
+Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [970 kB]
+Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/main Translation-en [329 kB]
+Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1085 kB]
+Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/universe Translation-en [337 kB]
+Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [15.9 kB]
+Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse Translation-en [6420 B]
+Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [7516 B]
+Get:23 http://archive.ubuntu.com/ubuntu bionic-backports/main Translation-en [4764 B]
+Get:24 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [7484 B]
+Get:25 http://archive.ubuntu.com/ubuntu bionic-backports/universe Translation-en [4436 B]
+Get:26 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 Packages [88.4 kB]
+Get:27 http://archive.ubuntu.com/ubuntu bionic-proposed/main Translation-en [33.1 kB]
+Get:28 http://archive.ubuntu.com/ubuntu bionic-proposed/universe amd64 Packages [19.4 kB]
+Get:29 http://archive.ubuntu.com/ubuntu bionic-proposed/universe Translation-en [11.5 kB]
+Fetched 19.1 MB in 27s (703 kB/s)
 Reading package lists...
 Reading package lists...
 Building dependency tree...
@@ -104,12 +143,12 @@ The following package was automatically installed and is no longer required:
 Use 'apt autoremove' to remove it.
 The following packages will be upgraded:
   cloud-init
-1 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
+1 upgraded, 0 newly installed, 0 to remove and 14 not upgraded.
 Need to get 422 kB of archives.
 After this operation, 68.6 kB of additional disk space will be used.
 Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~18.04.1 [422 kB]
 Preconfiguring packages ...
-Fetched 422 kB in 2s (249 kB/s)
+Fetched 422 kB in 2s (212 kB/s)
 Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~18.04.1_all.deb ...
 Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) over (19.4-33-gbb4131a2-0ubuntu1~18.04.1) ...
 Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) ...
@@ -118,12 +157,14 @@ Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
 Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
 Processing triggers for rsyslog (8.32.0-1ubuntu4) ...
 invoke-rc.d: could not determine current runlevel
-+ lxc init bionic-proposed test-bionic-proposed
+++ cat userdata.yaml
++ lxc init bionic-proposed test-bionic-proposed -c 'user.user-data=#cloud-config
+ssh_import_id: [lamoura]'
 Creating test-bionic-proposed
 + lxc exec test-bionic-proposed -- cloud-init status --wait --long
-...........................................................
+..........................................
 status: done
-time: Thu, 18 Jun 2020 20:02:24 +0000
+time: Wed, 24 Jun 2020 13:31:31 +0000
 detail:
 DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
 + verify_redacted_instance test-bionic-proposed bionic
@@ -149,22 +190,41 @@ SUCCESS: bionic have sensitive keys redacted in instance-data.json
 + '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
 + echo 'SUCCESS: bionic have sensitive keys not redacted in instance-data-sensitive.json'
 SUCCESS: bionic have sensitive keys not redacted in instance-data-sensitive.json
++ verify_non_root_user_redacted_instance test-bionic-proposed bionic
++ name=test-bionic-proposed
++ series=bionic
+++ lxc ls -c4 test-bionic-proposed --format=json
+++ jq -r '.[]|.state.network.eth0.addresses[0].address'
++ VM_IP=10.121.212.173
++ expected_output='redacted for non-root user'
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.173 -- cloud-init query --all
+++ jq -r '.sensitive_keys[]'
++ sensitive_key=merged_cfg
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.173 -- cloud-init query merged_cfg
++ actual_output='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: bionic did not show merged_cfg for non-root user'
+SUCCESS: bionic did not show merged_cfg for non-root user
++ echo '=== END ' bionic
+=== END  bionic
 + for SERIES in bionic eoan focal xenial
 + echo '=== BEGIN ' eoan
 === BEGIN  eoan
++ verify eoan
++ series=eoan
 + ref=eoan-proposed
 + name=test-eoan-proposed
 + lxc delete test-eoan-proposed --force
 + lxc-proposed-snapshot --proposed --upgrade cloud-init --publish eoan eoan-proposed
-Creating eoan-proposed-2277521367
+Creating eoan-proposed-359416723
 Get:1 http://security.ubuntu.com/ubuntu eoan-security InRelease [97.5 kB]
 Hit:2 http://archive.ubuntu.com/ubuntu eoan InRelease
 Get:3 http://archive.ubuntu.com/ubuntu eoan-updates InRelease [97.5 kB]
-Get:4 http://security.ubuntu.com/ubuntu eoan-security/main amd64 Packages [229 kB]
+Get:4 http://security.ubuntu.com/ubuntu eoan-security/main amd64 Packages [231 kB]
 Get:5 http://archive.ubuntu.com/ubuntu eoan-backports InRelease [88.8 kB]
-Get:6 http://security.ubuntu.com/ubuntu eoan-security/main Translation-en [80.2 kB]
-Get:7 http://archive.ubuntu.com/ubuntu eoan-proposed InRelease [107 kB]
-Get:8 http://security.ubuntu.com/ubuntu eoan-security/main amd64 c-n-f Metadata [5980 B]
+Get:6 http://archive.ubuntu.com/ubuntu eoan-proposed InRelease [107 kB]
+Get:7 http://security.ubuntu.com/ubuntu eoan-security/main Translation-en [81.5 kB]
+Get:8 http://security.ubuntu.com/ubuntu eoan-security/main amd64 c-n-f Metadata [6152 B]
 Get:9 http://security.ubuntu.com/ubuntu eoan-security/universe amd64 Packages [173 kB]
 Get:10 http://security.ubuntu.com/ubuntu eoan-security/universe Translation-en [62.7 kB]
 Get:11 http://security.ubuntu.com/ubuntu eoan-security/universe amd64 c-n-f Metadata [6648 B]
@@ -177,11 +237,11 @@ Get:17 http://archive.ubuntu.com/ubuntu eoan/universe amd64 c-n-f Metadata [271 
 Get:18 http://archive.ubuntu.com/ubuntu eoan/multiverse amd64 Packages [153 kB]
 Get:19 http://archive.ubuntu.com/ubuntu eoan/multiverse Translation-en [111 kB]
 Get:20 http://archive.ubuntu.com/ubuntu eoan/multiverse amd64 c-n-f Metadata [9424 B]
-Get:21 http://archive.ubuntu.com/ubuntu eoan-updates/main amd64 Packages [309 kB]
-Get:22 http://archive.ubuntu.com/ubuntu eoan-updates/main Translation-en [113 kB]
-Get:23 http://archive.ubuntu.com/ubuntu eoan-updates/main amd64 c-n-f Metadata [9556 B]
+Get:21 http://archive.ubuntu.com/ubuntu eoan-updates/main amd64 Packages [311 kB]
+Get:22 http://archive.ubuntu.com/ubuntu eoan-updates/main Translation-en [114 kB]
+Get:23 http://archive.ubuntu.com/ubuntu eoan-updates/main amd64 c-n-f Metadata [9680 B]
 Get:24 http://archive.ubuntu.com/ubuntu eoan-updates/universe amd64 Packages [219 kB]
-Get:25 http://archive.ubuntu.com/ubuntu eoan-updates/universe Translation-en [85.7 kB]
+Get:25 http://archive.ubuntu.com/ubuntu eoan-updates/universe Translation-en [85.9 kB]
 Get:26 http://archive.ubuntu.com/ubuntu eoan-updates/universe amd64 c-n-f Metadata [7812 B]
 Get:27 http://archive.ubuntu.com/ubuntu eoan-updates/multiverse amd64 Packages [6320 B]
 Get:28 http://archive.ubuntu.com/ubuntu eoan-updates/multiverse Translation-en [2596 B]
@@ -194,13 +254,13 @@ Get:34 http://archive.ubuntu.com/ubuntu eoan-backports/universe amd64 Packages [
 Get:35 http://archive.ubuntu.com/ubuntu eoan-backports/universe Translation-en [1608 B]
 Get:36 http://archive.ubuntu.com/ubuntu eoan-backports/universe amd64 c-n-f Metadata [212 B]
 Get:37 http://archive.ubuntu.com/ubuntu eoan-backports/multiverse amd64 c-n-f Metadata [116 B]
-Get:38 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 Packages [30.2 kB]
-Get:39 http://archive.ubuntu.com/ubuntu eoan-proposed/main Translation-en [14.0 kB]
-Get:40 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 c-n-f Metadata [1120 B]
-Get:41 http://archive.ubuntu.com/ubuntu eoan-proposed/universe amd64 Packages [19.2 kB]
-Get:42 http://archive.ubuntu.com/ubuntu eoan-proposed/universe Translation-en [13.1 kB]
+Get:38 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 Packages [33.0 kB]
+Get:39 http://archive.ubuntu.com/ubuntu eoan-proposed/main Translation-en [14.9 kB]
+Get:40 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 c-n-f Metadata [1268 B]
+Get:41 http://archive.ubuntu.com/ubuntu eoan-proposed/universe amd64 Packages [20.3 kB]
+Get:42 http://archive.ubuntu.com/ubuntu eoan-proposed/universe Translation-en [13.6 kB]
 Get:43 http://archive.ubuntu.com/ubuntu eoan-proposed/universe amd64 c-n-f Metadata [1164 B]
-Fetched 16.3 MB in 18s (905 kB/s)
+Fetched 16.3 MB in 19s (883 kB/s)
 Reading package lists...
 Reading package lists...
 Building dependency tree...
@@ -210,12 +270,12 @@ The following package was automatically installed and is no longer required:
 Use 'apt autoremove' to remove it.
 The following packages will be upgraded:
   cloud-init
-1 upgraded, 0 newly installed, 0 to remove and 18 not upgraded.
+1 upgraded, 0 newly installed, 0 to remove and 23 not upgraded.
 Need to get 420 kB of archives.
 After this operation, 69.6 kB of additional disk space will be used.
 Get:1 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~19.10.1 [420 kB]
 Preconfiguring packages ...
-Fetched 420 kB in 9s (48.8 kB/s)
+Fetched 420 kB in 2s (210 kB/s)
 Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~19.10.1_all.deb ...
 Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) over (19.4-33-gbb4131a2-0ubuntu1~19.10.1) ...
 Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) ...
@@ -224,12 +284,14 @@ Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
 Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
 Processing triggers for rsyslog (8.1901.0-1ubuntu4) ...
 invoke-rc.d: could not determine current runlevel
-+ lxc init eoan-proposed test-eoan-proposed
+++ cat userdata.yaml
++ lxc init eoan-proposed test-eoan-proposed -c 'user.user-data=#cloud-config
+ssh_import_id: [lamoura]'
 Creating test-eoan-proposed
 + lxc exec test-eoan-proposed -- cloud-init status --wait --long
-..............................................................................................
+.............................................................................................................................................................
 status: done
-time: Thu, 18 Jun 2020 20:04:28 +0000
+time: Wed, 24 Jun 2020 13:33:47 +0000
 detail:
 DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
 + verify_redacted_instance test-eoan-proposed eoan
@@ -255,20 +317,39 @@ SUCCESS: eoan have sensitive keys redacted in instance-data.json
 + '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
 + echo 'SUCCESS: eoan have sensitive keys not redacted in instance-data-sensitive.json'
 SUCCESS: eoan have sensitive keys not redacted in instance-data-sensitive.json
++ verify_non_root_user_redacted_instance test-eoan-proposed eoan
++ name=test-eoan-proposed
++ series=eoan
+++ lxc ls -c4 test-eoan-proposed --format=json
+++ jq -r '.[]|.state.network.eth0.addresses[0].address'
++ VM_IP=10.121.212.132
++ expected_output='redacted for non-root user'
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.132 -- cloud-init query --all
+++ jq -r '.sensitive_keys[]'
++ sensitive_key=merged_cfg
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.132 -- cloud-init query merged_cfg
++ actual_output='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: eoan did not show merged_cfg for non-root user'
+SUCCESS: eoan did not show merged_cfg for non-root user
++ echo '=== END ' eoan
+=== END  eoan
 + for SERIES in bionic eoan focal xenial
 + echo '=== BEGIN ' focal
 === BEGIN  focal
++ verify focal
++ series=focal
 + ref=focal-proposed
 + name=test-focal-proposed
 + lxc delete test-focal-proposed --force
 + lxc-proposed-snapshot --proposed --upgrade cloud-init --publish focal focal-proposed
-Creating focal-proposed-317672640
+Creating focal-proposed-1274227175
 Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [107 kB]
 Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
 Get:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease [107 kB]
-Get:4 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [106 kB]
+Get:4 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [108 kB]
 Get:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease [98.3 kB]
-Get:6 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [2764 B]
+Get:6 http://security.ubuntu.com/ubuntu focal-security/main Translation-en [41.6 kB]
 Get:7 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [35.5 kB]
 Get:8 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [17.7 kB]
 Get:9 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [1612 B]
@@ -282,28 +363,30 @@ Get:16 http://archive.ubuntu.com/ubuntu focal/universe amd64 c-n-f Metadata [265
 Get:17 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [144 kB]
 Get:18 http://archive.ubuntu.com/ubuntu focal/multiverse Translation-en [104 kB]
 Get:19 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 c-n-f Metadata [9136 B]
-Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [199 kB]
-Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main Translation-en [78.8 kB]
-Get:22 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [5856 B]
-Get:23 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [110 kB]
-Get:24 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [52.3 kB]
-Get:25 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [4112 B]
-Get:26 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [1172 B]
-Get:27 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [540 B]
-Get:28 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [116 B]
-Get:29 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [112 B]
-Get:30 http://archive.ubuntu.com/ubuntu focal-backports/restricted amd64 c-n-f Metadata [116 B]
-Get:31 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [2784 B]
-Get:32 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [1272 B]
-Get:33 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [192 B]
-Get:34 http://archive.ubuntu.com/ubuntu focal-backports/multiverse amd64 c-n-f Metadata [116 B]
-Get:35 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 Packages [45.0 kB]
-Get:36 http://archive.ubuntu.com/ubuntu focal-proposed/main Translation-en [22.8 kB]
-Get:37 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 c-n-f Metadata [1460 B]
-Get:38 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 Packages [23.6 kB]
-Get:39 http://archive.ubuntu.com/ubuntu focal-proposed/universe Translation-en [18.4 kB]
-Get:40 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 c-n-f Metadata [1608 B]
-Fetched 15.6 MB in 19s (820 kB/s)
+Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [204 kB]
+Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main Translation-en [82.2 kB]
+Get:22 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [5980 B]
+Get:23 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [11.1 kB]
+Get:24 http://archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [3036 B]
+Get:25 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [115 kB]
+Get:26 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [54.5 kB]
+Get:27 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [4164 B]
+Get:28 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [1172 B]
+Get:29 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [540 B]
+Get:30 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [116 B]
+Get:31 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [112 B]
+Get:32 http://archive.ubuntu.com/ubuntu focal-backports/restricted amd64 c-n-f Metadata [116 B]
+Get:33 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [2784 B]
+Get:34 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [1272 B]
+Get:35 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [192 B]
+Get:36 http://archive.ubuntu.com/ubuntu focal-backports/multiverse amd64 c-n-f Metadata [116 B]
+Get:37 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 Packages [87.3 kB]
+Get:38 http://archive.ubuntu.com/ubuntu focal-proposed/main Translation-en [37.0 kB]
+Get:39 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 c-n-f Metadata [2144 B]
+Get:40 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 Packages [37.0 kB]
+Get:41 http://archive.ubuntu.com/ubuntu focal-proposed/universe Translation-en [25.8 kB]
+Get:42 http://archive.ubuntu.com/ubuntu focal-proposed/universe amd64 c-n-f Metadata [1920 B]
+Fetched 15.7 MB in 18s (866 kB/s)
 Reading package lists...
 Reading package lists...
 Building dependency tree...
@@ -313,12 +396,12 @@ The following package was automatically installed and is no longer required:
 Use 'apt autoremove' to remove it.
 The following packages will be upgraded:
   cloud-init
-1 upgraded, 0 newly installed, 0 to remove and 21 not upgraded.
+1 upgraded, 0 newly installed, 0 to remove and 26 not upgraded.
 Need to get 416 kB of archives.
 After this operation, 52.2 kB of additional disk space will be used.
 Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~20.04.1 [416 kB]
 Preconfiguring packages ...
-Fetched 416 kB in 2s (239 kB/s)
+Fetched 416 kB in 2s (202 kB/s)
 Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~20.04.1_all.deb ...
 Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) over (20.1-10-g71af48df-0ubuntu5) ...
 Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) ...
@@ -327,12 +410,14 @@ Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
 Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
 Processing triggers for rsyslog (8.2001.0-1ubuntu1) ...
 invoke-rc.d: could not determine current runlevel
-+ lxc init focal-proposed test-focal-proposed
+++ cat userdata.yaml
++ lxc init focal-proposed test-focal-proposed -c 'user.user-data=#cloud-config
+ssh_import_id: [lamoura]'
 Creating test-focal-proposed
 + lxc exec test-focal-proposed -- cloud-init status --wait --long
-..................................................................................................
+..............................................................................................
 status: done
-time: Thu, 18 Jun 2020 20:06:29 +0000
+time: Wed, 24 Jun 2020 13:35:49 +0000
 detail:
 DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
 + verify_redacted_instance test-focal-proposed focal
@@ -358,44 +443,62 @@ SUCCESS: focal have sensitive keys redacted in instance-data.json
 + '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
 + echo 'SUCCESS: focal have sensitive keys not redacted in instance-data-sensitive.json'
 SUCCESS: focal have sensitive keys not redacted in instance-data-sensitive.json
++ verify_non_root_user_redacted_instance test-focal-proposed focal
++ name=test-focal-proposed
++ series=focal
+++ lxc ls -c4 test-focal-proposed --format=json
+++ jq -r '.[]|.state.network.eth0.addresses[0].address'
++ VM_IP=10.121.212.174
++ expected_output='redacted for non-root user'
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.174 -- cloud-init query --all
+++ jq -r '.sensitive_keys[]'
++ sensitive_key=merged_cfg
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.174 -- cloud-init query merged_cfg
++ actual_output='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: focal did not show merged_cfg for non-root user'
+SUCCESS: focal did not show merged_cfg for non-root user
++ echo '=== END ' focal
+=== END  focal
 + for SERIES in bionic eoan focal xenial
 + echo '=== BEGIN ' xenial
 === BEGIN  xenial
++ verify xenial
++ series=xenial
 + ref=xenial-proposed
 + name=test-xenial-proposed
 + lxc delete test-xenial-proposed --force
 + lxc-proposed-snapshot --proposed --upgrade cloud-init --publish xenial xenial-proposed
-Creating xenial-proposed-122328625
-Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
-Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Creating xenial-proposed-2901110100
+Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
 Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
-Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [883 kB]
+Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [884 kB]
 Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
-Get:6 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [331 kB]
-Get:7 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [494 kB]
-Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [202 kB]
-Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6084 B]
-Get:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [2888 B]
-Get:11 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease [260 kB]
-Get:12 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7532 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial-proposed InRelease [260 kB]
+Get:7 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [331 kB]
+Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [494 kB]
+Get:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7532 kB]
+Get:10 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [202 kB]
+Get:11 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6084 B]
+Get:12 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [2888 B]
 Get:13 http://archive.ubuntu.com/ubuntu xenial/universe Translation-en [4354 kB]
 Get:14 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [144 kB]
 Get:15 http://archive.ubuntu.com/ubuntu xenial/multiverse Translation-en [106 kB]
 Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1161 kB]
-Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [437 kB]
-Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [799 kB]
-Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [334 kB]
-Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [17.1 kB]
-Get:21 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [8632 B]
-Get:22 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7280 B]
-Get:23 http://archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [4456 B]
-Get:24 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8064 B]
-Get:25 http://archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [4328 B]
-Get:26 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 Packages [39.9 kB]
-Get:27 http://archive.ubuntu.com/ubuntu xenial-proposed/main Translation-en [16.6 kB]
-Get:28 http://archive.ubuntu.com/ubuntu xenial-proposed/universe amd64 Packages [8660 B]
-Get:29 http://archive.ubuntu.com/ubuntu xenial-proposed/universe Translation-en [6636 B]
-Fetched 17.5 MB in 23s (748 kB/s)
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [799 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [334 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [17.1 kB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [8632 B]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7280 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [4456 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8064 B]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [4328 B]
+Get:25 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 Packages [41.8 kB]
+Get:26 http://archive.ubuntu.com/ubuntu xenial-proposed/main Translation-en [17.3 kB]
+Get:27 http://archive.ubuntu.com/ubuntu xenial-proposed/universe amd64 Packages [9492 B]
+Get:28 http://archive.ubuntu.com/ubuntu xenial-proposed/universe Translation-en [7276 B]
+Fetched 17.1 MB in 19s (891 kB/s)
 Reading package lists...
 Reading package lists...
 Building dependency tree...
@@ -405,12 +508,12 @@ The following package was automatically installed and is no longer required:
 Use 'apt autoremove' to remove it.
 The following packages will be upgraded:
   cloud-init
-1 upgraded, 0 newly installed, 0 to remove and 14 not upgraded.
+1 upgraded, 0 newly installed, 0 to remove and 17 not upgraded.
 Need to get 425 kB of archives.
 After this operation, 68.6 kB of additional disk space will be used.
 Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~16.04.1 [425 kB]
 Preconfiguring packages ...
-Fetched 425 kB in 1s (238 kB/s)
+Fetched 425 kB in 2s (210 kB/s)
 Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~16.04.1_all.deb ...
 Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) over (19.4-33-gbb4131a2-0ubuntu1~16.04.1) ...
 Processing triggers for ureadahead (0.100.0-19.1) ...
@@ -419,12 +522,14 @@ Installing new version of config file /etc/cloud/templates/chef_client.rb.tmpl .
 Installing new version of config file /etc/cloud/templates/hosts.suse.tmpl ...
 Installing new version of config file /etc/cloud/templates/resolv.conf.tmpl ...
 Leaving 'diversion of /etc/init/ureadahead.conf to /etc/init/ureadahead.conf.disabled by cloud-init'
-+ lxc init xenial-proposed test-xenial-proposed
+++ cat userdata.yaml
++ lxc init xenial-proposed test-xenial-proposed -c 'user.user-data=#cloud-config
+ssh_import_id: [lamoura]'
 Creating test-xenial-proposed
 + lxc exec test-xenial-proposed -- cloud-init status --wait --long
-..........................
+................................
 status: done
-time: Thu, 18 Jun 2020 20:08:22 +0000
+time: Wed, 24 Jun 2020 13:37:18 +0000
 detail:
 DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
 + verify_redacted_instance test-xenial-proposed xenial
@@ -450,3 +555,20 @@ SUCCESS: xenial have sensitive keys redacted in instance-data.json
 + '[' 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' = 'Merged cloud-init system config from /etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/' ']'
 + echo 'SUCCESS: xenial have sensitive keys not redacted in instance-data-sensitive.json'
 SUCCESS: xenial have sensitive keys not redacted in instance-data-sensitive.json
++ verify_non_root_user_redacted_instance test-xenial-proposed xenial
++ name=test-xenial-proposed
++ series=xenial
+++ lxc ls -c4 test-xenial-proposed --format=json
+++ jq -r '.[]|.state.network.eth0.addresses[0].address'
++ VM_IP=10.121.212.196
++ expected_output='redacted for non-root user'
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.196 -- cloud-init query --all
+++ jq -r '.sensitive_keys[]'
++ sensitive_key=merged_cfg
+++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@10.121.212.196 -- cloud-init query merged_cfg
++ actual_output='redacted for non-root user'
++ '[' 'redacted for non-root user' = 'redacted for non-root user' ']'
++ echo 'SUCCESS: xenial did not show merged_cfg for non-root user'
+SUCCESS: xenial did not show merged_cfg for non-root user
++ echo '=== END ' xenial
+=== END  xenial


### PR DESCRIPTION
Manual verification for [#233](https://github.com/canonical/cloud-init/pull/233)

I have not replicated the issue on the current version of cloud-init becuase it seems that there is no `sensitive_keys`  on older releases. The `instance_data.json` is empty for that field.