### PR TITLE
Sru/20.2.45 curtin proposed sru test results

### DIFF
--- a/20200529/README.md
+++ b/20200529/README.md
@@ -57,3 +57,4 @@ The links listed below are to bugs fixed in this SRU and the verification of tho
 | Manual nocloud-kvm test | [verification output](../manual/nocloud-kvm-20.2.45.txt) |
 | Manual softlayer test | [verification output](../manual/softlayer-sru-20.2.45.txt) |
 | Manual nocloud-lxd test | [verification output](../manual/nocloud-lxd-20.2.45.txt) |
+| Manual curtin-cloudinit-sru test | [verification output](../manual/curtin-cloudinit-sru-20.2.45.txt) |

--- a/bin/sru-get-jenkins-logs
+++ b/bin/sru-get-jenkins-logs
@@ -34,6 +34,11 @@ for platform in lxd kvm; do
   done
   echo "Wrote $manuallog. Upload with lp-attach-file $SRU_BUG $manuallog"
 done
+echo "=== Downloading curtin cloudinit-sru -proposed results"
+jenkins-get-job curtin-cloudinit-sru -v -s;
+curtin_sru_log=`ls ./jenkins/curtin-cloudinit-sru/*/console.log`
+cp $curtin_sru_log manual/curtin-cloudinit-sru-$SRU_VERSION.txt
+echo "Upload with lp-attach-file manual/curtin-cloudinit-sru-$SRU_VERSION.txt"
 echo "=== Downloading MAAS SRU -proposed results"
 jenkins-get-job --url http://10.245.136.4:8080 --username $SRU_MAAS_JENKINS_USER --password $SRU_MAAS_JENKINS_PASSWORD SRU-proposed-cloudinit-sru-manual -v -s;
 maas_sru_log=`ls ./jenkins/SRU-proposed-cloudinit-sru-manual/*/console.log`

--- a/manual/curtin-cloudinit-sru-20.2.45.txt
+++ b/manual/curtin-cloudinit-sru-20.2.45.txt
@@ -1,0 +1,2095 @@
+Started by user Chad Smith
+Running as SYSTEM
+Building remotely on torkoal in workspace /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru
+[WS-CLEANUP] Deleting project workspace...
+[WS-CLEANUP] Deferred wipeout is used...
+[WS-CLEANUP] Done
+[curtin-cloudinit-sru] $ /bin/bash /tmp/jenkins6473738249339211295.sh
+++ find /srv/images/.vmtest-data -maxdepth 0 -mmin -1080
++ test ''
+++ pgrep -c vmtest-sync-images
++ vsc_count=0
++ rc=1
++ (( rc > 1 ))
++ (( vsc_count == 1 ))
++ (( vsc_count >= 2 ))
++ git clone https://git.launchpad.net/curtin curtin-sync-images
+Cloning into 'curtin-sync-images'...
++ cd curtin-sync-images
++ ./tools/vmtest-sync-images
+2020-06-18 20:11:23,414 - tests.vmtests - INFO - Logfile: /tmp/vmtest-2020-06-18T201123.413714.log .  Working dir: /tmp/vmtest-2020-06-18T201123.413714
+Acquiring an exclusive lock on /srv/images...
+Acquiring an exclusive lock on /srv/images/vmtest-images.lock...
+2020-06-18 20:43:54,534 - tests.vmtests - INFO - Syncing images from http://images.maas.io/ephemeral-v3/daily/streams/v1/index.sjson with filters=['os=ubuntu', 'release~bionic|focal|xenial|eoan', 'ftype~(boot-initrd|boot-kernel|root-tgz|squashfs)', 'arch~amd64|i386']
+=> bionic/amd64/20200618/ga-18.04/generic/boot-initrd [61762198]
+...............................................................................
+=> bionic/amd64/20200618/ga-18.04/generic/boot-kernel [8380064]
+...............................................................................
+=> bionic/amd64/20200618/squashfs [187985920]
+...............................................................................
+
+=> bionic/amd64/20200618/ga-18.04/lowlatency/boot-initrd [61775449]
+...............................................................................
+=> bionic/amd64/20200618/ga-18.04/lowlatency/boot-kernel [8429216]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04/generic/boot-initrd [69911977]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04/generic/boot-kernel [9158912]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04-edge/generic/boot-initrd [68876691]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04-edge/generic/boot-kernel [9371904]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04/lowlatency/boot-initrd [69914948]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04/lowlatency/boot-kernel [9220352]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04-edge/lowlatency/boot-initrd [68879628]
+...............................................................................
+=> bionic/amd64/20200618/hwe-18.04-edge/lowlatency/boot-kernel [9437440]
+...............................................................................
+=> bionic/i386/20200618/ga-18.04/generic/boot-initrd [56079016]
+...............................................................................
+=> bionic/i386/20200618/ga-18.04/generic/boot-kernel [7623488]
+...............................................................................
+=> bionic/i386/20200618/squashfs [189206528]
+...............................................................................
+=> bionic/i386/20200618/ga-18.04/lowlatency/boot-initrd [56082642]
+...............................................................................
+=> bionic/i386/20200618/ga-18.04/lowlatency/boot-kernel [7652448]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04/generic/boot-initrd [63404922]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04/generic/boot-kernel [8289184]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04-edge/generic/boot-initrd [62328635]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04-edge/generic/boot-kernel [8403488]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04/lowlatency/boot-initrd [63405462]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04/lowlatency/boot-kernel [8329920]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04-edge/lowlatency/boot-initrd [62326021]
+...............................................................................
+=> bionic/i386/20200618/hwe-18.04-edge/lowlatency/boot-kernel [8445952]
+...............................................................................
+=> focal/amd64/20200617/ga-20.04/generic/boot-initrd [86224356]
+...............................................................................
+=> focal/amd64/20200617/ga-20.04/generic/boot-kernel [11662080]
+...............................................................................
+=> focal/amd64/20200617/squashfs [367996928]
+...............................................................................
+=> focal/amd64/20200617/ga-20.04/lowlatency/boot-initrd [86231861]
+...............................................................................
+=> focal/amd64/20200617/ga-20.04/lowlatency/boot-kernel [11715328]
+...............................................................................
+2020-06-18 20:57:57,672 - tests.vmtests - INFO - Syncing images from http://images.maas.io/ephemeral-v3/daily/streams/v1/index.sjson with filters=['os=centos', 'release~centos66|centos70', 'ftype~(boot-initrd|boot-kernel|root-tgz|squashfs)', 'arch~amd64|i386']
+[curtin-cloudinit-sru] $ /bin/bash /tmp/jenkins3959018236511511187.sh
+test filter args: " --filter=target_distro=ubuntu --filter=test_type=network"
+Trying: git clone --branch=master https://git.launchpad.net/curtin curtin-14
+Cloning into 'curtin-14'...
+Trying: git fetch upstream --tags
+From https://git.launchpad.net/curtin
+ * [new branch]        19.1          -> upstream/19.1
+ * [new branch]        master        -> upstream/master
+ * [new branch]        ubuntu/artful -> upstream/ubuntu/artful
+ * [new branch]        ubuntu/bionic -> upstream/ubuntu/bionic
+ * [new branch]        ubuntu/cosmic -> upstream/ubuntu/cosmic
+ * [new branch]        ubuntu/devel  -> upstream/ubuntu/devel
+ * [new branch]        ubuntu/disco  -> upstream/ubuntu/disco
+ * [new branch]        ubuntu/eoan   -> upstream/ubuntu/eoan
+ * [new branch]        ubuntu/focal  -> upstream/ubuntu/focal
+ * [new branch]        ubuntu/xenial -> upstream/ubuntu/xenial
+ * [new branch]        ubuntu/zesty  -> upstream/ubuntu/zesty
+2020-06-18 20:58:34,660 - tests.vmtests - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+CURTIN_VMTEST_ADD_REPOS=ppa:cloud-init-dev/proposed
+CURTIN_VMTEST_CURTIN_EXE_VERSION=20.1-10-g14ce7d41
+CURTIN_VMTEST_CURTIN_VERSION=20.1-10-g14ce7d41
+CURTIN_VMTEST_IMAGE_SYNC=0
+CURTIN_VMTEST_ISCSI_PORTAL=10.247.8.15:32092
+CURTIN_VMTEST_KEEP_DATA_FAIL=logs,collect
+CURTIN_VMTEST_KEEP_DATA_PASS=logs,collect
+CURTIN_VMTEST_LOG=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log
+CURTIN_VMTEST_PARALLEL=4
+CURTIN_VMTEST_REUSE_TOPDIR=0
+CURTIN_VMTEST_SHUFFLE_TESTS=1
+CURTIN_VMTEST_SYSTEM_UPGRADE=false
+CURTIN_VMTEST_TAR_DISKS=0
+CURTIN_VMTEST_TOPDIR=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+CURTIN_VMTEST_UPGRADE_PACKAGES=cloud-init
+TGT_IPC_SOCKET=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/tgt.d/socket
+TGT_LOG_D=/var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/tgt.d
+TGT_PID=10340
+TGT_PORTAL=10.247.8.15:32092
+http_proxy=
+https_proxy=
+no_proxy=
+Quering synced ephemeral images/kernels in /srv/images
+======================================================================================
+ Release Codename ImageDate    Arch /SubArch         Path
+--------------------------------------------------------------------------------------
+   16.04   xenial 20200611     amd64/ga-16.04       xenial/amd64/20200611/squashfs
+   16.04   xenial 20200611     amd64/hwe-16.04      xenial/amd64/20200611/squashfs
+   16.04   xenial 20200611     amd64/hwe-16.04-edge xenial/amd64/20200611/squashfs
+   16.04   xenial 20200611     i386 /ga-16.04       xenial/i386/20200611/squashfs
+   16.04   xenial 20200611     i386 /hwe-16.04      xenial/i386/20200611/squashfs
+   16.04   xenial 20200611     i386 /hwe-16.04-edge xenial/i386/20200611/squashfs
+   17.10   artful 20180718     amd64/ga-17.10       artful/amd64/20180718/squashfs
+   17.10   artful 20180718     i386 /ga-17.10       artful/i386/20180718/squashfs
+   18.04   bionic 20200618     amd64/ga-18.04       bionic/amd64/20200618/squashfs
+   18.04   bionic 20200618     amd64/hwe-18.04      bionic/amd64/20200618/squashfs
+   18.04   bionic 20200618     amd64/hwe-18.04-edge bionic/amd64/20200618/squashfs
+   18.04   bionic 20200618     i386 /ga-18.04       bionic/i386/20200618/squashfs
+   18.04   bionic 20200618     i386 /hwe-18.04      bionic/i386/20200618/squashfs
+   18.04   bionic 20200618     i386 /hwe-18.04-edge bionic/i386/20200618/squashfs
+   18.10   cosmic 20190718     amd64/ga-18.10       cosmic/amd64/20190718/squashfs
+   18.10   cosmic 20190718     i386 /ga-18.10       cosmic/i386/20190718/squashfs
+   19.04    disco 20200123     amd64/ga-19.04       disco/amd64/20200123/squashfs
+   19.04    disco 20200123     i386 /ga-19.04       disco/i386/20200123/squashfs
+   19.10     eoan 20190929     i386 /ga-19.10       eoan/i386/20190929/squashfs
+   19.10     eoan 20200611     amd64/ga-19.10       eoan/amd64/20200611/squashfs
+   20.04    focal 20200617     amd64/ga-20.04       focal/amd64/20200617/squashfs
+--------------------------------------------------------------------------------------
+     6.6 centos66 20190701_01  amd64/generic        centos66/amd64/20190701_01/root-tgz
+     7.0 centos70 20190701_01  amd64/generic        centos70/amd64/20190701_01/root-tgz
+======================================================================================
+
+Thu, 18 Jun 2020 20:58:37 +0000: vmtest start: nosetests3 --process-timeout=86400 --processes=4 -vv --nologcapture tests/vmtests/test_network.py:FocalTestNetworkBasic tests/vmtests/test_network_static_routes.py:FocalTestNetworkStaticRoutes tests/vmtests/test_network_ovs.py:FocalTestNetworkOvs tests/vmtests/test_network_ipv6_static.py:XenialTestNetworkIPV6Static tests/vmtests/test_network_vlan.py:BionicTestNetworkVlan tests/vmtests/test_network_alias.py:XenialTestNetworkAlias tests/vmtests/test_network.py:EoanTestNetworkBasic tests/vmtests/test_network_ipv6_vlan.py:BionicTestNetworkIPV6Vlan tests/vmtests/test_network_vlan.py:EoanTestNetworkVlan tests/vmtests/test_network_ovs.py:BionicTestNetworkOvs tests/vmtests/test_network_static.py:EoanTestNetworkStatic tests/vmtests/test_network_static.py:BionicTestNetworkStatic tests/vmtests/test_network_disabled.py:FocalCurtinDisableNetworkRendering tests/vmtests/test_network_bridging.py:FocalTestBridging tests/vmtests/test_network_mtu.py:FocalTestNetworkMtu tests/vmtests/test_network_disabled.py:FocalCurtinDisableCloudInitNetworkingVersion1 tests/vmtests/test_network_mtu.py:EoanTestNetworkMtu tests/vmtests/test_network_static_routes.py:BionicTestNetworkStaticRoutes tests/vmtests/test_network_ipv6_enisource.py:XenialTestNetworkIPV6ENISource tests/vmtests/test_network_bonding.py:BionicTestBonding tests/vmtests/test_network_ipv6_vlan.py:EoanTestNetworkIPV6Vlan tests/vmtests/test_network_static_routes.py:EoanTestNetworkStaticRoutes tests/vmtests/test_network_bridging.py:EoanTestBridging tests/vmtests/test_network_bridging.py:XenialTestBridgingV2 tests/vmtests/test_network_ipv6_static.py:FocalTestNetworkIPV6Static tests/vmtests/test_network_vlan.py:XenialTestNetworkVlan tests/vmtests/test_network_alias.py:FocalTestNetworkAlias tests/vmtests/test_network_bonding.py:EoanTestBonding tests/vmtests/test_network_bonding.py:XenialTestBonding tests/vmtests/test_network.py:BionicTestNetworkBasic tests/vmtests/test_network_bonding.py:FocalTestBonding tests/vmtests/test_network_ipv6_vlan.py:XenialTestNetworkIPV6Vlan tests/vmtests/test_network_vlan.py:FocalTestNetworkVlan tests/vmtests/test_network.py:XenialTestNetworkBasic tests/vmtests/test_network_static.py:XenialTestNetworkStatic tests/vmtests/test_network_ipv6_static.py:BionicTestNetworkIPV6Static tests/vmtests/test_network_enisource.py:XenialTestNetworkENISource tests/vmtests/test_network_static_routes.py:XenialTestNetworkStaticRoutes tests/vmtests/test_network_ipv6.py:XenialTestNetworkIPV6 tests/vmtests/test_network_ipv6.py:EoanTestNetworkIPV6 tests/vmtests/test_network_ovs.py:EoanTestNetworkOvs tests/vmtests/test_network_ipv6_static.py:EoanTestNetworkIPV6Static tests/vmtests/test_network_alias.py:EoanTestNetworkAlias tests/vmtests/test_network_static.py:FocalTestNetworkStatic tests/vmtests/test_network_mtu.py:TestNetworkMtu tests/vmtests/test_network_bridging.py:BionicTestBridging tests/vmtests/test_network_disabled.py:FocalCurtinDisableCloudInitNetworking tests/vmtests/test_network_ipv6_vlan.py:FocalTestNetworkIPV6Vlan tests/vmtests/test_network_mtu.py:BionicTestNetworkMtu tests/vmtests/test_network_ipv6.py:BionicTestNetworkIPV6 tests/vmtests/test_network_alias.py:BionicTestNetworkAlias
+nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
+2020-06-18 20:58:38,172 - vmtests - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 20:58:38,294 - FocalTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 20:58:38,302 - EoanTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 20:58:38,312 - BionicTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 20:58:38,319 - XenialTestNetworkBasic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 20:58:38,330 - FocalTestNetworkBasic - INFO - Starting setup for testclass: FocalTestNetworkBasic (ubuntu/focal -> ubuntu/focal)
+2020-06-18 20:58:38,330 - EoanTestNetworkBasic - INFO - Starting setup for testclass: EoanTestNetworkBasic (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 20:58:38,330 - BionicTestNetworkBasic - INFO - Starting setup for testclass: BionicTestNetworkBasic (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 20:58:38,330 - XenialTestNetworkBasic - INFO - Starting setup for testclass: XenialTestNetworkBasic (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 20:58:38,410 - EoanTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkBasic
+2020-06-18 20:58:38,411 - EoanTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,411 - BionicTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkBasic
+2020-06-18 20:58:38,412 - BionicTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,421 - XenialTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkBasic
+2020-06-18 20:58:38,422 - XenialTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,422 - FocalTestNetworkBasic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkBasic
+2020-06-18 20:58:38,423 - EoanTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 20:58:38,423 - FocalTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,423 - EoanTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 20:58:38,423 - BionicTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 20:58:38,423 - BionicTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 20:58:38,433 - XenialTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 20:58:38,433 - XenialTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 20:58:38,433 - FocalTestNetworkBasic - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 20:58:38,433 - FocalTestNetworkBasic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 20:58:38,435 - EoanTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,435 - BionicTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,439 - EoanTestNetworkBasic - INFO - disk_serials: []
+2020-06-18 20:58:38,440 - EoanTestNetworkBasic - INFO - nvme_serials: []
+2020-06-18 20:58:38,440 - EoanTestNetworkBasic - INFO - nvme disks: []
+2020-06-18 20:58:38,440 - BionicTestNetworkBasic - INFO - disk_serials: []
+2020-06-18 20:58:38,440 - BionicTestNetworkBasic - INFO - nvme_serials: []
+2020-06-18 20:58:38,440 - BionicTestNetworkBasic - INFO - nvme disks: []
+2020-06-18 20:58:38,445 - FocalTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,447 - XenialTestNetworkBasic - INFO - Loading testcase config file: examples/tests/basic_network.yaml
+2020-06-18 20:58:38,450 - FocalTestNetworkBasic - INFO - disk_serials: []
+2020-06-18 20:58:38,450 - FocalTestNetworkBasic - INFO - nvme_serials: []
+2020-06-18 20:58:38,450 - EoanTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 20:58:38,451 - FocalTestNetworkBasic - INFO - nvme disks: []
+2020-06-18 20:58:38,451 - EoanTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 20:58:38,452 - BionicTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 20:58:38,453 - BionicTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 20:58:38,453 - XenialTestNetworkBasic - INFO - disk_serials: []
+2020-06-18 20:58:38,453 - XenialTestNetworkBasic - INFO - nvme_serials: []
+2020-06-18 20:58:38,453 - XenialTestNetworkBasic - INFO - nvme disks: []
+2020-06-18 20:58:38,458 - EoanTestNetworkBasic - INFO - Using root_disk: []
+2020-06-18 20:58:38,458 - EoanTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkBasic/logs/install-serial.log
+2020-06-18 20:58:38,460 - BionicTestNetworkBasic - INFO - Using root_disk: []
+2020-06-18 20:58:38,461 - BionicTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkBasic/logs/install-serial.log
+2020-06-18 20:58:38,462 - FocalTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 20:58:38,462 - FocalTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 20:58:38,466 - XenialTestNetworkBasic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 20:58:38,466 - XenialTestNetworkBasic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 20:58:38,470 - FocalTestNetworkBasic - INFO - Using root_disk: []
+2020-06-18 20:58:38,470 - FocalTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkBasic/logs/install-serial.log
+2020-06-18 20:58:38,473 - XenialTestNetworkBasic - INFO - Using root_disk: []
+2020-06-18 20:58:38,473 - XenialTestNetworkBasic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkBasic/logs/install-serial.log
+2020-06-18 21:00:56,401 - XenialTestNetworkBasic - INFO - XenialTestNetworkBasic[install]: boot took 137.93 seconds. returned True
+2020-06-18 21:00:56,725 - XenialTestNetworkBasic - INFO - Install OK
+2020-06-18 21:00:56,725 - XenialTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkBasic/logs/boot-serial.log
+2020-06-18 21:01:19,096 - BionicTestNetworkBasic - INFO - BionicTestNetworkBasic[install]: boot took 160.64 seconds. returned True
+2020-06-18 21:01:19,598 - BionicTestNetworkBasic - INFO - Install OK
+2020-06-18 21:01:19,598 - BionicTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkBasic/logs/boot-serial.log
+2020-06-18 21:01:28,901 - XenialTestNetworkBasic - INFO - XenialTestNetworkBasic[first_boot]: boot took 32.18 seconds. returned True
+2020-06-18 21:01:28,956 - XenialTestNetworkBasic - INFO - XenialTestNetworkBasic: setUpClass finished. took 170.63 seconds. Running testcases.
+get_test_files (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.XenialTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.XenialTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.XenialTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.XenialTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.XenialTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_output_files_exist (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.XenialTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.XenialTestNetworkBasic) ... SKIP: This test does not use storage config.
+2020-06-18 21:01:29,318 - FocalTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:01:29,319 - FocalTestNetworkStaticRoutes - INFO - Starting setup for testclass: FocalTestNetworkStaticRoutes (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:01:29,468 - FocalTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStaticRoutes
+2020-06-18 21:01:29,468 - FocalTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:01:29,476 - FocalTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:01:29,476 - FocalTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:01:29,481 - FocalTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:01:29,485 - FocalTestNetworkStaticRoutes - INFO - disk_serials: []
+2020-06-18 21:01:29,485 - FocalTestNetworkStaticRoutes - INFO - nvme_serials: []
+2020-06-18 21:01:29,485 - FocalTestNetworkStaticRoutes - INFO - nvme disks: []
+2020-06-18 21:01:29,496 - FocalTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:01:29,497 - FocalTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:01:29,503 - FocalTestNetworkStaticRoutes - INFO - Using root_disk: []
+2020-06-18 21:01:29,503 - FocalTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStaticRoutes/logs/install-serial.log
+2020-06-18 21:01:39,589 - EoanTestNetworkBasic - INFO - EoanTestNetworkBasic[install]: boot took 181.13 seconds. returned True
+2020-06-18 21:01:39,833 - EoanTestNetworkBasic - INFO - Install OK
+2020-06-18 21:01:39,833 - EoanTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkBasic/logs/boot-serial.log
+2020-06-18 21:01:48,409 - FocalTestNetworkBasic - INFO - FocalTestNetworkBasic[install]: boot took 189.94 seconds. returned True
+2020-06-18 21:01:48,878 - FocalTestNetworkBasic - INFO - Install OK
+2020-06-18 21:01:48,879 - FocalTestNetworkBasic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkBasic/logs/boot-serial.log
+2020-06-18 21:02:01,317 - BionicTestNetworkBasic - INFO - BionicTestNetworkBasic[first_boot]: boot took 41.72 seconds. returned True
+2020-06-18 21:02:01,376 - BionicTestNetworkBasic - INFO - BionicTestNetworkBasic: setUpClass finished. took 203.05 seconds. Running testcases.
+get_test_files (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.BionicTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.BionicTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_output_files_exist (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.BionicTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.BionicTestNetworkBasic) ... SKIP: This test does not use storage config.
+2020-06-18 21:02:01,733 - BionicTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:02:01,733 - BionicTestNetworkStaticRoutes - INFO - Starting setup for testclass: BionicTestNetworkStaticRoutes (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:02:02,299 - BionicTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStaticRoutes
+2020-06-18 21:02:02,300 - BionicTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:02:02,307 - BionicTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:02:02,307 - BionicTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:02:02,312 - BionicTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:02:02,314 - BionicTestNetworkStaticRoutes - INFO - disk_serials: []
+2020-06-18 21:02:02,315 - BionicTestNetworkStaticRoutes - INFO - nvme_serials: []
+2020-06-18 21:02:02,315 - BionicTestNetworkStaticRoutes - INFO - nvme disks: []
+2020-06-18 21:02:02,325 - BionicTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:02:02,325 - BionicTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:02:02,331 - BionicTestNetworkStaticRoutes - INFO - Using root_disk: []
+2020-06-18 21:02:02,332 - BionicTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStaticRoutes/logs/install-serial.log
+2020-06-18 21:02:22,963 - EoanTestNetworkBasic - INFO - EoanTestNetworkBasic[first_boot]: boot took 43.13 seconds. returned True
+2020-06-18 21:02:23,022 - EoanTestNetworkBasic - INFO - EoanTestNetworkBasic: setUpClass finished. took 224.69 seconds. Running testcases.
+get_test_files (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.EoanTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.EoanTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.EoanTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.EoanTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.EoanTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.EoanTestNetworkBasic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.EoanTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.EoanTestNetworkBasic) ... SKIP: This test does not use storage config.
+2020-06-18 21:02:23,414 - EoanTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:02:23,415 - EoanTestNetworkStaticRoutes - INFO - Starting setup for testclass: EoanTestNetworkStaticRoutes (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:02:24,024 - EoanTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkStaticRoutes
+2020-06-18 21:02:24,024 - EoanTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:02:24,032 - EoanTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:02:24,032 - EoanTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:02:24,038 - EoanTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:02:24,041 - EoanTestNetworkStaticRoutes - INFO - disk_serials: []
+2020-06-18 21:02:24,041 - EoanTestNetworkStaticRoutes - INFO - nvme_serials: []
+2020-06-18 21:02:24,041 - EoanTestNetworkStaticRoutes - INFO - nvme disks: []
+2020-06-18 21:02:24,051 - EoanTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:02:24,052 - EoanTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:02:24,058 - EoanTestNetworkStaticRoutes - INFO - Using root_disk: []
+2020-06-18 21:02:24,058 - EoanTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkStaticRoutes/logs/install-serial.log
+2020-06-18 21:02:32,149 - FocalTestNetworkBasic - INFO - FocalTestNetworkBasic[first_boot]: boot took 43.27 seconds. returned True
+2020-06-18 21:02:32,208 - FocalTestNetworkBasic - INFO - FocalTestNetworkBasic: setUpClass finished. took 233.88 seconds. Running testcases.
+get_test_files (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_clear_holders_ran (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: passthrough available on <class 'vmtests.test_network.FocalTestNetworkBasic'>
+test_cloudinit_network_passthrough (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_dname (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_dname_rules (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_etc_network_interfaces (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: <class 'vmtests.test_network.FocalTestNetworkBasic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_fstab (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_ip_output (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_kernel_img_conf (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_reporting_data (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_static_routes (vmtests.test_network.FocalTestNetworkBasic) ... ok
+test_swaps_used (vmtests.test_network.FocalTestNetworkBasic) ... SKIP: This test does not use storage config.
+2020-06-18 21:02:32,605 - XenialTestNetworkStaticRoutes - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:02:32,605 - XenialTestNetworkStaticRoutes - INFO - Starting setup for testclass: XenialTestNetworkStaticRoutes (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:02:33,210 - XenialTestNetworkStaticRoutes - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkStaticRoutes
+2020-06-18 21:02:33,211 - XenialTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:02:33,219 - XenialTestNetworkStaticRoutes - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:02:33,219 - XenialTestNetworkStaticRoutes - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:02:33,224 - XenialTestNetworkStaticRoutes - INFO - Loading testcase config file: examples/tests/network_static_routes.yaml
+2020-06-18 21:02:33,228 - XenialTestNetworkStaticRoutes - INFO - disk_serials: []
+2020-06-18 21:02:33,228 - XenialTestNetworkStaticRoutes - INFO - nvme_serials: []
+2020-06-18 21:02:33,228 - XenialTestNetworkStaticRoutes - INFO - nvme disks: []
+2020-06-18 21:02:33,238 - XenialTestNetworkStaticRoutes - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:02:33,239 - XenialTestNetworkStaticRoutes - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:02:33,245 - XenialTestNetworkStaticRoutes - INFO - Using root_disk: []
+2020-06-18 21:02:33,245 - XenialTestNetworkStaticRoutes - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkStaticRoutes/logs/install-serial.log
+2020-06-18 21:04:38,909 - FocalTestNetworkStaticRoutes - INFO - FocalTestNetworkStaticRoutes[install]: boot took 189.40 seconds. returned True
+2020-06-18 21:04:39,285 - FocalTestNetworkStaticRoutes - INFO - Install OK
+2020-06-18 21:04:39,285 - FocalTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStaticRoutes/logs/boot-serial.log
+2020-06-18 21:04:39,462 - BionicTestNetworkStaticRoutes - INFO - BionicTestNetworkStaticRoutes[install]: boot took 157.13 seconds. returned True
+2020-06-18 21:04:39,945 - BionicTestNetworkStaticRoutes - INFO - Install OK
+2020-06-18 21:04:39,946 - BionicTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStaticRoutes/logs/boot-serial.log
+2020-06-18 21:04:47,125 - XenialTestNetworkStaticRoutes - INFO - XenialTestNetworkStaticRoutes[install]: boot took 133.88 seconds. returned True
+2020-06-18 21:04:47,427 - XenialTestNetworkStaticRoutes - INFO - Install OK
+2020-06-18 21:04:47,427 - XenialTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkStaticRoutes/logs/boot-serial.log
+2020-06-18 21:05:13,058 - BionicTestNetworkStaticRoutes - INFO - BionicTestNetworkStaticRoutes[first_boot]: boot took 33.11 seconds. returned True
+2020-06-18 21:05:13,116 - BionicTestNetworkStaticRoutes - INFO - BionicTestNetworkStaticRoutes: setUpClass finished. took 191.38 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_output_files_exist (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.BionicTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+2020-06-18 21:05:13,459 - FocalTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:05:13,459 - FocalTestNetworkOvs - INFO - Starting setup for testclass: FocalTestNetworkOvs (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:05:14,020 - FocalTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkOvs
+2020-06-18 21:05:14,020 - FocalTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2020-06-18 21:05:14,030 - FocalTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:05:14,030 - FocalTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:05:14,035 - FocalTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2020-06-18 21:05:14,039 - FocalTestNetworkOvs - INFO - disk_serials: []
+2020-06-18 21:05:14,040 - FocalTestNetworkOvs - INFO - nvme_serials: []
+2020-06-18 21:05:14,040 - FocalTestNetworkOvs - INFO - nvme disks: []
+2020-06-18 21:05:14,050 - FocalTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:05:14,051 - FocalTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:05:14,057 - FocalTestNetworkOvs - INFO - Using root_disk: []
+2020-06-18 21:05:14,058 - FocalTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkOvs/logs/install-serial.log
+2020-06-18 21:05:14,305 - FocalTestNetworkStaticRoutes - INFO - FocalTestNetworkStaticRoutes[first_boot]: boot took 35.02 seconds. returned True
+2020-06-18 21:05:14,361 - FocalTestNetworkStaticRoutes - INFO - FocalTestNetworkStaticRoutes: setUpClass finished. took 225.04 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.FocalTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+2020-06-18 21:05:14,769 - BionicTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:05:14,770 - BionicTestNetworkOvs - INFO - Starting setup for testclass: BionicTestNetworkOvs (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:05:15,396 - BionicTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkOvs
+2020-06-18 21:05:15,397 - BionicTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2020-06-18 21:05:15,406 - BionicTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:05:15,406 - BionicTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:05:15,411 - BionicTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2020-06-18 21:05:15,416 - BionicTestNetworkOvs - INFO - disk_serials: []
+2020-06-18 21:05:15,416 - BionicTestNetworkOvs - INFO - nvme_serials: []
+2020-06-18 21:05:15,416 - BionicTestNetworkOvs - INFO - nvme disks: []
+2020-06-18 21:05:15,426 - BionicTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:05:15,427 - BionicTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:05:15,433 - BionicTestNetworkOvs - INFO - Using root_disk: []
+2020-06-18 21:05:15,433 - BionicTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkOvs/logs/install-serial.log
+2020-06-18 21:05:17,166 - XenialTestNetworkStaticRoutes - INFO - XenialTestNetworkStaticRoutes[first_boot]: boot took 29.74 seconds. returned True
+2020-06-18 21:05:17,222 - XenialTestNetworkStaticRoutes - INFO - XenialTestNetworkStaticRoutes: setUpClass finished. took 164.62 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_output_files_exist (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.XenialTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+2020-06-18 21:05:17,533 - EoanTestNetworkOvs - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:05:17,533 - EoanTestNetworkOvs - INFO - Starting setup for testclass: EoanTestNetworkOvs (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:05:17,687 - EoanTestNetworkOvs - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkOvs
+2020-06-18 21:05:17,687 - EoanTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2020-06-18 21:05:17,696 - EoanTestNetworkOvs - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:05:17,696 - EoanTestNetworkOvs - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:05:17,701 - EoanTestNetworkOvs - INFO - Loading testcase config file: examples/tests/network_v2_ovs.yaml
+2020-06-18 21:05:17,706 - EoanTestNetworkOvs - INFO - disk_serials: []
+2020-06-18 21:05:17,706 - EoanTestNetworkOvs - INFO - nvme_serials: []
+2020-06-18 21:05:17,706 - EoanTestNetworkOvs - INFO - nvme disks: []
+2020-06-18 21:05:17,717 - EoanTestNetworkOvs - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:05:17,717 - EoanTestNetworkOvs - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:05:17,724 - EoanTestNetworkOvs - INFO - Using root_disk: []
+2020-06-18 21:05:17,724 - EoanTestNetworkOvs - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkOvs/logs/install-serial.log
+2020-06-18 21:05:23,720 - EoanTestNetworkStaticRoutes - INFO - EoanTestNetworkStaticRoutes[install]: boot took 179.66 seconds. returned True
+2020-06-18 21:05:23,936 - EoanTestNetworkStaticRoutes - INFO - Install OK
+2020-06-18 21:05:23,936 - EoanTestNetworkStaticRoutes - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkStaticRoutes/logs/boot-serial.log
+2020-06-18 21:05:58,377 - EoanTestNetworkStaticRoutes - INFO - EoanTestNetworkStaticRoutes[first_boot]: boot took 34.44 seconds. returned True
+2020-06-18 21:05:58,438 - EoanTestNetworkStaticRoutes - INFO - EoanTestNetworkStaticRoutes: setUpClass finished. took 215.02 seconds. Running testcases.
+get_test_files (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_clear_holders_ran (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... SKIP: passthrough available on <class 'vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes'>
+test_cloudinit_network_passthrough (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_dname (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_dname_rules (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_etc_network_interfaces (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... SKIP: <class 'vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_fstab (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_ip_output (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_kernel_img_conf (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_reporting_data (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_static_routes (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... ok
+test_swaps_used (vmtests.test_network_static_routes.EoanTestNetworkStaticRoutes) ... SKIP: This test does not use storage config.
+2020-06-18 21:05:58,823 - XenialTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:05:58,823 - XenialTestNetworkIPV6Static - INFO - Starting setup for testclass: XenialTestNetworkIPV6Static (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:05:59,427 - XenialTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6Static
+2020-06-18 21:05:59,427 - XenialTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:05:59,435 - XenialTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:05:59,435 - XenialTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:05:59,440 - XenialTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:05:59,443 - XenialTestNetworkIPV6Static - INFO - disk_serials: []
+2020-06-18 21:05:59,443 - XenialTestNetworkIPV6Static - INFO - nvme_serials: []
+2020-06-18 21:05:59,443 - XenialTestNetworkIPV6Static - INFO - nvme disks: []
+2020-06-18 21:05:59,454 - XenialTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:05:59,454 - XenialTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:05:59,461 - XenialTestNetworkIPV6Static - INFO - Using root_disk: []
+2020-06-18 21:05:59,461 - XenialTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6Static/logs/install-serial.log
+2020-06-18 21:08:00,176 - BionicTestNetworkOvs - INFO - BionicTestNetworkOvs[install]: boot took 164.74 seconds. returned True
+2020-06-18 21:08:00,681 - BionicTestNetworkOvs - INFO - Install OK
+2020-06-18 21:08:00,681 - BionicTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkOvs/logs/boot-serial.log
+2020-06-18 21:08:13,185 - XenialTestNetworkIPV6Static - INFO - XenialTestNetworkIPV6Static[install]: boot took 133.72 seconds. returned True
+2020-06-18 21:08:13,464 - XenialTestNetworkIPV6Static - INFO - Install OK
+2020-06-18 21:08:13,464 - XenialTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6Static/logs/boot-serial.log
+2020-06-18 21:08:22,769 - EoanTestNetworkOvs - INFO - EoanTestNetworkOvs[install]: boot took 185.04 seconds. returned True
+2020-06-18 21:08:22,809 - EoanTestNetworkOvs - INFO - Install OK
+2020-06-18 21:08:22,809 - EoanTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkOvs/logs/boot-serial.log
+2020-06-18 21:08:29,684 - FocalTestNetworkOvs - INFO - FocalTestNetworkOvs[install]: boot took 195.63 seconds. returned True
+2020-06-18 21:08:30,177 - FocalTestNetworkOvs - INFO - Install OK
+2020-06-18 21:08:30,177 - FocalTestNetworkOvs - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkOvs/logs/boot-serial.log
+2020-06-18 21:08:32,726 - BionicTestNetworkOvs - INFO - BionicTestNetworkOvs[first_boot]: boot took 32.04 seconds. returned True
+2020-06-18 21:08:32,789 - BionicTestNetworkOvs - INFO - BionicTestNetworkOvs: setUpClass finished. took 198.02 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.BionicTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_openvswitch_package_status (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.BionicTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.BionicTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.BionicTestNetworkOvs) ... SKIP: This test does not use storage config.
+2020-06-18 21:08:33,140 - FocalTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:08:33,140 - FocalTestNetworkIPV6Static - INFO - Starting setup for testclass: FocalTestNetworkIPV6Static (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:08:33,711 - FocalTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Static
+2020-06-18 21:08:33,712 - FocalTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:08:33,719 - FocalTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:08:33,719 - FocalTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:08:33,724 - FocalTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:08:33,727 - FocalTestNetworkIPV6Static - INFO - disk_serials: []
+2020-06-18 21:08:33,727 - FocalTestNetworkIPV6Static - INFO - nvme_serials: []
+2020-06-18 21:08:33,727 - FocalTestNetworkIPV6Static - INFO - nvme disks: []
+2020-06-18 21:08:33,738 - FocalTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:08:33,738 - FocalTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:08:33,745 - FocalTestNetworkIPV6Static - INFO - Using root_disk: []
+2020-06-18 21:08:33,745 - FocalTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Static/logs/install-serial.log
+2020-06-18 21:08:45,097 - XenialTestNetworkIPV6Static - INFO - XenialTestNetworkIPV6Static[first_boot]: boot took 31.63 seconds. returned True
+2020-06-18 21:08:45,150 - XenialTestNetworkIPV6Static - INFO - XenialTestNetworkIPV6Static: setUpClass finished. took 166.33 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.XenialTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+2020-06-18 21:08:45,437 - BionicTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:08:45,437 - BionicTestNetworkIPV6Static - INFO - Starting setup for testclass: BionicTestNetworkIPV6Static (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:08:45,582 - BionicTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Static
+2020-06-18 21:08:45,582 - BionicTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:08:45,589 - BionicTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:08:45,589 - BionicTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:08:45,594 - BionicTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:08:45,596 - BionicTestNetworkIPV6Static - INFO - disk_serials: []
+2020-06-18 21:08:45,597 - BionicTestNetworkIPV6Static - INFO - nvme_serials: []
+2020-06-18 21:08:45,597 - BionicTestNetworkIPV6Static - INFO - nvme disks: []
+2020-06-18 21:08:45,606 - BionicTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:08:45,606 - BionicTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:08:45,612 - BionicTestNetworkIPV6Static - INFO - Using root_disk: []
+2020-06-18 21:08:45,613 - BionicTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Static/logs/install-serial.log
+2020-06-18 21:08:56,241 - EoanTestNetworkOvs - INFO - EoanTestNetworkOvs[first_boot]: boot took 33.43 seconds. returned True
+2020-06-18 21:08:56,295 - EoanTestNetworkOvs - INFO - EoanTestNetworkOvs: setUpClass finished. took 218.76 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.EoanTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.EoanTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.EoanTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.EoanTestNetworkOvs) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_openvswitch_package_status (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.EoanTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.EoanTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.EoanTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.EoanTestNetworkOvs) ... SKIP: This test does not use storage config.
+2020-06-18 21:08:56,646 - EoanTestNetworkIPV6Static - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:08:56,646 - EoanTestNetworkIPV6Static - INFO - Starting setup for testclass: EoanTestNetworkIPV6Static (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:08:57,250 - EoanTestNetworkIPV6Static - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6Static
+2020-06-18 21:08:57,250 - EoanTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:08:57,258 - EoanTestNetworkIPV6Static - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:08:57,258 - EoanTestNetworkIPV6Static - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:08:57,263 - EoanTestNetworkIPV6Static - INFO - Loading testcase config file: examples/tests/basic_network_static_ipv6.yaml
+2020-06-18 21:08:57,266 - EoanTestNetworkIPV6Static - INFO - disk_serials: []
+2020-06-18 21:08:57,266 - EoanTestNetworkIPV6Static - INFO - nvme_serials: []
+2020-06-18 21:08:57,266 - EoanTestNetworkIPV6Static - INFO - nvme disks: []
+2020-06-18 21:08:57,276 - EoanTestNetworkIPV6Static - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:08:57,277 - EoanTestNetworkIPV6Static - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:08:57,283 - EoanTestNetworkIPV6Static - INFO - Using root_disk: []
+2020-06-18 21:08:57,283 - EoanTestNetworkIPV6Static - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6Static/logs/install-serial.log
+2020-06-18 21:09:02,997 - FocalTestNetworkOvs - INFO - FocalTestNetworkOvs[first_boot]: boot took 32.82 seconds. returned True
+2020-06-18 21:09:03,057 - FocalTestNetworkOvs - INFO - FocalTestNetworkOvs: setUpClass finished. took 229.60 seconds. Running testcases.
+get_test_files (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_bridge_params (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_clear_holders_ran (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: passthrough available on <class 'vmtests.test_network_ovs.FocalTestNetworkOvs'>
+test_cloudinit_network_passthrough (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_dname (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_dname_rules (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_etc_network_interfaces (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_etc_resolvconf (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_fstab (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_ip_output (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_kernel_img_conf (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_openvswitch_package_status (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_output_files_exist (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_reporting_data (vmtests.test_network_ovs.FocalTestNetworkOvs) ... ok
+test_static_routes (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_ovs.FocalTestNetworkOvs'>
+test_swaps_used (vmtests.test_network_ovs.FocalTestNetworkOvs) ... SKIP: This test does not use storage config.
+2020-06-18 21:09:03,447 - BionicTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:09:03,447 - BionicTestNetworkVlan - INFO - Starting setup for testclass: BionicTestNetworkVlan (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:09:04,082 - BionicTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkVlan
+2020-06-18 21:09:04,083 - BionicTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:09:04,098 - BionicTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:09:04,098 - BionicTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:09:04,140 - BionicTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:09:04,151 - BionicTestNetworkVlan - INFO - disk_serials: []
+2020-06-18 21:09:04,151 - BionicTestNetworkVlan - INFO - nvme_serials: []
+2020-06-18 21:09:04,151 - BionicTestNetworkVlan - INFO - nvme disks: []
+2020-06-18 21:09:04,162 - BionicTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:09:04,162 - BionicTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:09:04,169 - BionicTestNetworkVlan - INFO - Using root_disk: []
+2020-06-18 21:09:04,169 - BionicTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkVlan/logs/install-serial.log
+2020-06-18 21:11:22,857 - BionicTestNetworkIPV6Static - INFO - BionicTestNetworkIPV6Static[install]: boot took 157.24 seconds. returned True
+2020-06-18 21:11:23,334 - BionicTestNetworkIPV6Static - INFO - Install OK
+2020-06-18 21:11:23,334 - BionicTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Static/logs/boot-serial.log
+2020-06-18 21:11:43,200 - FocalTestNetworkIPV6Static - INFO - FocalTestNetworkIPV6Static[install]: boot took 189.46 seconds. returned True
+2020-06-18 21:11:43,641 - FocalTestNetworkIPV6Static - INFO - Install OK
+2020-06-18 21:11:43,642 - FocalTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Static/logs/boot-serial.log
+2020-06-18 21:11:44,009 - BionicTestNetworkVlan - INFO - BionicTestNetworkVlan[install]: boot took 159.84 seconds. returned True
+2020-06-18 21:11:44,062 - BionicTestNetworkVlan - INFO - Install OK
+2020-06-18 21:11:44,062 - BionicTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkVlan/logs/boot-serial.log
+2020-06-18 21:11:57,428 - EoanTestNetworkIPV6Static - INFO - EoanTestNetworkIPV6Static[install]: boot took 180.14 seconds. returned True
+2020-06-18 21:11:57,653 - EoanTestNetworkIPV6Static - INFO - Install OK
+2020-06-18 21:11:57,654 - EoanTestNetworkIPV6Static - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6Static/logs/boot-serial.log
+2020-06-18 21:12:06,409 - BionicTestNetworkIPV6Static - INFO - BionicTestNetworkIPV6Static[first_boot]: boot took 43.08 seconds. returned True
+2020-06-18 21:12:06,483 - BionicTestNetworkIPV6Static - INFO - BionicTestNetworkIPV6Static: setUpClass finished. took 201.05 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.BionicTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+2020-06-18 21:12:06,800 - EoanTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:12:06,800 - EoanTestNetworkVlan - INFO - Starting setup for testclass: EoanTestNetworkVlan (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:12:07,357 - EoanTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkVlan
+2020-06-18 21:12:07,358 - EoanTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:12:07,372 - EoanTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:12:07,372 - EoanTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:12:07,408 - EoanTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:12:07,417 - EoanTestNetworkVlan - INFO - disk_serials: []
+2020-06-18 21:12:07,417 - EoanTestNetworkVlan - INFO - nvme_serials: []
+2020-06-18 21:12:07,417 - EoanTestNetworkVlan - INFO - nvme disks: []
+2020-06-18 21:12:07,427 - EoanTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:12:07,427 - EoanTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:12:07,433 - EoanTestNetworkVlan - INFO - Using root_disk: []
+2020-06-18 21:12:07,433 - EoanTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkVlan/logs/install-serial.log
+2020-06-18 21:12:26,861 - BionicTestNetworkVlan - INFO - BionicTestNetworkVlan[first_boot]: boot took 42.80 seconds. returned True
+2020-06-18 21:12:26,920 - BionicTestNetworkVlan - INFO - BionicTestNetworkVlan: setUpClass finished. took 203.47 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.BionicTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.BionicTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_output_files_exist (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_vlan.BionicTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.BionicTestNetworkVlan) ... SKIP: release 'bionic' does not need the vlan package
+2020-06-18 21:12:27,339 - XenialTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:12:27,339 - XenialTestNetworkVlan - INFO - Starting setup for testclass: XenialTestNetworkVlan (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:12:27,920 - XenialTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkVlan
+2020-06-18 21:12:27,921 - XenialTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:12:27,936 - XenialTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:12:27,936 - XenialTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:12:27,978 - XenialTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:12:27,988 - XenialTestNetworkVlan - INFO - disk_serials: []
+2020-06-18 21:12:27,988 - XenialTestNetworkVlan - INFO - nvme_serials: []
+2020-06-18 21:12:27,988 - XenialTestNetworkVlan - INFO - nvme disks: []
+2020-06-18 21:12:27,999 - XenialTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:12:27,999 - XenialTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:12:28,006 - XenialTestNetworkVlan - INFO - Using root_disk: []
+2020-06-18 21:12:28,006 - XenialTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkVlan/logs/install-serial.log
+2020-06-18 21:12:42,886 - FocalTestNetworkIPV6Static - INFO - FocalTestNetworkIPV6Static[first_boot]: boot took 59.24 seconds. returned True
+2020-06-18 21:12:42,946 - FocalTestNetworkIPV6Static - INFO - FocalTestNetworkIPV6Static: setUpClass finished. took 249.81 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.FocalTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+2020-06-18 21:12:43,349 - FocalTestNetworkVlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:12:43,349 - FocalTestNetworkVlan - INFO - Starting setup for testclass: FocalTestNetworkVlan (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:12:44,042 - FocalTestNetworkVlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkVlan
+2020-06-18 21:12:44,043 - FocalTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:12:44,058 - FocalTestNetworkVlan - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:12:44,058 - FocalTestNetworkVlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:12:44,099 - FocalTestNetworkVlan - INFO - Loading testcase config file: examples/tests/vlan_network.yaml
+2020-06-18 21:12:44,109 - FocalTestNetworkVlan - INFO - disk_serials: []
+2020-06-18 21:12:44,109 - FocalTestNetworkVlan - INFO - nvme_serials: []
+2020-06-18 21:12:44,109 - FocalTestNetworkVlan - INFO - nvme disks: []
+2020-06-18 21:12:44,120 - FocalTestNetworkVlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:12:44,120 - FocalTestNetworkVlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:12:44,127 - FocalTestNetworkVlan - INFO - Using root_disk: []
+2020-06-18 21:12:44,127 - FocalTestNetworkVlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkVlan/logs/install-serial.log
+2020-06-18 21:12:50,482 - EoanTestNetworkIPV6Static - INFO - EoanTestNetworkIPV6Static[first_boot]: boot took 52.83 seconds. returned True
+2020-06-18 21:12:50,541 - EoanTestNetworkIPV6Static - INFO - EoanTestNetworkIPV6Static: setUpClass finished. took 233.90 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_dname (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_dname_rules (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... SKIP: <class 'vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_fstab (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_ip_output (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_reporting_data (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_static_routes (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... ok
+test_swaps_used (vmtests.test_network_ipv6_static.EoanTestNetworkIPV6Static) ... SKIP: This test does not use storage config.
+2020-06-18 21:12:50,913 - XenialTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:12:50,914 - XenialTestNetworkAlias - INFO - Starting setup for testclass: XenialTestNetworkAlias (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:12:51,545 - XenialTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkAlias
+2020-06-18 21:12:51,545 - XenialTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:12:51,567 - XenialTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:12:51,567 - XenialTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:12:51,618 - XenialTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:12:51,635 - XenialTestNetworkAlias - INFO - disk_serials: []
+2020-06-18 21:12:51,636 - XenialTestNetworkAlias - INFO - nvme_serials: []
+2020-06-18 21:12:51,636 - XenialTestNetworkAlias - INFO - nvme disks: []
+2020-06-18 21:12:51,646 - XenialTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:12:51,647 - XenialTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:12:51,654 - XenialTestNetworkAlias - INFO - Using root_disk: []
+2020-06-18 21:12:51,654 - XenialTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkAlias/logs/install-serial.log
+2020-06-18 21:14:41,764 - XenialTestNetworkVlan - INFO - XenialTestNetworkVlan[install]: boot took 133.76 seconds. returned True
+2020-06-18 21:14:42,016 - XenialTestNetworkVlan - INFO - Install OK
+2020-06-18 21:14:42,017 - XenialTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkVlan/logs/boot-serial.log
+2020-06-18 21:15:06,813 - XenialTestNetworkAlias - INFO - XenialTestNetworkAlias[install]: boot took 135.16 seconds. returned True
+2020-06-18 21:15:07,090 - XenialTestNetworkAlias - INFO - Install OK
+2020-06-18 21:15:07,090 - XenialTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkAlias/logs/boot-serial.log
+2020-06-18 21:15:07,444 - EoanTestNetworkVlan - INFO - EoanTestNetworkVlan[install]: boot took 180.01 seconds. returned True
+2020-06-18 21:15:07,867 - EoanTestNetworkVlan - INFO - Install OK
+2020-06-18 21:15:07,868 - EoanTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkVlan/logs/boot-serial.log
+2020-06-18 21:15:33,561 - XenialTestNetworkVlan - INFO - XenialTestNetworkVlan[first_boot]: boot took 51.54 seconds. returned True
+2020-06-18 21:15:33,611 - XenialTestNetworkVlan - INFO - XenialTestNetworkVlan: setUpClass finished. took 186.27 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.XenialTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.XenialTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.XenialTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.XenialTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.XenialTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_output_files_exist (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.XenialTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.XenialTestNetworkVlan) ... ok
+2020-06-18 21:15:33,974 - FocalTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:15:33,974 - FocalTestNetworkAlias - INFO - Starting setup for testclass: FocalTestNetworkAlias (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:15:34,113 - FocalTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkAlias
+2020-06-18 21:15:34,114 - FocalTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:15:34,135 - FocalTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:15:34,135 - FocalTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:15:34,179 - FocalTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:15:34,195 - FocalTestNetworkAlias - INFO - disk_serials: []
+2020-06-18 21:15:34,195 - FocalTestNetworkAlias - INFO - nvme_serials: []
+2020-06-18 21:15:34,195 - FocalTestNetworkAlias - INFO - nvme disks: []
+2020-06-18 21:15:34,205 - FocalTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:15:34,205 - FocalTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:15:34,211 - FocalTestNetworkAlias - INFO - Using root_disk: []
+2020-06-18 21:15:34,211 - FocalTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkAlias/logs/install-serial.log
+2020-06-18 21:15:52,252 - FocalTestNetworkVlan - INFO - FocalTestNetworkVlan[install]: boot took 188.12 seconds. returned True
+2020-06-18 21:15:52,331 - FocalTestNetworkVlan - INFO - Install OK
+2020-06-18 21:15:52,331 - FocalTestNetworkVlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkVlan/logs/boot-serial.log
+2020-06-18 21:16:00,486 - XenialTestNetworkAlias - INFO - XenialTestNetworkAlias[first_boot]: boot took 53.40 seconds. returned True
+2020-06-18 21:16:00,539 - XenialTestNetworkAlias - INFO - XenialTestNetworkAlias: setUpClass finished. took 189.63 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.XenialTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.XenialTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.XenialTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.XenialTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.XenialTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_output_files_exist (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.XenialTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.XenialTestNetworkAlias) ... SKIP: This test does not use storage config.
+2020-06-18 21:16:00,944 - EoanTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:16:00,944 - EoanTestNetworkAlias - INFO - Starting setup for testclass: EoanTestNetworkAlias (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:16:01,099 - EoanTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkAlias
+2020-06-18 21:16:01,100 - EoanTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:16:01,123 - EoanTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:16:01,123 - EoanTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:16:01,174 - EoanTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:16:01,192 - EoanTestNetworkAlias - INFO - disk_serials: []
+2020-06-18 21:16:01,192 - EoanTestNetworkAlias - INFO - nvme_serials: []
+2020-06-18 21:16:01,192 - EoanTestNetworkAlias - INFO - nvme disks: []
+2020-06-18 21:16:01,203 - EoanTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:16:01,204 - EoanTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:16:01,211 - EoanTestNetworkAlias - INFO - Using root_disk: []
+2020-06-18 21:16:01,212 - EoanTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkAlias/logs/install-serial.log
+2020-06-18 21:16:01,397 - EoanTestNetworkVlan - INFO - EoanTestNetworkVlan[first_boot]: boot took 53.53 seconds. returned True
+2020-06-18 21:16:01,459 - EoanTestNetworkVlan - INFO - EoanTestNetworkVlan: setUpClass finished. took 234.66 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.EoanTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.EoanTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.EoanTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.EoanTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.EoanTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.EoanTestNetworkVlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.EoanTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_vlan.EoanTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.EoanTestNetworkVlan) ... SKIP: release 'eoan' does not need the vlan package
+2020-06-18 21:16:01,957 - BionicTestNetworkAlias - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:16:01,957 - BionicTestNetworkAlias - INFO - Starting setup for testclass: BionicTestNetworkAlias (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:16:02,572 - BionicTestNetworkAlias - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkAlias
+2020-06-18 21:16:02,573 - BionicTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:16:02,596 - BionicTestNetworkAlias - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:16:02,596 - BionicTestNetworkAlias - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:16:02,649 - BionicTestNetworkAlias - INFO - Loading testcase config file: examples/tests/network_alias.yaml
+2020-06-18 21:16:02,667 - BionicTestNetworkAlias - INFO - disk_serials: []
+2020-06-18 21:16:02,667 - BionicTestNetworkAlias - INFO - nvme_serials: []
+2020-06-18 21:16:02,668 - BionicTestNetworkAlias - INFO - nvme disks: []
+2020-06-18 21:16:02,678 - BionicTestNetworkAlias - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:16:02,679 - BionicTestNetworkAlias - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:16:02,685 - BionicTestNetworkAlias - INFO - Using root_disk: []
+2020-06-18 21:16:02,686 - BionicTestNetworkAlias - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkAlias/logs/install-serial.log
+2020-06-18 21:16:46,885 - FocalTestNetworkVlan - INFO - FocalTestNetworkVlan[first_boot]: boot took 54.55 seconds. returned True
+2020-06-18 21:16:46,946 - FocalTestNetworkVlan - INFO - FocalTestNetworkVlan: setUpClass finished. took 243.60 seconds. Running testcases.
+get_test_files (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_clear_holders_ran (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: passthrough available on <class 'vmtests.test_network_vlan.FocalTestNetworkVlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_dname (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_dname_rules (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: <class 'vmtests.test_network_vlan.FocalTestNetworkVlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_fstab (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_ip_output (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_kernel_img_conf (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_reporting_data (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_static_routes (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_swaps_used (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_vlan.FocalTestNetworkVlan) ... ok
+test_vlan_installed (vmtests.test_network_vlan.FocalTestNetworkVlan) ... SKIP: release 'focal' does not need the vlan package
+2020-06-18 21:16:47,429 - BionicTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:16:47,429 - BionicTestNetworkIPV6Vlan - INFO - Starting setup for testclass: BionicTestNetworkIPV6Vlan (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:16:48,064 - BionicTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Vlan
+2020-06-18 21:16:48,064 - BionicTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:16:48,081 - BionicTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:16:48,081 - BionicTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:16:48,128 - BionicTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:16:48,139 - BionicTestNetworkIPV6Vlan - INFO - disk_serials: []
+2020-06-18 21:16:48,139 - BionicTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2020-06-18 21:16:48,139 - BionicTestNetworkIPV6Vlan - INFO - nvme disks: []
+2020-06-18 21:16:48,150 - BionicTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:16:48,151 - BionicTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:16:48,157 - BionicTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2020-06-18 21:16:48,158 - BionicTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Vlan/logs/install-serial.log
+2020-06-18 21:18:41,037 - BionicTestNetworkAlias - INFO - BionicTestNetworkAlias[install]: boot took 158.35 seconds. returned True
+2020-06-18 21:18:41,459 - BionicTestNetworkAlias - INFO - Install OK
+2020-06-18 21:18:41,459 - BionicTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkAlias/logs/boot-serial.log
+2020-06-18 21:18:44,992 - FocalTestNetworkAlias - INFO - FocalTestNetworkAlias[install]: boot took 190.78 seconds. returned True
+2020-06-18 21:18:45,229 - FocalTestNetworkAlias - INFO - Install OK
+2020-06-18 21:18:45,229 - FocalTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkAlias/logs/boot-serial.log
+2020-06-18 21:19:01,317 - EoanTestNetworkAlias - INFO - EoanTestNetworkAlias[install]: boot took 180.10 seconds. returned True
+2020-06-18 21:19:01,321 - EoanTestNetworkAlias - INFO - Install OK
+2020-06-18 21:19:01,321 - EoanTestNetworkAlias - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkAlias/logs/boot-serial.log
+2020-06-18 21:19:17,781 - BionicTestNetworkAlias - INFO - BionicTestNetworkAlias[first_boot]: boot took 36.32 seconds. returned True
+2020-06-18 21:19:17,841 - BionicTestNetworkAlias - INFO - BionicTestNetworkAlias: setUpClass finished. took 195.88 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.BionicTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.BionicTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_output_files_exist (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.BionicTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.BionicTestNetworkAlias) ... SKIP: This test does not use storage config.
+2020-06-18 21:19:18,261 - EoanTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:19:18,261 - EoanTestNetworkIPV6Vlan - INFO - Starting setup for testclass: EoanTestNetworkIPV6Vlan (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:19:18,827 - EoanTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6Vlan
+2020-06-18 21:19:18,828 - EoanTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:19:18,844 - EoanTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:19:18,844 - EoanTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:19:18,891 - EoanTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:19:18,902 - EoanTestNetworkIPV6Vlan - INFO - disk_serials: []
+2020-06-18 21:19:18,903 - EoanTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2020-06-18 21:19:18,903 - EoanTestNetworkIPV6Vlan - INFO - nvme disks: []
+2020-06-18 21:19:18,914 - EoanTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:19:18,914 - EoanTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:19:18,921 - EoanTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2020-06-18 21:19:18,921 - EoanTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6Vlan/logs/install-serial.log
+2020-06-18 21:19:22,425 - FocalTestNetworkAlias - INFO - FocalTestNetworkAlias[first_boot]: boot took 37.20 seconds. returned True
+2020-06-18 21:19:22,489 - FocalTestNetworkAlias - INFO - FocalTestNetworkAlias: setUpClass finished. took 228.51 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.FocalTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.FocalTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.FocalTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.FocalTestNetworkAlias) ... SKIP: This test does not use storage config.
+2020-06-18 21:19:23,012 - XenialTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:19:23,012 - XenialTestNetworkIPV6Vlan - INFO - Starting setup for testclass: XenialTestNetworkIPV6Vlan (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:19:23,644 - XenialTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6Vlan
+2020-06-18 21:19:23,645 - XenialTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:19:23,659 - XenialTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:19:23,659 - XenialTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:19:23,703 - XenialTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:19:23,713 - XenialTestNetworkIPV6Vlan - INFO - disk_serials: []
+2020-06-18 21:19:23,713 - XenialTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2020-06-18 21:19:23,714 - XenialTestNetworkIPV6Vlan - INFO - nvme disks: []
+2020-06-18 21:19:23,724 - XenialTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:19:23,724 - XenialTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:19:23,730 - XenialTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2020-06-18 21:19:23,730 - XenialTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6Vlan/logs/install-serial.log
+2020-06-18 21:19:26,508 - BionicTestNetworkIPV6Vlan - INFO - BionicTestNetworkIPV6Vlan[install]: boot took 158.35 seconds. returned True
+2020-06-18 21:19:26,587 - BionicTestNetworkIPV6Vlan - INFO - Install OK
+2020-06-18 21:19:26,587 - BionicTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6Vlan/logs/boot-serial.log
+2020-06-18 21:19:39,501 - EoanTestNetworkAlias - INFO - EoanTestNetworkAlias[first_boot]: boot took 38.18 seconds. returned True
+2020-06-18 21:19:39,570 - EoanTestNetworkAlias - INFO - EoanTestNetworkAlias: setUpClass finished. took 218.63 seconds. Running testcases.
+get_test_files (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_clear_holders_ran (vmtests.test_network_alias.EoanTestNetworkAlias) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_alias.EoanTestNetworkAlias) ... SKIP: passthrough available on <class 'vmtests.test_network_alias.EoanTestNetworkAlias'>
+test_cloudinit_network_passthrough (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_dname (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_dname_rules (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_etc_network_interfaces (vmtests.test_network_alias.EoanTestNetworkAlias) ... SKIP: <class 'vmtests.test_network_alias.EoanTestNetworkAlias'>: cloud-init and curtin eni rendering differ
+test_etc_resolvconf (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_fstab (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_ip_output (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_kernel_img_conf (vmtests.test_network_alias.EoanTestNetworkAlias) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_reporting_data (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_static_routes (vmtests.test_network_alias.EoanTestNetworkAlias) ... ok
+test_swaps_used (vmtests.test_network_alias.EoanTestNetworkAlias) ... SKIP: This test does not use storage config.
+2020-06-18 21:19:40,083 - FocalTestNetworkIPV6Vlan - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:19:40,083 - FocalTestNetworkIPV6Vlan - INFO - Starting setup for testclass: FocalTestNetworkIPV6Vlan (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:19:40,703 - FocalTestNetworkIPV6Vlan - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Vlan
+2020-06-18 21:19:40,704 - FocalTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:19:40,720 - FocalTestNetworkIPV6Vlan - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:19:40,720 - FocalTestNetworkIPV6Vlan - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:19:40,767 - FocalTestNetworkIPV6Vlan - INFO - Loading testcase config file: examples/tests/vlan_network_ipv6.yaml
+2020-06-18 21:19:40,779 - FocalTestNetworkIPV6Vlan - INFO - disk_serials: []
+2020-06-18 21:19:40,779 - FocalTestNetworkIPV6Vlan - INFO - nvme_serials: []
+2020-06-18 21:19:40,780 - FocalTestNetworkIPV6Vlan - INFO - nvme disks: []
+2020-06-18 21:19:40,791 - FocalTestNetworkIPV6Vlan - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:19:40,792 - FocalTestNetworkIPV6Vlan - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:19:40,799 - FocalTestNetworkIPV6Vlan - INFO - Using root_disk: []
+2020-06-18 21:19:40,799 - FocalTestNetworkIPV6Vlan - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Vlan/logs/install-serial.log
+2020-06-18 21:20:14,914 - BionicTestNetworkIPV6Vlan - INFO - BionicTestNetworkIPV6Vlan[first_boot]: boot took 48.33 seconds. returned True
+2020-06-18 21:20:14,977 - BionicTestNetworkIPV6Vlan - INFO - BionicTestNetworkIPV6Vlan: setUpClass finished. took 207.55 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.BionicTestNetworkIPV6Vlan) ... SKIP: release 'bionic' does not need the vlan package
+2020-06-18 21:20:15,425 - EoanTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:20:15,425 - EoanTestNetworkStatic - INFO - Starting setup for testclass: EoanTestNetworkStatic (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:20:15,997 - EoanTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkStatic
+2020-06-18 21:20:15,997 - EoanTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:20:16,004 - EoanTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:20:16,004 - EoanTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:20:16,008 - EoanTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:20:16,010 - EoanTestNetworkStatic - INFO - disk_serials: []
+2020-06-18 21:20:16,011 - EoanTestNetworkStatic - INFO - nvme_serials: []
+2020-06-18 21:20:16,011 - EoanTestNetworkStatic - INFO - nvme disks: []
+2020-06-18 21:20:16,021 - EoanTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:20:16,022 - EoanTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:20:16,028 - EoanTestNetworkStatic - INFO - Using root_disk: []
+2020-06-18 21:20:16,029 - EoanTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkStatic/logs/install-serial.log
+2020-06-18 21:21:35,687 - XenialTestNetworkIPV6Vlan - INFO - XenialTestNetworkIPV6Vlan[install]: boot took 131.96 seconds. returned True
+2020-06-18 21:21:36,029 - XenialTestNetworkIPV6Vlan - INFO - Install OK
+2020-06-18 21:21:36,030 - XenialTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6Vlan/logs/boot-serial.log
+2020-06-18 21:22:17,125 - EoanTestNetworkIPV6Vlan - INFO - EoanTestNetworkIPV6Vlan[install]: boot took 178.20 seconds. returned True
+2020-06-18 21:22:17,261 - XenialTestNetworkIPV6Vlan - INFO - XenialTestNetworkIPV6Vlan[first_boot]: boot took 41.23 seconds. returned True
+2020-06-18 21:22:17,320 - XenialTestNetworkIPV6Vlan - INFO - XenialTestNetworkIPV6Vlan: setUpClass finished. took 174.31 seconds. Running testcases.
+2020-06-18 21:22:17,605 - EoanTestNetworkIPV6Vlan - INFO - Install OK
+2020-06-18 21:22:17,606 - EoanTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6Vlan/logs/boot-serial.log
+get_test_files (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.XenialTestNetworkIPV6Vlan) ... ok
+2020-06-18 21:22:17,754 - BionicTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:22:17,754 - BionicTestNetworkStatic - INFO - Starting setup for testclass: BionicTestNetworkStatic (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:22:17,916 - BionicTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStatic
+2020-06-18 21:22:17,917 - BionicTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:22:17,924 - BionicTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:22:17,924 - BionicTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:22:17,928 - BionicTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:22:17,931 - BionicTestNetworkStatic - INFO - disk_serials: []
+2020-06-18 21:22:17,931 - BionicTestNetworkStatic - INFO - nvme_serials: []
+2020-06-18 21:22:17,931 - BionicTestNetworkStatic - INFO - nvme disks: []
+2020-06-18 21:22:17,942 - BionicTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:22:17,943 - BionicTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:22:17,950 - BionicTestNetworkStatic - INFO - Using root_disk: []
+2020-06-18 21:22:17,951 - BionicTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStatic/logs/install-serial.log
+2020-06-18 21:22:51,124 - FocalTestNetworkIPV6Vlan - INFO - FocalTestNetworkIPV6Vlan[install]: boot took 190.32 seconds. returned True
+2020-06-18 21:22:51,132 - FocalTestNetworkIPV6Vlan - INFO - Install OK
+2020-06-18 21:22:51,132 - FocalTestNetworkIPV6Vlan - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkIPV6Vlan/logs/boot-serial.log
+2020-06-18 21:23:15,777 - EoanTestNetworkStatic - INFO - EoanTestNetworkStatic[install]: boot took 179.75 seconds. returned True
+2020-06-18 21:23:15,926 - EoanTestNetworkStatic - INFO - Install OK
+2020-06-18 21:23:15,926 - EoanTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkStatic/logs/boot-serial.log
+2020-06-18 21:23:18,146 - EoanTestNetworkIPV6Vlan - INFO - EoanTestNetworkIPV6Vlan[first_boot]: boot took 60.54 seconds. returned True
+2020-06-18 21:23:18,206 - EoanTestNetworkIPV6Vlan - INFO - EoanTestNetworkIPV6Vlan: setUpClass finished. took 239.94 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.EoanTestNetworkIPV6Vlan) ... SKIP: release 'eoan' does not need the vlan package
+2020-06-18 21:23:18,699 - XenialTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:23:18,699 - XenialTestNetworkStatic - INFO - Starting setup for testclass: XenialTestNetworkStatic (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:23:19,287 - XenialTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkStatic
+2020-06-18 21:23:19,288 - XenialTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:23:19,295 - XenialTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:23:19,295 - XenialTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:23:19,299 - XenialTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:23:19,301 - XenialTestNetworkStatic - INFO - disk_serials: []
+2020-06-18 21:23:19,301 - XenialTestNetworkStatic - INFO - nvme_serials: []
+2020-06-18 21:23:19,301 - XenialTestNetworkStatic - INFO - nvme disks: []
+2020-06-18 21:23:19,312 - XenialTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:23:19,312 - XenialTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:23:19,318 - XenialTestNetworkStatic - INFO - Using root_disk: []
+2020-06-18 21:23:19,319 - XenialTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkStatic/logs/install-serial.log
+2020-06-18 21:23:48,877 - EoanTestNetworkStatic - INFO - EoanTestNetworkStatic[first_boot]: boot took 32.95 seconds. returned True
+2020-06-18 21:23:48,939 - EoanTestNetworkStatic - INFO - EoanTestNetworkStatic: setUpClass finished. took 213.51 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.EoanTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.EoanTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.EoanTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.EoanTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.EoanTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.EoanTestNetworkStatic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.EoanTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.EoanTestNetworkStatic) ... SKIP: This test does not use storage config.
+2020-06-18 21:23:49,358 - FocalTestNetworkStatic - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:23:49,358 - FocalTestNetworkStatic - INFO - Starting setup for testclass: FocalTestNetworkStatic (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:23:49,966 - FocalTestNetworkStatic - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStatic
+2020-06-18 21:23:49,966 - FocalTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:23:49,973 - FocalTestNetworkStatic - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:23:49,973 - FocalTestNetworkStatic - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:23:49,977 - FocalTestNetworkStatic - INFO - Loading testcase config file: examples/tests/basic_network_static.yaml
+2020-06-18 21:23:49,980 - FocalTestNetworkStatic - INFO - disk_serials: []
+2020-06-18 21:23:49,980 - FocalTestNetworkStatic - INFO - nvme_serials: []
+2020-06-18 21:23:49,980 - FocalTestNetworkStatic - INFO - nvme disks: []
+2020-06-18 21:23:49,991 - FocalTestNetworkStatic - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:23:49,991 - FocalTestNetworkStatic - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:23:49,998 - FocalTestNetworkStatic - INFO - Using root_disk: []
+2020-06-18 21:23:49,998 - FocalTestNetworkStatic - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStatic/logs/install-serial.log
+2020-06-18 21:23:50,966 - FocalTestNetworkIPV6Vlan - INFO - FocalTestNetworkIPV6Vlan[first_boot]: boot took 59.83 seconds. returned True
+2020-06-18 21:23:51,031 - FocalTestNetworkIPV6Vlan - INFO - FocalTestNetworkIPV6Vlan: setUpClass finished. took 250.95 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_dname (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_dname_rules (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: <class 'vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_fstab (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_ip_output (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_output_files_exist_vlan (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_reporting_data (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_static_routes (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_swaps_used (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: This test does not use storage config.
+test_vlan_enabled (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... ok
+test_vlan_installed (vmtests.test_network_ipv6_vlan.FocalTestNetworkIPV6Vlan) ... SKIP: release 'focal' does not need the vlan package
+2020-06-18 21:23:51,537 - FocalCurtinDisableNetworkRendering - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:23:51,537 - FocalCurtinDisableNetworkRendering - INFO - Starting setup for testclass: FocalCurtinDisableNetworkRendering (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:23:52,155 - FocalCurtinDisableNetworkRendering - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableNetworkRendering
+2020-06-18 21:23:52,156 - FocalCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2020-06-18 21:23:52,161 - FocalCurtinDisableNetworkRendering - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:23:52,161 - FocalCurtinDisableNetworkRendering - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:23:52,162 - FocalCurtinDisableNetworkRendering - INFO - Loading testcase config file: examples/tests/network_disabled.yaml
+2020-06-18 21:23:52,163 - FocalCurtinDisableNetworkRendering - INFO - disk_serials: []
+2020-06-18 21:23:52,163 - FocalCurtinDisableNetworkRendering - INFO - nvme_serials: []
+2020-06-18 21:23:52,163 - FocalCurtinDisableNetworkRendering - INFO - nvme disks: []
+2020-06-18 21:23:52,175 - FocalCurtinDisableNetworkRendering - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:23:52,175 - FocalCurtinDisableNetworkRendering - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:23:52,182 - FocalCurtinDisableNetworkRendering - INFO - Using root_disk: []
+2020-06-18 21:23:52,182 - FocalCurtinDisableNetworkRendering - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableNetworkRendering/logs/install-serial.log
+2020-06-18 21:24:51,025 - BionicTestNetworkStatic - INFO - BionicTestNetworkStatic[install]: boot took 153.07 seconds. returned True
+2020-06-18 21:24:51,467 - BionicTestNetworkStatic - INFO - Install OK
+2020-06-18 21:24:51,467 - BionicTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkStatic/logs/boot-serial.log
+2020-06-18 21:25:25,649 - BionicTestNetworkStatic - INFO - BionicTestNetworkStatic[first_boot]: boot took 34.18 seconds. returned True
+2020-06-18 21:25:25,707 - BionicTestNetworkStatic - INFO - BionicTestNetworkStatic: setUpClass finished. took 187.95 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.BionicTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.BionicTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_output_files_exist (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.BionicTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.BionicTestNetworkStatic) ... SKIP: This test does not use storage config.
+2020-06-18 21:25:26,058 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:25:26,059 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Starting setup for testclass: FocalCurtinDisableCloudInitNetworkingVersion1 (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:25:26,596 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworkingVersion1
+2020-06-18 21:25:26,597 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2020-06-18 21:25:26,602 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:25:26,602 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:25:26,603 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Loading testcase config file: examples/tests/network_config_disabled_with_version.yaml
+2020-06-18 21:25:26,604 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - disk_serials: []
+2020-06-18 21:25:26,604 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme_serials: []
+2020-06-18 21:25:26,604 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - nvme disks: []
+2020-06-18 21:25:26,615 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:25:26,616 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:25:26,623 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Using root_disk: []
+2020-06-18 21:25:26,623 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworkingVersion1/logs/install-serial.log
+2020-06-18 21:25:32,180 - XenialTestNetworkStatic - INFO - XenialTestNetworkStatic[install]: boot took 132.86 seconds. returned True
+2020-06-18 21:25:32,482 - XenialTestNetworkStatic - INFO - Install OK
+2020-06-18 21:25:32,482 - XenialTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkStatic/logs/boot-serial.log
+2020-06-18 21:26:02,949 - XenialTestNetworkStatic - INFO - XenialTestNetworkStatic[first_boot]: boot took 30.47 seconds. returned True
+2020-06-18 21:26:03,009 - XenialTestNetworkStatic - INFO - XenialTestNetworkStatic: setUpClass finished. took 164.31 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.XenialTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.XenialTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.XenialTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.XenialTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.XenialTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_output_files_exist (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.XenialTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.XenialTestNetworkStatic) ... SKIP: This test does not use storage config.
+2020-06-18 21:26:03,355 - FocalCurtinDisableCloudInitNetworking - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:26:03,355 - FocalCurtinDisableCloudInitNetworking - INFO - Starting setup for testclass: FocalCurtinDisableCloudInitNetworking (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:26:03,514 - FocalCurtinDisableCloudInitNetworking - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworking
+2020-06-18 21:26:03,514 - FocalCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2020-06-18 21:26:03,520 - FocalCurtinDisableCloudInitNetworking - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:26:03,520 - FocalCurtinDisableCloudInitNetworking - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:26:03,520 - FocalCurtinDisableCloudInitNetworking - INFO - Loading testcase config file: examples/tests/network_config_disabled.yaml
+2020-06-18 21:26:03,521 - FocalCurtinDisableCloudInitNetworking - INFO - disk_serials: []
+2020-06-18 21:26:03,521 - FocalCurtinDisableCloudInitNetworking - INFO - nvme_serials: []
+2020-06-18 21:26:03,521 - FocalCurtinDisableCloudInitNetworking - INFO - nvme disks: []
+2020-06-18 21:26:03,535 - FocalCurtinDisableCloudInitNetworking - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:26:03,535 - FocalCurtinDisableCloudInitNetworking - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:26:03,543 - FocalCurtinDisableCloudInitNetworking - INFO - Using root_disk: []
+2020-06-18 21:26:03,543 - FocalCurtinDisableCloudInitNetworking - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworking/logs/install-serial.log
+2020-06-18 21:26:59,709 - FocalCurtinDisableNetworkRendering - INFO - FocalCurtinDisableNetworkRendering[install]: boot took 187.53 seconds. returned True
+2020-06-18 21:27:00,079 - FocalCurtinDisableNetworkRendering - INFO - Install OK
+2020-06-18 21:27:00,080 - FocalCurtinDisableNetworkRendering - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableNetworkRendering/logs/boot-serial.log
+2020-06-18 21:27:00,570 - FocalTestNetworkStatic - INFO - FocalTestNetworkStatic[install]: boot took 190.57 seconds. returned True
+2020-06-18 21:27:00,964 - FocalTestNetworkStatic - INFO - Install OK
+2020-06-18 21:27:00,964 - FocalTestNetworkStatic - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkStatic/logs/boot-serial.log
+2020-06-18 21:27:35,790 - FocalCurtinDisableNetworkRendering - INFO - FocalCurtinDisableNetworkRendering[first_boot]: boot took 35.71 seconds. returned True
+2020-06-18 21:27:35,848 - FocalCurtinDisableNetworkRendering - INFO - FocalCurtinDisableNetworkRendering: setUpClass finished. took 224.31 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_cloudinit_network_not_created (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_dname (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_dname_rules (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_fstab (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_ip_output (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_kernel_img_conf (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_reporting_data (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... ok
+test_static_routes (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering'>
+test_swaps_used (vmtests.test_network_disabled.FocalCurtinDisableNetworkRendering) ... SKIP: This test does not use storage config.
+2020-06-18 21:27:36,256 - FocalTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:27:36,256 - FocalTestBridging - INFO - Starting setup for testclass: FocalTestBridging (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:27:36,886 - FocalTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBridging
+2020-06-18 21:27:36,887 - FocalTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2020-06-18 21:27:36,897 - FocalTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:27:36,897 - FocalTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:27:36,912 - FocalTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2020-06-18 21:27:36,917 - FocalTestBridging - INFO - disk_serials: []
+2020-06-18 21:27:36,917 - FocalTestBridging - INFO - nvme_serials: []
+2020-06-18 21:27:36,918 - FocalTestBridging - INFO - nvme disks: []
+2020-06-18 21:27:36,932 - FocalTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:27:36,932 - FocalTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:27:36,939 - FocalTestBridging - INFO - Using root_disk: []
+2020-06-18 21:27:36,940 - FocalTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBridging/logs/install-serial.log
+2020-06-18 21:27:37,290 - FocalTestNetworkStatic - INFO - FocalTestNetworkStatic[first_boot]: boot took 36.33 seconds. returned True
+2020-06-18 21:27:37,362 - FocalTestNetworkStatic - INFO - FocalTestNetworkStatic: setUpClass finished. took 228.00 seconds. Running testcases.
+get_test_files (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_clear_holders_ran (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: passthrough available on <class 'vmtests.test_network_static.FocalTestNetworkStatic'>
+test_cloudinit_network_passthrough (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_dname (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_dname_rules (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_etc_network_interfaces (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: <class 'vmtests.test_network_static.FocalTestNetworkStatic'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_fstab (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_ip_output (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_kernel_img_conf (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_reporting_data (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_static_routes (vmtests.test_network_static.FocalTestNetworkStatic) ... ok
+test_swaps_used (vmtests.test_network_static.FocalTestNetworkStatic) ... SKIP: This test does not use storage config.
+2020-06-18 21:27:37,820 - EoanTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:27:37,821 - EoanTestBridging - INFO - Starting setup for testclass: EoanTestBridging (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:27:38,456 - EoanTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestBridging
+2020-06-18 21:27:38,457 - EoanTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2020-06-18 21:27:38,467 - EoanTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:27:38,467 - EoanTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:27:38,483 - EoanTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2020-06-18 21:27:38,488 - EoanTestBridging - INFO - disk_serials: []
+2020-06-18 21:27:38,488 - EoanTestBridging - INFO - nvme_serials: []
+2020-06-18 21:27:38,488 - EoanTestBridging - INFO - nvme disks: []
+2020-06-18 21:27:38,500 - EoanTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:27:38,500 - EoanTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:27:38,507 - EoanTestBridging - INFO - Using root_disk: []
+2020-06-18 21:27:38,508 - EoanTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestBridging/logs/install-serial.log
+2020-06-18 21:28:36,025 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - FocalCurtinDisableCloudInitNetworkingVersion1[install]: boot took 189.40 seconds. returned True
+2020-06-18 21:28:36,425 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Install OK
+2020-06-18 21:28:36,426 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworkingVersion1/logs/boot-serial.log
+2020-06-18 21:29:10,314 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - FocalCurtinDisableCloudInitNetworkingVersion1[first_boot]: boot took 33.89 seconds. returned True
+2020-06-18 21:29:10,382 - FocalCurtinDisableCloudInitNetworkingVersion1 - INFO - FocalCurtinDisableCloudInitNetworkingVersion1: setUpClass finished. took 224.32 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_dname_rules (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_fstab (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_ip_output (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_kernel_img_conf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_reporting_data (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... ok
+test_static_routes (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1'>
+test_swaps_used (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworkingVersion1) ... SKIP: This test does not use storage config.
+2020-06-18 21:29:11,047 - XenialTestBridgingV2 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:29:11,047 - XenialTestBridgingV2 - INFO - Starting setup for testclass: XenialTestBridgingV2 (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:29:11,261 - FocalCurtinDisableCloudInitNetworking - INFO - FocalCurtinDisableCloudInitNetworking[install]: boot took 187.72 seconds. returned True
+2020-06-18 21:29:11,603 - FocalCurtinDisableCloudInitNetworking - INFO - Install OK
+2020-06-18 21:29:11,603 - FocalCurtinDisableCloudInitNetworking - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalCurtinDisableCloudInitNetworking/logs/boot-serial.log
+2020-06-18 21:29:13,158 - XenialTestBridgingV2 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestBridgingV2
+2020-06-18 21:29:13,158 - XenialTestBridgingV2 - INFO - Loading testcase config file: examples/tests/bridging_network_v2.yaml
+2020-06-18 21:29:13,168 - XenialTestBridgingV2 - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:29:13,168 - XenialTestBridgingV2 - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:29:13,173 - XenialTestBridgingV2 - INFO - Loading testcase config file: examples/tests/bridging_network_v2.yaml
+2020-06-18 21:29:13,178 - XenialTestBridgingV2 - INFO - disk_serials: []
+2020-06-18 21:29:13,179 - XenialTestBridgingV2 - INFO - nvme_serials: []
+2020-06-18 21:29:13,179 - XenialTestBridgingV2 - INFO - nvme disks: []
+2020-06-18 21:29:13,191 - XenialTestBridgingV2 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:29:13,191 - XenialTestBridgingV2 - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:29:13,199 - XenialTestBridgingV2 - INFO - Using root_disk: []
+2020-06-18 21:29:13,199 - XenialTestBridgingV2 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestBridgingV2/logs/install-serial.log
+2020-06-18 21:29:44,885 - FocalCurtinDisableCloudInitNetworking - INFO - FocalCurtinDisableCloudInitNetworking[first_boot]: boot took 33.28 seconds. returned True
+2020-06-18 21:29:44,951 - FocalCurtinDisableCloudInitNetworking - INFO - FocalCurtinDisableCloudInitNetworking: setUpClass finished. took 221.60 seconds. Running testcases.
+get_test_files (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_clear_holders_ran (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: passthrough available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_cloudinit_network_passthrough (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_dname (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_dname_rules (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_etc_network_interfaces (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_fstab (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_ip_output (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: not available on <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_kernel_img_conf (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_reporting_data (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... ok
+test_static_routes (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking'>
+test_swaps_used (vmtests.test_network_disabled.FocalCurtinDisableCloudInitNetworking) ... SKIP: This test does not use storage config.
+2020-06-18 21:29:45,371 - BionicTestBridging - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:29:45,371 - BionicTestBridging - INFO - Starting setup for testclass: BionicTestBridging (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:29:46,009 - BionicTestBridging - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBridging
+2020-06-18 21:29:46,010 - BionicTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2020-06-18 21:29:46,030 - BionicTestBridging - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:29:46,030 - BionicTestBridging - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:29:46,059 - BionicTestBridging - INFO - Loading testcase config file: examples/tests/bridging_network.yaml
+2020-06-18 21:29:46,065 - BionicTestBridging - INFO - disk_serials: []
+2020-06-18 21:29:46,065 - BionicTestBridging - INFO - nvme_serials: []
+2020-06-18 21:29:46,066 - BionicTestBridging - INFO - nvme disks: []
+2020-06-18 21:29:46,078 - BionicTestBridging - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:29:46,078 - BionicTestBridging - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:29:46,085 - BionicTestBridging - INFO - Using root_disk: []
+2020-06-18 21:29:46,085 - BionicTestBridging - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBridging/logs/install-serial.log
+2020-06-18 21:30:39,489 - EoanTestBridging - INFO - EoanTestBridging[install]: boot took 180.98 seconds. returned True
+2020-06-18 21:30:39,977 - EoanTestBridging - INFO - Install OK
+2020-06-18 21:30:39,978 - EoanTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestBridging/logs/boot-serial.log
+2020-06-18 21:30:49,069 - FocalTestBridging - INFO - FocalTestBridging[install]: boot took 192.13 seconds. returned True
+2020-06-18 21:30:49,419 - FocalTestBridging - INFO - Install OK
+2020-06-18 21:30:49,419 - FocalTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBridging/logs/boot-serial.log
+2020-06-18 21:31:15,085 - EoanTestBridging - INFO - EoanTestBridging[first_boot]: boot took 35.11 seconds. returned True
+2020-06-18 21:31:15,146 - EoanTestBridging - INFO - EoanTestBridging: setUpClass finished. took 217.32 seconds. Running testcases.
+2020-06-18 21:31:15,152 - EoanTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.EoanTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.EoanTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.EoanTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.EoanTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.EoanTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.EoanTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.EoanTestBridging) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.EoanTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.EoanTestBridging) ... SKIP: This test does not use storage config.
+2020-06-18 21:31:15,571 - FocalTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:31:15,571 - FocalTestNetworkMtu - INFO - Starting setup for testclass: FocalTestNetworkMtu (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:31:16,212 - FocalTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkMtu
+2020-06-18 21:31:16,213 - FocalTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2020-06-18 21:31:16,227 - FocalTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:31:16,227 - FocalTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:31:16,254 - FocalTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2020-06-18 21:31:16,263 - FocalTestNetworkMtu - INFO - disk_serials: []
+2020-06-18 21:31:16,263 - FocalTestNetworkMtu - INFO - nvme_serials: []
+2020-06-18 21:31:16,263 - FocalTestNetworkMtu - INFO - nvme disks: []
+2020-06-18 21:31:16,274 - FocalTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:31:16,274 - FocalTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:31:16,280 - FocalTestNetworkMtu - INFO - Using root_disk: []
+2020-06-18 21:31:16,280 - FocalTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkMtu/logs/install-serial.log
+2020-06-18 21:31:25,897 - FocalTestBridging - INFO - FocalTestBridging[first_boot]: boot took 36.48 seconds. returned True
+2020-06-18 21:31:25,957 - FocalTestBridging - INFO - FocalTestBridging: setUpClass finished. took 229.70 seconds. Running testcases.
+2020-06-18 21:31:25,963 - FocalTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.FocalTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.FocalTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.FocalTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.FocalTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.FocalTestBridging) ... SKIP: This test does not use storage config.
+2020-06-18 21:31:26,389 - EoanTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:31:26,389 - EoanTestNetworkMtu - INFO - Starting setup for testclass: EoanTestNetworkMtu (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:31:27,063 - EoanTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkMtu
+2020-06-18 21:31:27,064 - EoanTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2020-06-18 21:31:27,079 - EoanTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:31:27,079 - EoanTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:31:27,106 - EoanTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2020-06-18 21:31:27,115 - EoanTestNetworkMtu - INFO - disk_serials: []
+2020-06-18 21:31:27,116 - EoanTestNetworkMtu - INFO - nvme_serials: []
+2020-06-18 21:31:27,116 - EoanTestNetworkMtu - INFO - nvme disks: []
+2020-06-18 21:31:27,126 - EoanTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:31:27,127 - EoanTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:31:27,133 - EoanTestNetworkMtu - INFO - Using root_disk: []
+2020-06-18 21:31:27,134 - EoanTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkMtu/logs/install-serial.log
+2020-06-18 21:31:27,825 - XenialTestBridgingV2 - INFO - XenialTestBridgingV2[install]: boot took 134.63 seconds. returned True
+2020-06-18 21:31:28,166 - XenialTestBridgingV2 - INFO - Install OK
+2020-06-18 21:31:28,166 - XenialTestBridgingV2 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestBridgingV2/logs/boot-serial.log
+2020-06-18 21:31:58,505 - XenialTestBridgingV2 - INFO - XenialTestBridgingV2[first_boot]: boot took 30.34 seconds. returned True
+2020-06-18 21:31:58,561 - XenialTestBridgingV2 - INFO - XenialTestBridgingV2: setUpClass finished. took 167.51 seconds. Running testcases.
+get_test_files (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_bridge_params (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.XenialTestBridgingV2) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.XenialTestBridgingV2) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.XenialTestBridgingV2'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_dname (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_dname_rules (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_etc_resolvconf (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_fstab (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_ip_output (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_output_files_exist (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_reporting_data (vmtests.test_network_bridging.XenialTestBridgingV2) ... ok
+test_static_routes (vmtests.test_network_bridging.XenialTestBridgingV2) ... SKIP: passthrough enabled, skipping <class 'vmtests.test_network_bridging.XenialTestBridgingV2'>
+test_swaps_used (vmtests.test_network_bridging.XenialTestBridgingV2) ... SKIP: This test does not use storage config.
+2020-06-18 21:31:58,897 - TestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:31:58,897 - TestNetworkMtu - INFO - Starting setup for testclass: TestNetworkMtu (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:31:59,061 - TestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/TestNetworkMtu
+2020-06-18 21:31:59,062 - TestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu.yaml
+2020-06-18 21:31:59,079 - TestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:31:59,079 - TestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:31:59,132 - TestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu.yaml
+2020-06-18 21:31:59,144 - TestNetworkMtu - INFO - disk_serials: []
+2020-06-18 21:31:59,144 - TestNetworkMtu - INFO - nvme_serials: []
+2020-06-18 21:31:59,144 - TestNetworkMtu - INFO - nvme disks: []
+2020-06-18 21:31:59,155 - TestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:31:59,156 - TestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:31:59,162 - TestNetworkMtu - INFO - Using root_disk: []
+2020-06-18 21:31:59,163 - TestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/TestNetworkMtu/logs/install-serial.log
+2020-06-18 21:32:21,750 - BionicTestBridging - INFO - BionicTestBridging[install]: boot took 155.66 seconds. returned True
+2020-06-18 21:32:21,759 - BionicTestBridging - INFO - Install OK
+2020-06-18 21:32:21,759 - BionicTestBridging - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBridging/logs/boot-serial.log
+2020-06-18 21:32:55,457 - BionicTestBridging - INFO - BionicTestBridging[first_boot]: boot took 33.70 seconds. returned True
+2020-06-18 21:32:55,515 - BionicTestBridging - INFO - BionicTestBridging: setUpClass finished. took 190.14 seconds. Running testcases.
+2020-06-18 21:32:55,521 - BionicTestBridging - WARNING - Skipping: <class 'vmtests.test_network_bridging.BionicTestBridging'>: skip until lp#1668347 is fixed
+get_test_files (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_bridge_package_status (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_bridge_params (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_clear_holders_ran (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: passthrough available on <class 'vmtests.test_network_bridging.BionicTestBridging'>
+test_cloudinit_network_passthrough (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_dname (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_dname_rules (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_etc_network_interfaces (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: <class 'vmtests.test_network_bridging.BionicTestBridging'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_fstab (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_ip_output (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_kernel_img_conf (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_output_files_exist (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_output_files_exist_bridge (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_reporting_data (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_static_routes (vmtests.test_network_bridging.BionicTestBridging) ... ok
+test_swaps_used (vmtests.test_network_bridging.BionicTestBridging) ... SKIP: This test does not use storage config.
+2020-06-18 21:32:55,881 - BionicTestNetworkMtu - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:32:55,881 - BionicTestNetworkMtu - INFO - Starting setup for testclass: BionicTestNetworkMtu (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:32:56,439 - BionicTestNetworkMtu - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkMtu
+2020-06-18 21:32:56,440 - BionicTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2020-06-18 21:32:56,454 - BionicTestNetworkMtu - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:32:56,454 - BionicTestNetworkMtu - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:32:56,483 - BionicTestNetworkMtu - INFO - Loading testcase config file: examples/tests/network_mtu_networkd.yaml
+2020-06-18 21:32:56,493 - BionicTestNetworkMtu - INFO - disk_serials: []
+2020-06-18 21:32:56,494 - BionicTestNetworkMtu - INFO - nvme_serials: []
+2020-06-18 21:32:56,494 - BionicTestNetworkMtu - INFO - nvme disks: []
+2020-06-18 21:32:56,505 - BionicTestNetworkMtu - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:32:56,505 - BionicTestNetworkMtu - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:32:56,512 - BionicTestNetworkMtu - INFO - Using root_disk: []
+2020-06-18 21:32:56,512 - BionicTestNetworkMtu - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkMtu/logs/install-serial.log
+2020-06-18 21:34:13,368 - TestNetworkMtu - INFO - TestNetworkMtu[install]: boot took 134.21 seconds. returned True
+2020-06-18 21:34:13,645 - TestNetworkMtu - INFO - Install OK
+2020-06-18 21:34:13,645 - TestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/TestNetworkMtu/logs/boot-serial.log
+2020-06-18 21:34:27,637 - FocalTestNetworkMtu - INFO - FocalTestNetworkMtu[install]: boot took 191.36 seconds. returned True
+2020-06-18 21:34:28,133 - FocalTestNetworkMtu - INFO - Install OK
+2020-06-18 21:34:28,133 - FocalTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestNetworkMtu/logs/boot-serial.log
+2020-06-18 21:34:28,794 - EoanTestNetworkMtu - INFO - EoanTestNetworkMtu[install]: boot took 181.66 seconds. returned True
+2020-06-18 21:34:28,888 - EoanTestNetworkMtu - INFO - Install OK
+2020-06-18 21:34:28,888 - EoanTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkMtu/logs/boot-serial.log
+2020-06-18 21:34:58,781 - TestNetworkMtu - INFO - TestNetworkMtu[first_boot]: boot took 45.14 seconds. returned True
+2020-06-18 21:34:58,833 - TestNetworkMtu - INFO - TestNetworkMtu: setUpClass finished. took 179.94 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.TestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.TestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.TestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.TestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.TestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_output_files_exist (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.TestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.TestNetworkMtu) ... SKIP: This test does not use storage config.
+2020-06-18 21:34:59,202 - XenialTestNetworkIPV6ENISource - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:34:59,202 - XenialTestNetworkIPV6ENISource - INFO - Starting setup for testclass: XenialTestNetworkIPV6ENISource (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:34:59,349 - XenialTestNetworkIPV6ENISource - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6ENISource
+2020-06-18 21:34:59,349 - XenialTestNetworkIPV6ENISource - INFO - Loading testcase config file: examples/tests/network_source_ipv6.yaml
+2020-06-18 21:34:59,358 - XenialTestNetworkIPV6ENISource - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:34:59,358 - XenialTestNetworkIPV6ENISource - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:34:59,367 - XenialTestNetworkIPV6ENISource - INFO - Loading testcase config file: examples/tests/network_source_ipv6.yaml
+2020-06-18 21:34:59,371 - XenialTestNetworkIPV6ENISource - INFO - disk_serials: []
+2020-06-18 21:34:59,371 - XenialTestNetworkIPV6ENISource - INFO - nvme_serials: []
+2020-06-18 21:34:59,371 - XenialTestNetworkIPV6ENISource - INFO - nvme disks: []
+2020-06-18 21:34:59,381 - XenialTestNetworkIPV6ENISource - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:34:59,382 - XenialTestNetworkIPV6ENISource - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:34:59,388 - XenialTestNetworkIPV6ENISource - INFO - Using root_disk: []
+2020-06-18 21:34:59,388 - XenialTestNetworkIPV6ENISource - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6ENISource/logs/install-serial.log
+2020-06-18 21:35:06,085 - EoanTestNetworkMtu - INFO - EoanTestNetworkMtu[first_boot]: boot took 37.20 seconds. returned True
+2020-06-18 21:35:06,146 - EoanTestNetworkMtu - INFO - EoanTestNetworkMtu: setUpClass finished. took 219.76 seconds. Running testcases.
+2020-06-18 21:35:06,449 - FocalTestNetworkMtu - INFO - FocalTestNetworkMtu[first_boot]: boot took 38.32 seconds. returned True
+2020-06-18 21:35:06,512 - FocalTestNetworkMtu - INFO - FocalTestNetworkMtu: setUpClass finished. took 230.94 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.EoanTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.EoanTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.EoanTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.EoanTestNetworkMtu) ... SKIP: This test does not use storage config.
+2020-06-18 21:35:06,590 - BionicTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:35:06,590 - BionicTestBonding - INFO - Starting setup for testclass: BionicTestBonding (ubuntu/bionic -> ubuntu/bionic)
+get_test_files (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.FocalTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.FocalTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.FocalTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.FocalTestNetworkMtu) ... SKIP: This test does not use storage config.
+2020-06-18 21:35:06,974 - EoanTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:35:06,974 - EoanTestBonding - INFO - Starting setup for testclass: EoanTestBonding (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:35:07,818 - BionicTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBonding
+2020-06-18 21:35:07,818 - EoanTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestBonding
+2020-06-18 21:35:07,819 - EoanTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:35:07,819 - BionicTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:35:07,827 - EoanTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:35:07,827 - EoanTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:35:07,827 - BionicTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:35:07,828 - BionicTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:35:07,840 - EoanTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:35:07,840 - BionicTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:35:07,845 - EoanTestBonding - INFO - disk_serials: []
+2020-06-18 21:35:07,845 - EoanTestBonding - INFO - nvme_serials: []
+2020-06-18 21:35:07,845 - EoanTestBonding - INFO - nvme disks: []
+2020-06-18 21:35:07,845 - BionicTestBonding - INFO - disk_serials: []
+2020-06-18 21:35:07,845 - BionicTestBonding - INFO - nvme_serials: []
+2020-06-18 21:35:07,845 - BionicTestBonding - INFO - nvme disks: []
+2020-06-18 21:35:07,855 - EoanTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:35:07,856 - EoanTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:35:07,856 - BionicTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:35:07,856 - BionicTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:35:07,863 - EoanTestBonding - INFO - Using root_disk: []
+2020-06-18 21:35:07,863 - EoanTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestBonding/logs/install-serial.log
+2020-06-18 21:35:07,863 - BionicTestBonding - INFO - Using root_disk: []
+2020-06-18 21:35:07,863 - BionicTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBonding/logs/install-serial.log
+2020-06-18 21:35:33,957 - BionicTestNetworkMtu - INFO - BionicTestNetworkMtu[install]: boot took 157.44 seconds. returned True
+2020-06-18 21:35:34,422 - BionicTestNetworkMtu - INFO - Install OK
+2020-06-18 21:35:34,422 - BionicTestNetworkMtu - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkMtu/logs/boot-serial.log
+2020-06-18 21:36:11,253 - BionicTestNetworkMtu - INFO - BionicTestNetworkMtu[first_boot]: boot took 36.83 seconds. returned True
+2020-06-18 21:36:11,317 - BionicTestNetworkMtu - INFO - BionicTestNetworkMtu: setUpClass finished. took 195.44 seconds. Running testcases.
+get_test_files (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_clear_holders_ran (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: passthrough available on <class 'vmtests.test_network_mtu.BionicTestNetworkMtu'>
+test_cloudinit_network_passthrough (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_dname (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_dname_rules (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_etc_network_interfaces (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: <class 'vmtests.test_network_mtu.BionicTestNetworkMtu'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_fstab (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ip_output (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_equal_ipv4_non_default_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_up (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_iface_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_higher_than_default_no_ipv4_mtu_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: networkd does not support auto raising iface mtu
+test_ipv6_mtu_smaller_than_ipv4_non_default (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_ipv6_mtu_smaller_than_ipv4_v6_iface_first (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_kernel_img_conf (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_output_files_exist (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_reporting_data (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_static_routes (vmtests.test_network_mtu.BionicTestNetworkMtu) ... ok
+test_swaps_used (vmtests.test_network_mtu.BionicTestNetworkMtu) ... SKIP: This test does not use storage config.
+2020-06-18 21:36:11,745 - XenialTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:36:11,745 - XenialTestBonding - INFO - Starting setup for testclass: XenialTestBonding (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:36:12,292 - XenialTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestBonding
+2020-06-18 21:36:12,293 - XenialTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:36:12,303 - XenialTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:36:12,304 - XenialTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:36:12,321 - XenialTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:36:12,326 - XenialTestBonding - INFO - disk_serials: []
+2020-06-18 21:36:12,327 - XenialTestBonding - INFO - nvme_serials: []
+2020-06-18 21:36:12,327 - XenialTestBonding - INFO - nvme disks: []
+2020-06-18 21:36:12,343 - XenialTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:36:12,343 - XenialTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:36:12,352 - XenialTestBonding - INFO - Using root_disk: []
+2020-06-18 21:36:12,352 - XenialTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestBonding/logs/install-serial.log
+2020-06-18 21:37:14,285 - XenialTestNetworkIPV6ENISource - INFO - XenialTestNetworkIPV6ENISource[install]: boot took 134.90 seconds. returned True
+2020-06-18 21:37:14,577 - XenialTestNetworkIPV6ENISource - INFO - Install OK
+2020-06-18 21:37:14,577 - XenialTestNetworkIPV6ENISource - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6ENISource/logs/boot-serial.log
+2020-06-18 21:37:47,014 - XenialTestNetworkIPV6ENISource - INFO - XenialTestNetworkIPV6ENISource[first_boot]: boot took 32.44 seconds. returned True
+2020-06-18 21:37:47,072 - XenialTestNetworkIPV6ENISource - INFO - XenialTestNetworkIPV6ENISource: setUpClass finished. took 167.87 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_dname (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_dname_rules (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... SKIP: FIXME: cloud-init.net needs update
+test_etc_network_interfaces_source_cfg (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_etc_resolvconf (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_fstab (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_ip_output (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_output_files_exist (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_reporting_data (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_source_cfg_exists (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_static_routes (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... ok
+test_swaps_used (vmtests.test_network_ipv6_enisource.XenialTestNetworkIPV6ENISource) ... SKIP: This test does not use storage config.
+2020-06-18 21:37:47,430 - FocalTestBonding - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:37:47,430 - FocalTestBonding - INFO - Starting setup for testclass: FocalTestBonding (ubuntu/focal -> ubuntu/focal)
+2020-06-18 21:37:47,578 - FocalTestBonding - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBonding
+2020-06-18 21:37:47,578 - FocalTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:37:47,587 - FocalTestBonding - INFO - Publishing ephemeral image as --publish=/srv/images/focal/amd64/20200617/squashfs:root/squashfs
+2020-06-18 21:37:47,587 - FocalTestBonding - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:37:47,600 - FocalTestBonding - INFO - Loading testcase config file: examples/tests/bonding_network.yaml
+2020-06-18 21:37:47,605 - FocalTestBonding - INFO - disk_serials: []
+2020-06-18 21:37:47,605 - FocalTestBonding - INFO - nvme_serials: []
+2020-06-18 21:37:47,605 - FocalTestBonding - INFO - nvme disks: []
+2020-06-18 21:37:47,618 - FocalTestBonding - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:37:47,618 - FocalTestBonding - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:37:47,622 - BionicTestBonding - INFO - BionicTestBonding[install]: boot took 159.76 seconds. returned True
+2020-06-18 21:37:47,625 - FocalTestBonding - INFO - Using root_disk: []
+2020-06-18 21:37:47,625 - FocalTestBonding - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBonding/logs/install-serial.log
+2020-06-18 21:37:48,072 - BionicTestBonding - INFO - Install OK
+2020-06-18 21:37:48,073 - BionicTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestBonding/logs/boot-serial.log
+2020-06-18 21:38:09,053 - EoanTestBonding - INFO - EoanTestBonding[install]: boot took 181.19 seconds. returned True
+2020-06-18 21:38:09,206 - EoanTestBonding - INFO - Install OK
+2020-06-18 21:38:09,206 - EoanTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestBonding/logs/boot-serial.log
+2020-06-18 21:38:22,605 - BionicTestBonding - INFO - BionicTestBonding[first_boot]: boot took 34.53 seconds. returned True
+2020-06-18 21:38:22,671 - BionicTestBonding - INFO - BionicTestBonding: setUpClass finished. took 196.08 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.BionicTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.BionicTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_output_files_exist (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.BionicTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.BionicTestBonding) ... SKIP: This test does not use storage config.
+2020-06-18 21:38:23,052 - XenialTestNetworkENISource - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:38:23,052 - XenialTestNetworkENISource - INFO - Starting setup for testclass: XenialTestNetworkENISource (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:38:23,555 - XenialTestNetworkENISource - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkENISource
+2020-06-18 21:38:23,555 - XenialTestNetworkENISource - INFO - Loading testcase config file: examples/tests/network_source.yaml
+2020-06-18 21:38:23,564 - XenialTestNetworkENISource - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:38:23,564 - XenialTestNetworkENISource - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:38:23,575 - XenialTestNetworkENISource - INFO - Loading testcase config file: examples/tests/network_source.yaml
+2020-06-18 21:38:23,580 - XenialTestNetworkENISource - INFO - disk_serials: []
+2020-06-18 21:38:23,580 - XenialTestNetworkENISource - INFO - nvme_serials: []
+2020-06-18 21:38:23,580 - XenialTestNetworkENISource - INFO - nvme disks: []
+2020-06-18 21:38:23,591 - XenialTestNetworkENISource - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:38:23,591 - XenialTestNetworkENISource - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:38:23,598 - XenialTestNetworkENISource - INFO - Using root_disk: []
+2020-06-18 21:38:23,598 - XenialTestNetworkENISource - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkENISource/logs/install-serial.log
+2020-06-18 21:38:27,060 - XenialTestBonding - INFO - XenialTestBonding[install]: boot took 134.71 seconds. returned True
+2020-06-18 21:38:27,391 - XenialTestBonding - INFO - Install OK
+2020-06-18 21:38:27,391 - XenialTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestBonding/logs/boot-serial.log
+2020-06-18 21:38:43,709 - EoanTestBonding - INFO - EoanTestBonding[first_boot]: boot took 34.50 seconds. returned True
+2020-06-18 21:38:43,769 - EoanTestBonding - INFO - EoanTestBonding: setUpClass finished. took 216.79 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.EoanTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.EoanTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.EoanTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.EoanTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.EoanTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.EoanTestBonding) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.EoanTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.EoanTestBonding) ... SKIP: This test does not use storage config.
+2020-06-18 21:38:44,165 - XenialTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:38:44,165 - XenialTestNetworkIPV6 - INFO - Starting setup for testclass: XenialTestNetworkIPV6 (ubuntu/xenial -> ubuntu/xenial)
+2020-06-18 21:38:44,778 - XenialTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6
+2020-06-18 21:38:44,778 - XenialTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2020-06-18 21:38:44,790 - XenialTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/xenial/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:38:44,790 - XenialTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:38:44,813 - XenialTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2020-06-18 21:38:44,820 - XenialTestNetworkIPV6 - INFO - disk_serials: []
+2020-06-18 21:38:44,820 - XenialTestNetworkIPV6 - INFO - nvme_serials: []
+2020-06-18 21:38:44,820 - XenialTestNetworkIPV6 - INFO - nvme disks: []
+2020-06-18 21:38:44,831 - XenialTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:38:44,832 - XenialTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:38:44,838 - XenialTestNetworkIPV6 - INFO - Using root_disk: []
+2020-06-18 21:38:44,839 - XenialTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6/logs/install-serial.log
+2020-06-18 21:38:57,985 - XenialTestBonding - INFO - XenialTestBonding[first_boot]: boot took 30.59 seconds. returned True
+2020-06-18 21:38:58,038 - XenialTestBonding - INFO - XenialTestBonding: setUpClass finished. took 166.29 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.XenialTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.XenialTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.XenialTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.XenialTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.XenialTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_output_files_exist (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.XenialTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.XenialTestBonding) ... SKIP: This test does not use storage config.
+2020-06-18 21:38:58,352 - EoanTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:38:58,352 - EoanTestNetworkIPV6 - INFO - Starting setup for testclass: EoanTestNetworkIPV6 (ubuntu/eoan -> ubuntu/eoan)
+2020-06-18 21:38:58,503 - EoanTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6
+2020-06-18 21:38:58,504 - EoanTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2020-06-18 21:38:58,515 - EoanTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/eoan/amd64/20200611/squashfs:root/squashfs
+2020-06-18 21:38:58,515 - EoanTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:38:58,538 - EoanTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2020-06-18 21:38:58,545 - EoanTestNetworkIPV6 - INFO - disk_serials: []
+2020-06-18 21:38:58,545 - EoanTestNetworkIPV6 - INFO - nvme_serials: []
+2020-06-18 21:38:58,545 - EoanTestNetworkIPV6 - INFO - nvme disks: []
+2020-06-18 21:38:58,556 - EoanTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:38:58,556 - EoanTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:38:58,563 - EoanTestNetworkIPV6 - INFO - Using root_disk: []
+2020-06-18 21:38:58,563 - EoanTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6/logs/install-serial.log
+2020-06-18 21:40:36,685 - XenialTestNetworkENISource - INFO - XenialTestNetworkENISource[install]: boot took 133.09 seconds. returned True
+2020-06-18 21:40:37,023 - XenialTestNetworkENISource - INFO - Install OK
+2020-06-18 21:40:37,023 - XenialTestNetworkENISource - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkENISource/logs/boot-serial.log
+2020-06-18 21:40:58,071 - FocalTestBonding - INFO - FocalTestBonding[install]: boot took 190.44 seconds. returned True
+2020-06-18 21:40:58,469 - FocalTestBonding - INFO - Install OK
+2020-06-18 21:40:58,470 - FocalTestBonding - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/FocalTestBonding/logs/boot-serial.log
+2020-06-18 21:40:59,553 - XenialTestNetworkIPV6 - INFO - XenialTestNetworkIPV6[install]: boot took 134.71 seconds. returned True
+2020-06-18 21:40:59,830 - XenialTestNetworkIPV6 - INFO - Install OK
+2020-06-18 21:40:59,830 - XenialTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/XenialTestNetworkIPV6/logs/boot-serial.log
+2020-06-18 21:41:09,689 - XenialTestNetworkENISource - INFO - XenialTestNetworkENISource[first_boot]: boot took 32.67 seconds. returned True
+2020-06-18 21:41:09,745 - XenialTestNetworkENISource - INFO - XenialTestNetworkENISource: setUpClass finished. took 166.69 seconds. Running testcases.
+get_test_files (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_clear_holders_ran (vmtests.test_network_enisource.XenialTestNetworkENISource) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_enisource.XenialTestNetworkENISource) ... SKIP: passthrough available on <class 'vmtests.test_network_enisource.XenialTestNetworkENISource'>
+test_cloudinit_network_passthrough (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_dname (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_dname_rules (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_etc_network_interfaces (vmtests.test_network_enisource.XenialTestNetworkENISource) ... SKIP: <class 'vmtests.test_network_enisource.XenialTestNetworkENISource'>: using net-passthrough; deferring to cloud-init
+test_etc_network_interfaces_source_cfg (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_etc_resolvconf (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_fstab (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_ip_output (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_kernel_img_conf (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_output_files_exist (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_reporting_data (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_source_cfg_exists (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_static_routes (vmtests.test_network_enisource.XenialTestNetworkENISource) ... ok
+test_swaps_used (vmtests.test_network_enisource.XenialTestNetworkENISource) ... SKIP: This test does not use storage config.
+2020-06-18 21:41:10,088 - BionicTestNetworkIPV6 - INFO - Logfile: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/debug.log .  Working dir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output
+2020-06-18 21:41:10,088 - BionicTestNetworkIPV6 - INFO - Starting setup for testclass: BionicTestNetworkIPV6 (ubuntu/bionic -> ubuntu/bionic)
+2020-06-18 21:41:10,221 - BionicTestNetworkIPV6 - INFO - Using tempdir: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6
+2020-06-18 21:41:10,221 - BionicTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2020-06-18 21:41:10,233 - BionicTestNetworkIPV6 - INFO - Publishing ephemeral image as --publish=/srv/images/bionic/amd64/20200618/squashfs:root/squashfs
+2020-06-18 21:41:10,233 - BionicTestNetworkIPV6 - INFO - Curtin install source URI: cp:///media/root-ro
+2020-06-18 21:41:10,256 - BionicTestNetworkIPV6 - INFO - Loading testcase config file: examples/network-ipv6-bond-vlan.yaml
+2020-06-18 21:41:10,263 - BionicTestNetworkIPV6 - INFO - disk_serials: []
+2020-06-18 21:41:10,263 - BionicTestNetworkIPV6 - INFO - nvme_serials: []
+2020-06-18 21:41:10,264 - BionicTestNetworkIPV6 - INFO - nvme disks: []
+2020-06-18 21:41:10,274 - BionicTestNetworkIPV6 - INFO - Adding apt repositories: ppa:cloud-init-dev/proposed
+2020-06-18 21:41:10,275 - BionicTestNetworkIPV6 - INFO - Adding late-commands to install packages: cloud-init
+2020-06-18 21:41:10,281 - BionicTestNetworkIPV6 - INFO - Using root_disk: []
+2020-06-18 21:41:10,281 - BionicTestNetworkIPV6 - INFO - Running curtin installer: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6/logs/install-serial.log
+2020-06-18 21:41:33,421 - FocalTestBonding - INFO - FocalTestBonding[first_boot]: boot took 34.95 seconds. returned True
+2020-06-18 21:41:33,482 - FocalTestBonding - INFO - FocalTestBonding: setUpClass finished. took 226.05 seconds. Running testcases.
+get_test_files (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_clear_holders_ran (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: passthrough available on <class 'vmtests.test_network_bonding.FocalTestBonding'>
+test_cloudinit_network_passthrough (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_dname (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_dname_rules (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_etc_network_interfaces (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: <class 'vmtests.test_network_bonding.FocalTestBonding'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_fstab (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_ifenslave_package_status (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_ip_output (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_kernel_img_conf (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_reporting_data (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_static_routes (vmtests.test_network_bonding.FocalTestBonding) ... ok
+test_swaps_used (vmtests.test_network_bonding.FocalTestBonding) ... SKIP: This test does not use storage config.
+2020-06-18 21:41:51,037 - XenialTestNetworkIPV6 - INFO - XenialTestNetworkIPV6[first_boot]: boot took 51.21 seconds. returned True
+2020-06-18 21:41:51,091 - XenialTestNetworkIPV6 - INFO - XenialTestNetworkIPV6: setUpClass finished. took 186.93 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.XenialTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.XenialTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_output_files_exist (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.XenialTestNetworkIPV6) ... SKIP: This test does not use storage config.
+2020-06-18 21:41:55,696 - EoanTestNetworkIPV6 - INFO - EoanTestNetworkIPV6[install]: boot took 177.13 seconds. returned True
+2020-06-18 21:41:55,982 - EoanTestNetworkIPV6 - INFO - Install OK
+2020-06-18 21:41:55,982 - EoanTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/EoanTestNetworkIPV6/logs/boot-serial.log
+2020-06-18 21:42:34,981 - EoanTestNetworkIPV6 - INFO - EoanTestNetworkIPV6[first_boot]: boot took 39.00 seconds. returned True
+2020-06-18 21:42:35,040 - EoanTestNetworkIPV6 - INFO - EoanTestNetworkIPV6: setUpClass finished. took 216.69 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.EoanTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.EoanTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... SKIP: LP: #1847257 kernel-img.conf not needed in eoan and newer
+test_output_files_exist (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.EoanTestNetworkIPV6) ... SKIP: This test does not use storage config.
+2020-06-18 21:43:32,676 - BionicTestNetworkIPV6 - INFO - BionicTestNetworkIPV6[install]: boot took 142.39 seconds. returned True
+2020-06-18 21:43:32,851 - BionicTestNetworkIPV6 - INFO - Install OK
+2020-06-18 21:43:32,852 - BionicTestNetworkIPV6 - INFO - Booting target image: /var/lib/jenkins/servers/server/workspace/curtin-cloudinit-sru/output/BionicTestNetworkIPV6/logs/boot-serial.log
+2020-06-18 21:44:15,581 - BionicTestNetworkIPV6 - INFO - BionicTestNetworkIPV6[first_boot]: boot took 42.73 seconds. returned True
+2020-06-18 21:44:15,640 - BionicTestNetworkIPV6 - INFO - BionicTestNetworkIPV6: setUpClass finished. took 185.55 seconds. Running testcases.
+get_test_files (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_clear_holders_ran (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: This test does not use storage config.
+test_cloudinit_network_disabled (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: passthrough available on <class 'vmtests.test_network_ipv6.BionicTestNetworkIPV6'>
+test_cloudinit_network_passthrough (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_dname (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_dname_rules (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_etc_network_interfaces (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: <class 'vmtests.test_network_ipv6.BionicTestNetworkIPV6'>: using net-passthrough; deferring to cloud-init
+test_etc_resolvconf (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_fstab (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_installed_correct_kernel_package (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_interfacesd_eth0_removed (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_ip_output (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_kernel_img_conf (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_output_files_exist (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_reporting_data (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_static_routes (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... ok
+test_swaps_used (vmtests.test_network_ipv6.BionicTestNetworkIPV6) ... SKIP: This test does not use storage config.
+
+----------------------------------------------------------------------
+Ran 950 tests in 2737.751s
+
+OK (SKIP=258)
+Thu, 18 Jun 2020 21:44:16 +0000: vmtest end [0] in 2742s
+cleanup: deleting links and image files
+Archiving artifacts
+Started calculate disk usage of build
+Finished Calculation of disk usage of build in 0 seconds
+Started calculate disk usage of workspace
+Finished Calculation of disk usage of workspace in  1 second
+Finished: SUCCESS


### PR DESCRIPTION
Our jenkins server runs a manual test curtin-cloudinit-sru that needs to be validated when we SRU.

This PR also updates ./bin/sru-get-jenkins-logs to download and copy the latest success from the curtin-cloudinit-sru job.

Harvest these scripts by:
 - connecting to the VPN
- running ./bin/sru-get-jenkins-logs  20.2.45 1881018  

The branch grabs and stores the logs. We ensure we don't see errors in the logs and that it is testing ~cloud-init-dev/proposed ppa

Here is the successful run from jenkins of the curtin-cloudinit-sru that was downloaded.

https://jenkins.ubuntu.com/server/view/cloud-init,%20curtin,%20streams/job/curtin-cloudinit-sru/14/consoleFull

 The rest of the nocloud tests were already committed in #114.