### PR TITLE
sru/20.2.45 azure sru verification results

### DIFF
--- a/manual/azure-sru-20.2.45.txt
+++ b/manual/azure-sru-20.2.45.txt
@@ -321,12 +321,16 @@ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELE
     echo 'Get cloud-id'
     ssh $sshopts $IP -- cloud-id
     ssh $sshopts $IP -- cloud-init query --format "'cloud-region: {{cloud_name}}-{{ds.meta_data.imds.compute.location}}'"
-    echo 'Validating whether metadata is being updated per boot LP:1819913. Expect last log to be Sytem Boot'
+    echo 'Validating whether metadata is being updated per boot LP:1819913. Expect last log to be System Boot'
     ssh $sshopts $IP -- sudo reboot || true
     sleep 30
     ssh $sshopts $IP -- cloud-init status --wait --long
     echo 'After reboot'
     ssh $sshopts $IP -- "grep 'Update datasource' /var/log/cloud-init.log"
+
+    echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+    echo "Azure needs to use __builtin__ agent by default on all releases"
+    ssh $sshopts $IP -- "egrep 'fabric' /var/log/cloud-init.log"
 done
 echo "### END $UBUNTU_RELEASE"
 
@@ -1494,8 +1498,8 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: DHCPACK of 10.0.0.4 from 168.63.129.16
 +Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPACK of 10.0.0.4 from 168.63.129.16
 + echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
-Azure needs to use __builtin__ agent by default on all releases
-+ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Validate https://github.com/canonical/cloud-init/commit/22e683df
+echo "Azure needs to use __builtin__ agent by default on all releases"
 Azure needs to use __builtin__ agent by default on all releases
 2020-06-18 18:36:52,070 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
 2020-06-18 18:36:52,070 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
@@ -2388,8 +2392,8 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPACK of 10.0.0.4 from 168.63.129.16
 +Jun 18 18:41:48 SRU-worked-azure systemd-networkd[856]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
 + echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
-Azure needs to use __builtin__ agent by default on all releases
-+ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Validate https://github.com/canonical/cloud-init/commit/22e683df
++ echo "Azure needs to use __builtin__ agent by default on all releases"
 Azure needs to use __builtin__ agent by default on all releases
 2020-06-18 18:41:45,859 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
 2020-06-18 18:41:45,859 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
@@ -3302,8 +3306,8 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0xe60a9272)
 +Jun 18 18:45:50 SRU-worked-azure systemd-networkd[543]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
 + echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
-Azure needs to use __builtin__ agent by default on all releases
-+ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Validate https://github.com/canonical/cloud-init/commit/22e683df
++ echo "Azure needs to use __builtin__ agent by default on all releases"
 Azure needs to use __builtin__ agent by default on all releases
 2020-06-18 18:45:46,061 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
 2020-06-18 18:45:46,061 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric

--- a/manual/azure-sru-20.2.45.txt
+++ b/manual/azure-sru-20.2.45.txt
@@ -18,7 +18,7 @@ parse_args $0 $@
 assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME \
   AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP \
   AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
-create_samplecloudconfig
+create_samplecloudconfig SAMPLE_CLOUDCONFIG
 create_setup_proposed_script
 
 AZURE_VNET_NAME=$AZURE_VNET_NAME-$UBUNTU_RELEASE
@@ -335,120 +335,134 @@ done
 echo "### END $UBUNTU_RELEASE"
 
 
+
 === BEGIN verification output ===
 + SRU_VARS=./sru-scripts/sru-vars.template
-+ [ ! -f ./sru-scripts/sru-vars.template ]
++ '[' '!' -f ./sru-scripts/sru-vars.template ']'
 + . ./sru-scripts/sru-vars.template
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=UNSET
-+ PROPOSED_SCRIPT=setup_proposed.sh
-+ USE_DEV_PPA=0
-+ SAMPLE_CLOUDCONFIG=sethostname.yaml
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=UNSET
-+ AZURE_VNET_NAME=UNSET
-+ AZURE_NETWORK_SECURITY_GROUP=UNSET
-+ AZURE_NIC_NAME=UNSET
-+ AZURE_RESOURCE_GROUP=UNSET
-+ AZURE_BOOT_DIAG=UNSET
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
-+ SRU_VARS_RC=.sru-vars.rc
-+ [ -f .sru-vars.rc ]
-+ [ -f /root/.sru-vars.rc ]
-+ . /root/.sru-vars.rc
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=chad.smith
-+ USE_DEV_PPA=0
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=eastus2
-+ AZURE_VNET_NAME=sruVnet
-+ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
-+ AZURE_NIC_NAME=sruNic
-+ AZURE_RESOURCE_GROUP=srugroupIPV6
-+ AZURE_BOOT_DIAG=storeitsru
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
+++ PRESERVE_INSTANCE=false
+++ UBUNTU_RELEASE=
+++ LP_USER=UNSET
+++ PROPOSED_SCRIPT=setup_proposed.sh
+++ USE_DEV_PPA=0
+++ ENI_NETCFG_FILE=/etc/network/interfaces.d/50-cloud-init.cfg
+++ NETPLAN_NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
+++ SAMPLE_CLOUDCONFIG=sethostname.yaml
+++ SSH_KEY=/root/.ssh/id_rsa.pub
+++ SSHOPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+++ AZURE_REGION=UNSET
+++ AZURE_VNET_NAME=UNSET
+++ AZURE_NETWORK_SECURITY_GROUP=UNSET
+++ AZURE_NIC_NAME=UNSET
+++ AZURE_RESOURCE_GROUP=UNSET
+++ AZURE_BOOT_DIAG=UNSET
+++ AZURE_ADVANCED_NIC_TESTS=true
+++ GCE_ZONE=UNSET
+++ OPENSTACK_ADMIN_NET_ID=UNSET
+++ OPENSTACK_SSH_KEY_NAME=UNSET
+++ SRU_VARS_RC=.sru-vars.rc
+++ '[' -f .sru-vars.rc ']'
+++ '[' -f /root/.sru-vars.rc ']'
+++ . /root/.sru-vars.rc
++++ PRESERVE_INSTANCE=false
++++ UBUNTU_RELEASE=
++++ LP_USER=chad.smith
++++ USE_DEV_PPA=0
++++ SSH_KEY=/root/.ssh/id_rsa.pub
++++ AZURE_REGION=eastus2
++++ AZURE_VNET_NAME=sruVnet
++++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++++ AZURE_NIC_NAME=sruNic
++++ AZURE_RESOURCE_GROUP=srugroupIPV6
++++ AZURE_BOOT_DIAG=storeitsru
++++ AZURE_ADVANCED_NIC_TESTS=true
++++ GCE_ZONE=UNSET
++++ OPENSTACK_ADMIN_NET_ID=UNSET
++++ OPENSTACK_SSH_KEY_NAME=UNSET
 + parse_args ./sru-scripts/manual/azure-sru xenial
 + script=./sru-scripts/manual/azure-sru
 + shift
-+ [ 1 = 0 ]
-+ [ 1 -ne 0 ]
++ '[' 1 = 0 ']'
++ '[' 1 -ne 0 ']'
++ case "$1" in
 + UBUNTU_RELEASE=xenial
++ NETCFG_FILE=/etc/network/interfaces.d/50-cloud-init.cfg
 + shift
-+ [ 0 -ne 0 ]
-+ [ -z xenial ]
++ '[' 0 -ne 0 ']'
++ '[' -z xenial ']'
 + assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
 + local value=
-+ eval value=$PROPOSED_SCRIPT > /dev/null
-+ value=setup_proposed.sh
-+ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
-+ eval value=$AZURE_REGION > /dev/null
-+ value=eastus2
-+ [ -z eastus2 -o eastus2 = UNSET ]
-+ eval value=$AZURE_VNET_NAME > /dev/null
-+ value=sruVnet
-+ [ -z sruVnet -o sruVnet = UNSET ]
-+ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
-+ value=sruNetSecGroup
-+ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
-+ eval value=$AZURE_NIC_NAME > /dev/null
-+ value=sruNic
-+ [ -z sruNic -o sruNic = UNSET ]
-+ eval value=$AZURE_RESOURCE_GROUP > /dev/null
-+ value=srugroupIPV6
-+ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
-+ eval value=$AZURE_BOOT_DIAG > /dev/null
-+ value=storeitsru
-+ [ -z storeitsru -o storeitsru = UNSET ]
-+ eval value=$SSH_KEY > /dev/null
-+ value=/root/.ssh/id_rsa.pub
-+ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
-+ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
-+ value=sethostname.yaml
-+ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
-+ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
-+ value=true
-+ [ -z true -o true = UNSET ]
-+ create_samplecloudconfig
-+ filename=sethostname.yaml
++ for var in $@
++ eval 'value=$PROPOSED_SCRIPT > /dev/null'
+++ value=setup_proposed.sh
++ '[' -z setup_proposed.sh -o setup_proposed.sh = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_REGION > /dev/null'
+++ value=eastus2
++ '[' -z eastus2 -o eastus2 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_VNET_NAME > /dev/null'
+++ value=sruVnet
++ '[' -z sruVnet -o sruVnet = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null'
+++ value=sruNetSecGroup
++ '[' -z sruNetSecGroup -o sruNetSecGroup = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NIC_NAME > /dev/null'
+++ value=sruNic
++ '[' -z sruNic -o sruNic = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_RESOURCE_GROUP > /dev/null'
+++ value=srugroupIPV6
++ '[' -z srugroupIPV6 -o srugroupIPV6 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_BOOT_DIAG > /dev/null'
+++ value=storeitsru
++ '[' -z storeitsru -o storeitsru = UNSET ']'
++ for var in $@
++ eval 'value=$SSH_KEY > /dev/null'
+++ value=/root/.ssh/id_rsa.pub
++ '[' -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ']'
++ for var in $@
++ eval 'value=$SAMPLE_CLOUDCONFIG > /dev/null'
+++ value=sethostname.yaml
++ '[' -z sethostname.yaml -o sethostname.yaml = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_ADVANCED_NIC_TESTS > /dev/null'
+++ value=true
++ '[' -z true -o true = UNSET ']'
++ create_samplecloudconfig SAMPLE_CLOUDCONFIG
++ filename=SAMPLE_CLOUDCONFIG
 + cat
 + create_setup_proposed_script
-+ [ 0 -eq 0 ]
++ '[' 0 -eq 0 ']'
 + cat
 + AZURE_VNET_NAME=sruVnet-xenial
-+ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
-+ jq -r .properties.state
+++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
+++ jq -r .properties.state
 + IPV6_NET_REGISTERED=Registered
-+ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
-+ jq -r .properties.state
+++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
+++ jq -r .properties.state
 + IPV6_CA_LB_REGISTERED=Registered
-+ [ Registered != Registered -o Registered != Registered ]
-+ + az provider showjq -n -r Microsoft.Network .registrationState
-
++ '[' Registered '!=' Registered -o Registered '!=' Registered ']'
+++ az provider show -n Microsoft.Network
+++ jq -r .registrationState
 + IPV6_REGISTRATION_COMPLETE=Registered
-+ echo Waiting for Microsoft.Network IPv6 feature registration
++ echo 'Waiting for Microsoft.Network IPv6 feature registration'
 Waiting for Microsoft.Network IPv6 feature registration
-+ [ Registered != Registered ]
-+ echo ### BEGIN xenial
++ '[' Registered '!=' Registered ']'
++ echo '### BEGIN xenial'
 ### BEGIN xenial
 + az group show -g srugroupIPV6
-+ [ -n storeitsru ]
++ '[' -n storeitsru ']'
 + az storage account show --name storeitsru
 + az storage account create --name storeitsru --resource-group srugroupIPV6 --location eastus2 --sku Standard_RAGRS --kind StorageV2
 The default kind for created storage account will change to 'StorageV2' from 'Storage' in future
 {
   "accessTier": "Hot",
   "azureFilesIdentityBasedAuthentication": null,
-  "creationTime": "2020-06-18T18:32:15.827025+00:00",
+  "creationTime": "2020-06-24T20:03:01.724910+00:00",
   "customDomain": null,
   "enableHttpsTrafficOnly": true,
   "encryption": {
@@ -457,11 +471,11 @@ The default kind for created storage account will change to 'StorageV2' from 'St
     "services": {
       "blob": {
         "enabled": true,
-        "lastEnabledTime": "2020-06-18T18:32:15.920777+00:00"
+        "lastEnabledTime": "2020-06-24T20:03:01.818678+00:00"
       },
       "file": {
         "enabled": true,
-        "lastEnabledTime": "2020-06-18T18:32:15.920777+00:00"
+        "lastEnabledTime": "2020-06-24T20:03:01.818678+00:00"
       },
       "queue": null,
       "table": null
@@ -517,7 +531,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
   "tags": {},
   "type": "Microsoft.Storage/storageAccounts"
 }
-+ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ AZURE_BOOT_DIAG_ARG='--boot-diagnostics-storage storeitsru'
 + az network nsg show --name sruNetSecGroup -g srugroupIPV6
 + az network nsg create --resource-group srugroupIPV6 --location eastus2 --name sruNetSecGroup
 {
@@ -532,7 +546,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "destinationPortRange": "*",
         "destinationPortRanges": [],
         "direction": "Inbound",
-        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
         "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowVnetInBound",
         "name": "AllowVnetInBound",
         "priority": 65000,
@@ -555,7 +569,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "destinationPortRange": "*",
         "destinationPortRanges": [],
         "direction": "Inbound",
-        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
         "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowAzureLoadBalancerInBound",
         "name": "AllowAzureLoadBalancerInBound",
         "priority": 65001,
@@ -578,7 +592,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "destinationPortRange": "*",
         "destinationPortRanges": [],
         "direction": "Inbound",
-        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
         "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/DenyAllInBound",
         "name": "DenyAllInBound",
         "priority": 65500,
@@ -601,7 +615,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "destinationPortRange": "*",
         "destinationPortRanges": [],
         "direction": "Outbound",
-        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
         "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowVnetOutBound",
         "name": "AllowVnetOutBound",
         "priority": 65000,
@@ -624,7 +638,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "destinationPortRange": "*",
         "destinationPortRanges": [],
         "direction": "Outbound",
-        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
         "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowInternetOutBound",
         "name": "AllowInternetOutBound",
         "priority": 65001,
@@ -647,7 +661,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "destinationPortRange": "*",
         "destinationPortRanges": [],
         "direction": "Outbound",
-        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
         "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/DenyAllOutBound",
         "name": "DenyAllOutBound",
         "priority": 65500,
@@ -662,14 +676,14 @@ The default kind for created storage account will change to 'StorageV2' from 'St
         "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
       }
     ],
-    "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+    "etag": "W/\"b9896fc0-d4a1-4a0f-bfec-ecb3ee3b7cbd\"",
     "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
     "location": "eastus2",
     "name": "sruNetSecGroup",
     "networkInterfaces": null,
     "provisioningState": "Succeeded",
     "resourceGroup": "srugroupIPV6",
-    "resourceGuid": "05112927-8422-43ab-802d-aa64aca51b4b",
+    "resourceGuid": "b621db15-663e-496a-afec-6614cefb4ba3",
     "securityRules": [],
     "subnets": null,
     "tags": null,
@@ -677,7 +691,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
   }
 }
 + az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
-+ az network nsg rule create --name allowSSHIn --nsg-name sruNetSecGroup --resource-group srugroupIPV6 --priority 100 --description Allow SSH In --access Allow --protocol * --direction Inbound --source-address-prefixes * --source-port-ranges * --destination-address-prefixes * --destination-port-ranges 22
++ az network nsg rule create --name allowSSHIn --nsg-name sruNetSecGroup --resource-group srugroupIPV6 --priority 100 --description 'Allow SSH In' --access Allow --protocol '*' --direction Inbound --source-address-prefixes '*' --source-port-ranges '*' --destination-address-prefixes '*' --destination-port-ranges 22
 {
   "access": "Allow",
   "description": "Allow SSH In",
@@ -687,7 +701,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
   "destinationPortRange": "22",
   "destinationPortRanges": [],
   "direction": "Inbound",
-  "etag": "W/\"90ed4ab5-74f9-41a6-bbe2-2fa99a366f32\"",
+  "etag": "W/\"b4c3e273-4d2a-4617-8454-b7fa4d681576\"",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/securityRules/allowSSHIn",
   "name": "allowSSHIn",
   "priority": 100,
@@ -702,7 +716,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
   "type": "Microsoft.Network/networkSecurityGroups/securityRules"
 }
 + az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
-+ az network nsg rule create --name allowAllOut --resource-group srugroupIPV6 --nsg-name sruNetSecGroup --priority 200 --description Allow All Out --access Allow --protocol * --direction Outbound --source-address-prefixes * --source-port-ranges * --destination-address-prefixes * --destination-port-ranges *
++ az network nsg rule create --name allowAllOut --resource-group srugroupIPV6 --nsg-name sruNetSecGroup --priority 200 --description 'Allow All Out' --access Allow --protocol '*' --direction Outbound --source-address-prefixes '*' --source-port-ranges '*' --destination-address-prefixes '*' --destination-port-ranges '*'
 {
   "access": "Allow",
   "description": "Allow All Out",
@@ -712,7 +726,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
   "destinationPortRange": "*",
   "destinationPortRanges": [],
   "direction": "Outbound",
-  "etag": "W/\"851362de-277d-4855-b8d3-67456650aa34\"",
+  "etag": "W/\"62389d2b-51ef-4e18-bf40-f14f59a44d1e\"",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/securityRules/allowAllOut",
   "name": "allowAllOut",
   "priority": 200,
@@ -742,13 +756,13 @@ The default kind for created storage account will change to 'StorageV2' from 'St
     },
     "enableDdosProtection": false,
     "enableVmProtection": false,
-    "etag": "W/\"3355d29f-09a9-47b6-a32c-0d3371f124da\"",
+    "etag": "W/\"57c13696-72ec-40ec-888c-be5cff26d977\"",
     "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-xenial",
     "location": "eastus2",
     "name": "sruVnet-xenial",
     "provisioningState": "Succeeded",
     "resourceGroup": "srugroupIPV6",
-    "resourceGuid": "5b48766f-4c15-4579-aebb-7dd9da916ffa",
+    "resourceGuid": "d567f16a-643e-4e5f-90d0-e3ae1130f7fe",
     "subnets": [],
     "tags": {},
     "type": "Microsoft.Network/virtualNetworks",
@@ -764,7 +778,7 @@ The default kind for created storage account will change to 'StorageV2' from 'St
     "ace:cab:deca:deed::/64"
   ],
   "delegations": [],
-  "etag": "W/\"7f7f041b-698d-4db5-b783-a0bcc046d2fb\"",
+  "etag": "W/\"674987bd-d9d9-41d2-808f-d26c2be31ad2\"",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-xenial/subnets/sruSubnet",
   "ipConfigurationProfiles": null,
   "ipConfigurations": null,
@@ -798,12 +812,14 @@ The default kind for created storage account will change to 'StorageV2' from 'St
   "serviceEndpoints": null,
   "type": "Microsoft.Network/virtualNetworks/subnets"
 }
-+ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ sshopts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR'
 + netcfg=/etc/netplan/50-cloud-init.yaml
++ case $UBUNTU_RELEASE in
 + image_version=Canonical:UbuntuServer:16.04-DAILY-LTS
 + netcfg=/etc/network/interfaces.d/50-cloud-init.cfg
-+ [  =  ]
-+ echo Creating standard network vm
++ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELEASE --size Standard_DS2_v2"
++ '[' '' = '' ']'
++ echo 'Creating standard network vm'
 Creating standard network vm
 + name=test-sru-xenial
 + az vm show --name test-sru-xenial -g srugroupIPV6
@@ -812,28 +828,28 @@ Creating standard network vm
   "fqdns": "",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-xenial",
   "location": "eastus2",
-  "macAddress": "00-0D-3A-7E-7A-14",
+  "macAddress": "00-0D-3A-E6-60-59",
   "powerState": "VM running",
   "privateIpAddress": "10.0.0.4",
-  "publicIpAddress": "20.36.167.25",
+  "publicIpAddress": "20.186.42.44",
   "resourceGroup": "srugroupIPV6",
   "zones": ""
 }
-+ az vm list-ip-addresses --name test-sru-xenial
-+ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
-+ awk {printf "ubuntu@%s", $1}
-+ IP=ubuntu@20.36.167.25
-+ echo Created test-sru-xenial: ubuntu@ubuntu@20.36.167.25
-Created test-sru-xenial: ubuntu@ubuntu@20.36.167.25
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init status --wait --long
+++ az vm list-ip-addresses --name test-sru-xenial
+++ jq -r '.[] | .virtualMachine.network.publicIpAddresses[].ipAddress'
+++ awk '{printf "ubuntu@%s", $1}'
++ IP=ubuntu@20.186.42.44
++ echo 'Created test-sru-xenial: ubuntu@ubuntu@20.186.42.44'
+Created test-sru-xenial: ubuntu@ubuntu@20.186.42.44
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cloud-init status --wait --long
 
 status: done
-time: Thu, 18 Jun 2020 18:35:23 +0000
+time: Wed, 24 Jun 2020 20:06:30 +0000
 detail:
 DataSourceAzure [seed=/dev/sr0]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- dpkg-query --show cloud-init
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- dpkg-query --show cloud-init
 cloud-init	19.4-33-gbb4131a2-0ubuntu1~16.04.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo cat /run/cloud-init/result.json
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo cat /run/cloud-init/result.json
 sudo: unable to resolve host SRU-worked-azure
 {
  "v1": {
@@ -841,246 +857,245 @@ sudo: unable to resolve host SRU-worked-azure
   "errors": []
  }
 }
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- systemd-analyze
-Startup finished in 5.646s (kernel) + 24.900s (userspace) = 30.546s
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- systemd-analyze blame
-          8.012s cloud-init.service
-          4.461s cloud-config.service
-          3.763s cloud-init-local.service
-          2.510s snapd.service
-          2.162s pollinate.service
-          2.093s lxd-containers.service
-          1.849s dev-sda1.device
-          1.659s snapd.seeded.service
-          1.427s apparmor.service
-           923ms accounts-daemon.service
-           739ms networking.service
-           654ms cloud-final.service
-           594ms iscsid.service
-           526ms systemd-logind.service
-           522ms rsyslog.service
-           472ms grub-common.service
-           453ms mdadm.service
-           450ms lvm2-monitor.service
-           412ms open-iscsi.service
-           388ms systemd-timesyncd.service
-           281ms ssh.service
-           258ms systemd-modules-load.service
-           256ms resolvconf.service
-           250ms apport.service
-           216ms kmod-static-nodes.service
-           210ms keyboard-setup.service
-           209ms console-setup.service
-           209ms systemd-update-utmp.service
-           208ms ufw.service
-           208ms dev-mqueue.mount
-           208ms systemd-remount-fs.service
-           193ms lxd.socket
-           189ms irqbalance.service
-           175ms sys-kernel-debug.mount
-           162ms systemd-udev-trigger.service
-           160ms systemd-tmpfiles-setup-dev.service
-           157ms dev-hugepages.mount
-           133ms systemd-journald.service
-           102ms snapd.socket
-            99ms systemd-journal-flush.service
-            98ms systemd-udevd.service
-            87ms polkitd.service
-            74ms systemd-user-sessions.service
-            70ms systemd-machine-id-commit.service
-            62ms ondemand.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- systemd-analyze
+Startup finished in 5.650s (kernel) + 24.332s (userspace) = 29.982s
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- systemd-analyze blame
+          7.833s cloud-init.service
+          4.235s cloud-config.service
+          3.940s cloud-init-local.service
+          1.874s dev-sda1.device
+          1.869s snapd.service
+          1.764s pollinate.service
+          1.619s snapd.seeded.service
+          1.498s apparmor.service
+          1.485s lxd-containers.service
+           812ms networking.service
+           790ms cloud-final.service
+           764ms accounts-daemon.service
+           575ms mdadm.service
+           559ms iscsid.service
+           537ms lvm2-monitor.service
+           451ms systemd-timesyncd.service
+           366ms open-iscsi.service
+           362ms systemd-logind.service
+           343ms rsyslog.service
+           340ms grub-common.service
+           291ms rc-local.service
+           275ms console-setup.service
+           262ms irqbalance.service
+           249ms systemd-modules-load.service
+           226ms resolvconf.service
+           204ms systemd-journald.service
+           175ms systemd-udev-trigger.service
+           163ms polkitd.service
+           161ms kmod-static-nodes.service
+           160ms keyboard-setup.service
+           158ms systemd-remount-fs.service
+           157ms apport.service
+           156ms systemd-tmpfiles-setup-dev.service
+           153ms sys-kernel-debug.mount
+           151ms dev-hugepages.mount
+           144ms ufw.service
+           124ms ondemand.service
+           111ms snapd.socket
+           111ms systemd-udevd.service
+           111ms systemd-journal-flush.service
+            96ms systemd-random-seed.service
+            95ms ssh.service
+            85ms lxd.socket
+            78ms plymouth-read-write.service
+            72ms plymouth-quit-wait.service
+            69ms systemd-tmpfiles-setup.service
+            62ms plymouth-quit.service
             56ms systemd-sysctl.service
-            55ms plymouth-read-write.service
-            53ms systemd-tmpfiles-setup.service
-            49ms setvtrgb.service
-            48ms rc-local.service
-            37ms systemd-random-seed.service
-            30ms ephemeral-disk-warning.service
-            30ms boot-efi.mount
-            29ms plymouth-quit-wait.service
-            29ms sys-fs-fuse-connections.mount
-            26ms plymouth-quit.service
-            25ms sys-kernel-config.mount
-            20ms user@1000.service
-             9ms systemd-update-utmp-runlevel.service
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze show
+            50ms systemd-machine-id-commit.service
+            46ms sys-kernel-config.mount
+            46ms systemd-update-utmp.service
+            34ms dev-mqueue.mount
+            34ms ephemeral-disk-warning.service
+            29ms systemd-user-sessions.service
+            22ms boot-efi.mount
+            21ms user@1000.service
+            17ms setvtrgb.service
+            15ms sys-fs-fuse-connections.mount
+            10ms systemd-update-utmp-runlevel.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cloud-init analyze show
 -- Boot Record 01 --
 The total time elapsed since completing an event is printed after the "@" character.
 The time the event takes is printed after the "+" character.
 
 Starting stage: init-local
-|`->no cache found @00.00400s +00.00000s
+|`->no cache found @00.00500s +00.00000s
 Starting stage: init-local/search-Azure
 Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.10300s +00.00600s
-|`->get_boot_telemetry @00.10900s +00.00900s
-|`->get_system_info @00.11800s +00.00100s
+|`->found azure asset tag @00.12800s +00.00600s
+|`->get_boot_telemetry @00.13400s +00.00900s
+|`->get_system_info @00.14400s +00.00000s
 Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.11900s +00.05700s
-|`->load_azure_ds_dir @00.17600s +00.00000s
+|`->list_possible_azure_ds_devs @00.14400s +00.05800s
+|`->load_azure_ds_dir @00.20200s +00.00000s
 Starting stage: azure-ds/load_azure_ds_dir
 Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.29700s +00.00000s
-|`->_extract_preprovisioned_vm_setting @00.29700s +00.00100s
-Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+|`->load_azure_ovf_pubkeys @00.36200s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.36300s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.01500 seconds
 
-Finished stage: (azure-ds/load_azure_ds_dir) 00.00800 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.02000 seconds
 
 Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.33200s +00.27400s
-|`->_get_metadata_from_imds @00.60600s +00.10200s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.40100 seconds
+|`->obtain dhcp lease @00.39700s +00.44100s
+|`->_get_metadata_from_imds @00.83800s +00.04700s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.50900 seconds
 
-|`->_get_random_seed @00.73300s +00.00100s
-Finished stage: (azure-ds/crawl_metadata) 00.62100 seconds
+|`->_get_random_seed @00.90700s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.77000 seconds
 
-|`->write_files @00.74100s +00.00200s
-Finished stage: (azure-ds/_get_data) 00.64000 seconds
+|`->write_files @00.91400s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.78800 seconds
 
-Finished stage: (init-local/search-Azure) 00.64300 seconds
+Finished stage: (init-local/search-Azure) 00.79100 seconds
 
-|`->network config from fallback @00.80800s +00.02000s
-Finished stage: (init-local) 00.84100 seconds
+|`->network config from fallback @00.97500s +00.01900s
+Finished stage: (init-local) 01.00900 seconds
 
 Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @01.98000s +00.02200s
-|`->network config from fallback @02.05600s +00.02000s
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @02.23300s +00.02300s
+|`->network config from fallback @02.31100s +00.02200s
 Starting stage: init-network/setup-datasource
 Starting stage: azure-ds/setup
 Starting stage: azure-ds/_negotiate
 Starting stage: azure-ds/get_metadata_from_agent
 Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @02.08400s +00.00000s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+|`->temporary_hostname @02.34200s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
 
-|`->invoke_agent @02.08700s +00.17700s
-|`->wait for agents to retrieve SSH keys @02.26400s +01.00200s
+|`->invoke_agent @02.34500s +00.18000s
+|`->wait for agents to retrieve SSH keys @02.52500s +01.00300s
 Starting stage: azure-ds/pubkeys_from_crt_files
-|`->crtfile_to_pubkey @03.26700s +00.03100s
-Finished stage: (azure-ds/pubkeys_from_crt_files) 00.03200 seconds
+|`->crtfile_to_pubkey @03.52800s +00.03600s
+Finished stage: (azure-ds/pubkeys_from_crt_files) 00.03600 seconds
 
-Finished stage: (azure-ds/get_metadata_from_agent) 01.21500 seconds
+Finished stage: (azure-ds/get_metadata_from_agent) 01.22200 seconds
 
-Finished stage: (azure-ds/_negotiate) 01.21600 seconds
+Finished stage: (azure-ds/_negotiate) 01.22200 seconds
 
-Finished stage: (azure-ds/setup) 01.21600 seconds
+Finished stage: (azure-ds/setup) 01.22300 seconds
 
-Finished stage: (init-network/setup-datasource) 01.21600 seconds
+Finished stage: (init-network/setup-datasource) 01.22300 seconds
 
-|`->reading and applying user-data @03.30500s +00.00800s
-|`->reading and applying vendor-data @03.31300s +00.00000s
+|`->reading and applying user-data @03.57200s +00.00800s
+|`->reading and applying vendor-data @03.58000s +00.00000s
 Starting stage: init-network/activate-datasource
 Starting stage: azure-ds/activate
 Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @03.34300s +00.00000s
+|`->wait for ephemeral disk @03.61000s +00.00000s
 Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @03.34300s +00.05200s
+|`->_has_ntfs_filesystem @03.61000s +00.05100s
 Starting stage: azure-ds/mount-ntfs-and-count
-|`->count_files @03.45300s +00.00200s
-Finished stage: (azure-ds/mount-ntfs-and-count) 00.06700 seconds
+|`->count_files @03.72900s +00.00200s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.07600 seconds
 
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.11900 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.12700 seconds
 
-Finished stage: (azure-ds/address_ephemeral_resize) 00.11900 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.12700 seconds
 
-Finished stage: (azure-ds/activate) 00.12000 seconds
+Finished stage: (azure-ds/activate) 00.12700 seconds
 
-Finished stage: (init-network/activate-datasource) 00.12200 seconds
+Finished stage: (init-network/activate-datasource) 00.13000 seconds
 
-|`->config-migrator ran successfully @03.51000s +00.00100s
-|`->config-seed_random ran successfully @03.51100s +00.00100s
-|`->config-bootcmd ran successfully @03.51300s +00.00000s
-|`->config-write-files ran successfully @03.51400s +00.00000s
-|`->config-growpart ran successfully @03.51500s +00.37900s
-|`->config-resizefs ran successfully @03.89400s +00.24700s
-|`->config-disk_setup ran successfully @04.14100s +04.38700s
-|`->config-mounts ran successfully @08.52800s +00.12200s
-|`->config-set_hostname ran successfully @08.65000s +00.00600s
-|`->config-update_hostname ran successfully @08.65600s +00.00200s
-|`->config-update_etc_hosts ran successfully @08.65800s +00.00000s
-|`->config-ca-certs ran successfully @08.65900s +00.00100s
-|`->config-rsyslog ran successfully @08.66000s +00.00100s
-|`->config-users-groups ran successfully @08.66100s +00.72900s
-|`->config-ssh ran successfully @09.39100s +00.19500s
-Finished stage: (init-network) 07.62000 seconds
+|`->config-migrator ran successfully @03.80900s +00.00100s
+|`->config-seed_random ran successfully @03.81100s +00.00100s
+|`->config-bootcmd ran successfully @03.81200s +00.00100s
+|`->config-write-files ran successfully @03.81300s +00.00100s
+|`->config-growpart ran successfully @03.81400s +00.34800s
+|`->config-resizefs ran successfully @04.16300s +00.24400s
+|`->config-disk_setup ran successfully @04.40800s +04.35200s
+|`->config-mounts ran successfully @08.76000s +00.13000s
+|`->config-set_hostname ran successfully @08.89100s +00.00500s
+|`->config-update_hostname ran successfully @08.89700s +00.00100s
+|`->config-update_etc_hosts ran successfully @08.89900s +00.00000s
+|`->config-ca-certs ran successfully @08.90000s +00.00000s
+|`->config-rsyslog ran successfully @08.90100s +00.00100s
+|`->config-users-groups ran successfully @08.90200s +00.60700s
+|`->config-ssh ran successfully @09.51000s +00.13100s
+Finished stage: (init-network) 07.42100 seconds
 
 Starting stage: modules-config
-|`->config-emit_upstart ran successfully @15.00800s +00.00200s
-|`->config-snap ran successfully @15.01300s +00.00400s
-|`->config-ssh-import-id ran successfully @15.02400s +00.94800s
-|`->config-locale ran successfully @15.97300s +01.27600s
-|`->config-set-passwords ran successfully @17.25000s +00.00100s
-|`->config-grub-dpkg ran successfully @17.25200s +01.08300s
-|`->config-apt-pipelining ran successfully @18.33600s +00.00100s
-|`->config-apt-configure ran successfully @18.33700s +00.29800s
-|`->config-ubuntu-advantage ran successfully @18.63500s +00.00200s
-|`->config-ntp ran successfully @18.63700s +00.00100s
-|`->config-timezone ran successfully @18.63800s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @18.64000s +00.00000s
-|`->config-runcmd ran successfully @18.64000s +00.00100s
-|`->config-byobu ran successfully @18.64100s +00.00100s
-Finished stage: (modules-config) 03.68400 seconds
+|`->config-emit_upstart ran successfully @14.18100s +00.00100s
+|`->config-snap ran successfully @14.18300s +00.00200s
+|`->config-ssh-import-id ran successfully @14.18500s +01.08300s
+|`->config-locale ran successfully @15.26900s +01.43300s
+|`->config-set-passwords ran successfully @16.70300s +00.00200s
+|`->config-grub-dpkg ran successfully @16.70500s +00.93500s
+|`->config-apt-pipelining ran successfully @17.64100s +00.00100s
+|`->config-apt-configure ran successfully @17.64200s +00.30100s
+|`->config-ubuntu-advantage ran successfully @17.94300s +00.00100s
+|`->config-ntp ran successfully @17.94500s +00.00100s
+|`->config-timezone ran successfully @17.94600s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @17.94700s +00.00000s
+|`->config-runcmd ran successfully @17.94800s +00.00100s
+|`->config-byobu ran successfully @17.94900s +00.00100s
+Finished stage: (modules-config) 03.81600 seconds
 
 Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @19.10700s +00.00100s
-|`->config-fan ran successfully @19.10900s +00.00100s
-|`->config-landscape ran successfully @19.11000s +00.00100s
-|`->config-lxd ran successfully @19.11100s +00.00100s
-|`->config-ubuntu-drivers ran successfully @19.11200s +00.00100s
-|`->config-puppet ran successfully @19.11300s +00.00100s
-|`->config-chef ran successfully @19.11400s +00.00100s
-|`->config-mcollective ran successfully @19.11500s +00.00100s
-|`->config-salt-minion ran successfully @19.11700s +00.00000s
-|`->config-rightscale_userdata ran successfully @19.11800s +00.00000s
-|`->config-scripts-vendor ran successfully @19.11900s +00.00100s
-|`->config-scripts-per-once ran successfully @19.12000s +00.00100s
-|`->config-scripts-per-boot ran successfully @19.12100s +00.00100s
-|`->config-scripts-per-instance ran successfully @19.12200s +00.00100s
-|`->config-scripts-user ran successfully @19.12300s +00.00100s
-|`->config-ssh-authkey-fingerprints ran successfully @19.12400s +00.06000s
-|`->config-keys-to-console ran successfully @19.18400s +00.10500s
-|`->config-phone-home ran successfully @19.29000s +00.00100s
-|`->config-final-message ran successfully @19.29200s +00.00400s
-|`->config-power-state-change ran successfully @19.29700s +00.00000s
-Finished stage: (modules-final) 00.21400 seconds
+|`->config-package-update-upgrade-install ran successfully @18.55300s +00.00200s
+|`->config-fan ran successfully @18.55500s +00.00100s
+|`->config-landscape ran successfully @18.55600s +00.00100s
+|`->config-lxd ran successfully @18.55800s +00.00000s
+|`->config-ubuntu-drivers ran successfully @18.55900s +00.00100s
+|`->config-puppet ran successfully @18.56000s +00.00100s
+|`->config-chef ran successfully @18.56100s +00.00100s
+|`->config-mcollective ran successfully @18.56200s +00.00100s
+|`->config-salt-minion ran successfully @18.56300s +00.00100s
+|`->config-rightscale_userdata ran successfully @18.56500s +00.00000s
+|`->config-scripts-vendor ran successfully @18.56600s +00.00100s
+|`->config-scripts-per-once ran successfully @18.56700s +00.00100s
+|`->config-scripts-per-boot ran successfully @18.56800s +00.00000s
+|`->config-scripts-per-instance ran successfully @18.56900s +00.00100s
+|`->config-scripts-user ran successfully @18.57000s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @18.57100s +00.06000s
+|`->config-keys-to-console ran successfully @18.63200s +00.12600s
+|`->config-phone-home ran successfully @18.75900s +00.00100s
+|`->config-final-message ran successfully @18.76000s +00.00500s
+|`->config-power-state-change ran successfully @18.76500s +00.00100s
+Finished stage: (modules-final) 00.33400 seconds
 
-Total Time: 20.12200 seconds
+Total Time: 20.98900 seconds
 
 1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze blame
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cloud-init analyze blame
 -- Boot Record 01 --
-     04.38700s (init-network/config-disk_setup)
-     01.27600s (modules-config/config-locale)
-     01.08300s (modules-config/config-grub-dpkg)
-     01.00200s (azure-ds/waiting-for-ssh-public-key)
-     00.94800s (modules-config/config-ssh-import-id)
-     00.72900s (init-network/config-users-groups)
-     00.37900s (init-network/config-growpart)
-     00.29800s (modules-config/config-apt-configure)
-     00.27400s (azure-ds/obtain-dhcp-lease)
-     00.24700s (init-network/config-resizefs)
-     00.19500s (init-network/config-ssh)
-     00.17700s (azure-ds/invoke_agent)
-     00.12200s (init-network/config-mounts)
-     00.10500s (modules-final/config-keys-to-console)
-     00.10200s (azure-ds/_get_metadata_from_imds)
+     04.35200s (init-network/config-disk_setup)
+     01.43300s (modules-config/config-locale)
+     01.08300s (modules-config/config-ssh-import-id)
+     01.00300s (azure-ds/waiting-for-ssh-public-key)
+     00.93500s (modules-config/config-grub-dpkg)
+     00.60700s (init-network/config-users-groups)
+     00.44100s (azure-ds/obtain-dhcp-lease)
+     00.34800s (init-network/config-growpart)
+     00.30100s (modules-config/config-apt-configure)
+     00.24400s (init-network/config-resizefs)
+     00.18000s (azure-ds/invoke_agent)
+     00.13100s (init-network/config-ssh)
+     00.13000s (init-network/config-mounts)
+     00.12600s (modules-final/config-keys-to-console)
      00.06000s (modules-final/config-ssh-authkey-fingerprints)
-     00.05700s (azure-ds/list_possible_azure_ds_devs)
-     00.05200s (azure-ds/_has_ntfs_filesystem)
-     00.03100s (azure-ds/crtfile_to_pubkey)
-     00.02200s (init-network/check-cache)
-     00.02000s (azure-ds/parse_network_config)
-     00.02000s (azure-ds/parse_network_config)
+     00.05800s (azure-ds/list_possible_azure_ds_devs)
+     00.05100s (azure-ds/_has_ntfs_filesystem)
+     00.04700s (azure-ds/_get_metadata_from_imds)
+     00.03600s (azure-ds/crtfile_to_pubkey)
+     00.02300s (init-network/check-cache)
+     00.02200s (azure-ds/parse_network_config)
+     00.01900s (azure-ds/parse_network_config)
      00.00900s (azure-ds/get_boot_telemetry)
      00.00800s (init-network/consume-user-data)
-     00.00600s (init-network/config-set_hostname)
      00.00600s (azure-ds/check-platform-viability)
-     00.00400s (modules-final/config-final-message)
-     00.00400s (modules-config/config-snap)
-     00.00200s (modules-config/config-ubuntu-advantage)
-     00.00200s (modules-config/config-emit_upstart)
-     00.00200s (init-network/config-update_hostname)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (init-network/config-set_hostname)
+     00.00200s (modules-final/config-package-update-upgrade-install)
+     00.00200s (modules-config/config-snap)
+     00.00200s (modules-config/config-set-passwords)
      00.00200s (azure-ds/write_files)
      00.00200s (azure-ds/count_files)
      00.00100s (modules-final/config-ubuntu-drivers)
@@ -1088,54 +1103,55 @@ Total Time: 20.12200 seconds
      00.00100s (modules-final/config-scripts-user)
      00.00100s (modules-final/config-scripts-per-once)
      00.00100s (modules-final/config-scripts-per-instance)
-     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
      00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
      00.00100s (modules-final/config-phone-home)
-     00.00100s (modules-final/config-package-update-upgrade-install)
      00.00100s (modules-final/config-mcollective)
-     00.00100s (modules-final/config-lxd)
      00.00100s (modules-final/config-landscape)
      00.00100s (modules-final/config-fan)
      00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
      00.00100s (modules-config/config-timezone)
-     00.00100s (modules-config/config-set-passwords)
      00.00100s (modules-config/config-runcmd)
      00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
      00.00100s (modules-config/config-byobu)
      00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
      00.00100s (init-network/config-seed_random)
      00.00100s (init-network/config-rsyslog)
      00.00100s (init-network/config-migrator)
-     00.00100s (init-network/config-ca-certs)
-     00.00100s (azure-ds/get_system_info)
-     00.00100s (azure-ds/_get_random_seed)
-     00.00100s (azure-ds/_extract_preprovisioned_vm_setting)
-     00.00000s (modules-final/config-salt-minion)
+     00.00100s (init-network/config-bootcmd)
+     00.00000s (modules-final/config-scripts-per-boot)
      00.00000s (modules-final/config-rightscale_userdata)
-     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-final/config-lxd)
      00.00000s (modules-config/config-disable-ec2-metadata)
      00.00000s (init-network/consume-vendor-data)
-     00.00000s (init-network/config-write-files)
      00.00000s (init-network/config-update_etc_hosts)
-     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/config-ca-certs)
      00.00000s (init-local/check-cache)
      00.00000s (azure-ds/wait-for-ephemeral-disk)
      00.00000s (azure-ds/temporary_hostname)
      00.00000s (azure-ds/load_azure_ovf_pubkeys)
      00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
 
 1 boot records analyzed
-+ echo Writing networking config: previous-network.out
++ echo 'Writing networking config: previous-network.out'
 Writing networking config: previous-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cat /etc/network/interfaces.d/50-cloud-init.cfg
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- grep DHCP /var/log/syslog
-+ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@20.36.167.25:.
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cat /etc/network/interfaces.d/50-cloud-init.cfg
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@20.186.42.44:.
 PROPOSED_SCRIPT                               100%  196     3.3KB/s   00:00    
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo bash PROPOSED_SCRIPT
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo bash PROPOSED_SCRIPT
 + egrep cloud-init
   cloud-init
 Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~16.04.1 [425 kB]
@@ -1143,25 +1159,25 @@ Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~16.04.1_all.deb ..
 Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) over (19.4-33-gbb4131a2-0ubuntu1~16.04.1) ...
 Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) ...
 Leaving 'diversion of /etc/init/ureadahead.conf to /etc/init/ureadahead.conf.disabled by cloud-init'
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- dpkg-query --show cloud-init
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- dpkg-query --show cloud-init
 cloud-init	20.2-45-g5f7825e2-0ubuntu1~16.04.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo hostname SRU-didnt-work
 sudo: unable to resolve host SRU-worked-azure
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo rm -f /etc/network/interfaces.d/50-cloud-init.cfg
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo rm -f /etc/network/interfaces.d/50-cloud-init.cfg
 sudo: unable to resolve host SRU-didnt-work
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo cloud-init clean --logs --reboot
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo cloud-init clean --logs --reboot
 sudo: unable to resolve host SRU-didnt-work
-Connection to 20.36.167.25 closed by remote host.
+Connection to 20.186.42.44 closed by remote host.
 + true
 + sleep 60
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init status --wait --long
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cloud-init status --wait --long
 
 status: done
-time: Thu, 18 Jun 2020 18:36:58 +0000
+time: Wed, 24 Jun 2020 20:08:04 +0000
 detail:
 DataSourceAzure [seed=/var/lib/waagent]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo cat /run/cloud-init/result.json
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo cat /run/cloud-init/result.json
 sudo: unable to resolve host SRU-worked-azure
 {
  "v1": {
@@ -1169,633 +1185,67 @@ sudo: unable to resolve host SRU-worked-azure
   "errors": []
  }
 }
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo systemd-analyze blame
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- sudo systemd-analyze blame
 sudo: unable to resolve host SRU-worked-azure
-          2.580s cloud-config.service
-          1.700s cloud-init-local.service
-          1.622s cloud-init.service
-          1.414s snapd.service
-          1.356s dev-sda1.device
-           907ms iscsid.service
-           829ms accounts-daemon.service
-           778ms grub-common.service
-           733ms systemd-logind.service
-           723ms mdadm.service
-           690ms cloud-final.service
-           589ms apparmor.service
-           549ms ssh.service
-           546ms networking.service
-           538ms rsyslog.service
-           535ms lxd-containers.service
-           496ms rc-local.service
-           453ms lvm2-monitor.service
-           410ms systemd-timesyncd.service
-           296ms apport.service
-           223ms polkitd.service
-           218ms ondemand.service
-           210ms systemd-modules-load.service
-           202ms console-setup.service
-           193ms open-iscsi.service
-           145ms lxd.socket
-           145ms keyboard-setup.service
-           144ms dev-mqueue.mount
-           142ms resolvconf.service
-           134ms systemd-update-utmp.service
-           128ms irqbalance.service
-           126ms ufw.service
-           124ms systemd-udev-trigger.service
-           120ms systemd-journald.service
-           119ms sys-kernel-debug.mount
-           100ms kmod-static-nodes.service
-            99ms systemd-remount-fs.service
-            88ms dev-hugepages.mount
-            77ms systemd-journal-flush.service
-            76ms sys-kernel-config.mount
-            75ms systemd-tmpfiles-setup.service
-            63ms systemd-sysctl.service
-            63ms systemd-tmpfiles-setup-dev.service
-            60ms systemd-random-seed.service
-            59ms setvtrgb.service
-            56ms sys-fs-fuse-connections.mount
-            53ms snapd.socket
-            49ms snapd.seeded.service
-            43ms systemd-udevd.service
-            36ms systemd-user-sessions.service
-            35ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
-            28ms plymouth-quit-wait.service
-            27ms plymouth-quit.service
-            24ms plymouth-read-write.service
-            20ms user@1000.service
-            16ms systemd-update-utmp-runlevel.service
-            15ms boot-efi.mount
-            15ms ephemeral-disk-warning.service
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze show
--- Boot Record 01 --
-The total time elapsed since completing an event is printed after the "@" character.
-The time the event takes is printed after the "+" character.
-
-Starting stage: init-local
-|`->no cache found @00.00500s +00.00100s
-Starting stage: init-local/search-Azure
-Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.03600s +00.00600s
-|`->get_boot_telemetry @00.04200s +00.00900s
-|`->get_system_info @00.05100s +00.00000s
-Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.05100s +00.17500s
-|`->load_azure_ds_dir @00.22600s +00.00100s
-Starting stage: azure-ds/load_azure_ds_dir
-Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.23100s +00.00000s
-|`->_extract_preprovisioned_vm_setting @00.23100s +00.00100s
-Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
-
-Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
-
-Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.25200s +00.18400s
-|`->_get_metadata_from_imds @00.43600s +00.01100s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.21400 seconds
-
-|`->_get_random_seed @00.46500s +00.00100s
-Finished stage: (azure-ds/crawl_metadata) 00.42100 seconds
-
-|`->write_files @00.47300s +00.00200s
-Finished stage: (azure-ds/_get_data) 00.44100 seconds
-
-Finished stage: (init-local/search-Azure) 00.44400 seconds
-
-|`->network config from fallback @00.53700s +00.01800s
-Finished stage: (init-local) 00.56900 seconds
-
-Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @01.52200s +00.01900s
-|`->network config from fallback @01.59300s +00.01800s
-Starting stage: init-network/setup-datasource
-Starting stage: azure-ds/setup
-Starting stage: azure-ds/_negotiate
-Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @01.62000s +00.00000s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
-
-Starting stage: azure-ds/get_metadata_from_fabric
-Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @01.62400s +00.03000s
-Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @01.65400s +00.00000s
-|`->_load_dhclient_json @01.65400s +00.02400s
-|`->_get_value_from_dhcpoptions @01.67800s +00.00000s
-|`->_get_value_from_leases_file @01.67900s +00.00000s
-Finished stage: (azure-ds/find_endpoint) 00.02500 seconds
-
-Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @01.70000s +00.01700s
-Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @01.71700s +00.00600s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01100 seconds
-
-Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @01.72800s +00.00500s
-Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
-
-Finished stage: (azure-ds/parse_certificates) 00.03500 seconds
-
-|`->_report_ready @01.73400s +00.00600s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.11600 seconds
-
-Finished stage: (azure-ds/get_metadata_from_fabric) 00.11700 seconds
-
-Finished stage: (azure-ds/_negotiate) 00.12100 seconds
-
-Finished stage: (azure-ds/setup) 00.12100 seconds
-
-Finished stage: (init-network/setup-datasource) 00.12100 seconds
-
-|`->reading and applying user-data @01.74800s +00.00600s
-|`->reading and applying vendor-data @01.75500s +00.00000s
-Starting stage: init-network/activate-datasource
-Starting stage: azure-ds/activate
-Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @01.78200s +00.00000s
-Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @01.78200s +00.08800s
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.08800 seconds
-
-Finished stage: (azure-ds/address_ephemeral_resize) 00.08900 seconds
-
-Finished stage: (azure-ds/activate) 00.08900 seconds
-
-Finished stage: (init-network/activate-datasource) 00.09100 seconds
-
-|`->config-migrator ran successfully @01.89100s +00.00100s
-|`->config-seed_random ran successfully @01.89200s +00.00100s
-|`->config-bootcmd ran successfully @01.89400s +00.00000s
-|`->config-write-files ran successfully @01.89500s +00.00000s
-|`->config-growpart ran successfully @01.89600s +00.04200s
-|`->config-resizefs ran successfully @01.93800s +00.01500s
-|`->config-disk_setup ran successfully @01.95300s +00.18600s
-|`->config-mounts ran successfully @02.14000s +00.12400s
-|`->config-set_hostname ran successfully @02.26400s +00.00600s
-|`->config-update_hostname ran successfully @02.27000s +00.00200s
-|`->config-update_etc_hosts ran successfully @02.27200s +00.00100s
-|`->config-ca-certs ran successfully @02.27300s +00.00100s
-|`->config-rsyslog ran successfully @02.27400s +00.00100s
-|`->config-users-groups ran successfully @02.27500s +00.06500s
-|`->config-ssh ran successfully @02.34100s +00.38300s
-Finished stage: (init-network) 01.22000 seconds
-
-Starting stage: modules-config
-|`->config-emit_upstart ran successfully @05.50400s +00.00000s
-|`->config-snap ran successfully @05.50600s +00.00100s
-|`->config-ssh-import-id ran successfully @05.50700s +00.90000s
-|`->config-locale ran successfully @06.41100s +00.00100s
-|`->config-set-passwords ran successfully @06.41200s +00.00200s
-|`->config-grub-dpkg ran successfully @06.42000s +00.49500s
-|`->config-apt-pipelining ran successfully @06.91600s +00.00100s
-|`->config-apt-configure ran successfully @06.91700s +00.22400s
-|`->config-ubuntu-advantage ran successfully @07.14200s +00.00100s
-|`->config-ntp ran successfully @07.14300s +00.00100s
-|`->config-timezone ran successfully @07.14500s +00.00000s
-|`->config-disable-ec2-metadata ran successfully @07.14600s +00.00000s
-|`->config-runcmd ran successfully @07.14700s +00.00000s
-|`->config-byobu ran successfully @07.14800s +00.00000s
-Finished stage: (modules-config) 01.67500 seconds
-
-Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @07.65500s +00.00100s
-|`->config-fan ran successfully @07.65700s +00.00000s
-|`->config-landscape ran successfully @07.65800s +00.00100s
-|`->config-lxd ran successfully @07.65900s +00.00100s
-|`->config-ubuntu-drivers ran successfully @07.66000s +00.00100s
-|`->config-puppet ran successfully @07.66200s +00.00000s
-|`->config-chef ran successfully @07.66300s +00.00100s
-|`->config-mcollective ran successfully @07.66400s +00.00100s
-|`->config-salt-minion ran successfully @07.66500s +00.00100s
-|`->config-rightscale_userdata ran successfully @07.66600s +00.00100s
-|`->config-scripts-vendor ran successfully @07.66800s +00.00000s
-|`->config-scripts-per-once ran successfully @07.66900s +00.00100s
-|`->config-scripts-per-boot ran successfully @07.67000s +00.00000s
-|`->config-scripts-per-instance ran successfully @07.67100s +00.00100s
-|`->config-scripts-user ran successfully @07.67200s +00.00100s
-|`->config-ssh-authkey-fingerprints ran successfully @07.67300s +00.08900s
-|`->config-keys-to-console ran successfully @07.76300s +00.10200s
-|`->config-phone-home ran successfully @07.86600s +00.00100s
-|`->config-final-message ran successfully @07.86800s +00.00400s
-|`->config-power-state-change ran successfully @07.87300s +00.00100s
-Finished stage: (modules-final) 00.23800 seconds
-
-Total Time: 6.26400 seconds
-
-1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze blame
--- Boot Record 01 --
-     00.90000s (modules-config/config-ssh-import-id)
-     00.49500s (modules-config/config-grub-dpkg)
-     00.38300s (init-network/config-ssh)
-     00.22400s (modules-config/config-apt-configure)
-     00.18600s (init-network/config-disk_setup)
-     00.18400s (azure-ds/obtain-dhcp-lease)
-     00.17500s (azure-ds/list_possible_azure_ds_devs)
-     00.12400s (init-network/config-mounts)
-     00.10200s (modules-final/config-keys-to-console)
-     00.08900s (modules-final/config-ssh-authkey-fingerprints)
-     00.08800s (azure-ds/_has_ntfs_filesystem)
-     00.06500s (init-network/config-users-groups)
-     00.04200s (init-network/config-growpart)
-     00.03000s (azure-ds/generate_certificate)
-     00.02400s (azure-ds/_load_dhclient_json)
-     00.01900s (init-network/check-cache)
-     00.01800s (azure-ds/parse_network_config)
-     00.01800s (azure-ds/parse_network_config)
-     00.01700s (azure-ds/_decrypt_certs_from_xml)
-     00.01500s (init-network/config-resizefs)
-     00.01100s (azure-ds/_get_metadata_from_imds)
-     00.00900s (azure-ds/get_boot_telemetry)
-     00.00600s (init-network/consume-user-data)
-     00.00600s (init-network/config-set_hostname)
-     00.00600s (azure-ds/check-platform-viability)
-     00.00600s (azure-ds/_run_x509_action)
-     00.00600s (azure-ds/_report_ready)
-     00.00500s (azure-ds/_run_x509_action)
-     00.00400s (modules-final/config-final-message)
-     00.00200s (modules-config/config-set-passwords)
-     00.00200s (init-network/config-update_hostname)
-     00.00200s (azure-ds/write_files)
-     00.00100s (modules-final/config-ubuntu-drivers)
-     00.00100s (modules-final/config-scripts-user)
-     00.00100s (modules-final/config-scripts-per-once)
-     00.00100s (modules-final/config-scripts-per-instance)
-     00.00100s (modules-final/config-salt-minion)
-     00.00100s (modules-final/config-rightscale_userdata)
-     00.00100s (modules-final/config-power-state-change)
-     00.00100s (modules-final/config-phone-home)
-     00.00100s (modules-final/config-package-update-upgrade-install)
-     00.00100s (modules-final/config-mcollective)
-     00.00100s (modules-final/config-lxd)
-     00.00100s (modules-final/config-landscape)
-     00.00100s (modules-final/config-chef)
-     00.00100s (modules-config/config-ubuntu-advantage)
-     00.00100s (modules-config/config-snap)
-     00.00100s (modules-config/config-ntp)
-     00.00100s (modules-config/config-locale)
-     00.00100s (modules-config/config-apt-pipelining)
-     00.00100s (init-network/config-update_etc_hosts)
-     00.00100s (init-network/config-seed_random)
-     00.00100s (init-network/config-rsyslog)
-     00.00100s (init-network/config-migrator)
-     00.00100s (init-network/config-ca-certs)
-     00.00100s (init-local/check-cache)
-     00.00100s (azure-ds/load_azure_ds_dir)
-     00.00100s (azure-ds/_get_random_seed)
-     00.00100s (azure-ds/_extract_preprovisioned_vm_setting)
-     00.00000s (modules-final/config-scripts-vendor)
-     00.00000s (modules-final/config-scripts-per-boot)
-     00.00000s (modules-final/config-puppet)
-     00.00000s (modules-final/config-fan)
-     00.00000s (modules-config/config-timezone)
-     00.00000s (modules-config/config-runcmd)
-     00.00000s (modules-config/config-emit_upstart)
-     00.00000s (modules-config/config-disable-ec2-metadata)
-     00.00000s (modules-config/config-byobu)
-     00.00000s (init-network/consume-vendor-data)
-     00.00000s (init-network/config-write-files)
-     00.00000s (init-network/config-bootcmd)
-     00.00000s (azure-ds/wait-for-ephemeral-disk)
-     00.00000s (azure-ds/temporary_hostname)
-     00.00000s (azure-ds/load_azure_ovf_pubkeys)
-     00.00000s (azure-ds/get_system_info)
-     00.00000s (azure-ds/_networkd_get_value_from_leases)
-     00.00000s (azure-ds/_get_value_from_leases_file)
-     00.00000s (azure-ds/_get_value_from_dhcpoptions)
-
-1 boot records analyzed
-+ echo After upgrade write network config: upgrade-network.out
-After upgrade write network config: upgrade-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cat /etc/network/interfaces.d/50-cloud-init.cfg
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- grep DHCP /var/log/syslog
-+ echo ------- Diff previous-network to post-upgrade-network ------
-------- Diff previous-network to post-upgrade-network ------
-+ diff -urN previous-network.out upgrade-network.out
---- previous-network.out	2020-06-18 18:36:01.824734350 +0000
-+++ upgrade-network.out	2020-06-18 18:37:40.862284064 +0000
-@@ -40,3 +40,14 @@
- Jun 18 18:35:15 SRU-worked-azure ifup[910]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
- Jun 18 18:35:15 SRU-worked-azure dhclient[1006]: DHCPACK of 10.0.0.4 from 168.63.129.16
- Jun 18 18:35:15 SRU-worked-azure ifup[910]: DHCPACK of 10.0.0.4 from 168.63.129.16
-+Jun 18 18:36:54 SRU-worked-azure dhclient[895]: Internet Systems Consortium DHCP Client 4.3.3
-+Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x38ad7c27)
-+Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x277cad38)
-+Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
-+Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPACK of 10.0.0.4 from 168.63.129.16
-+Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: Internet Systems Consortium DHCP Client 4.3.3
-+Jun 18 18:36:54 SRU-worked-azure ifup[942]: Internet Systems Consortium DHCP Client 4.3.3
-+Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x701d9f8)
-+Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x701d9f8)
-+Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: DHCPACK of 10.0.0.4 from 168.63.129.16
-+Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPACK of 10.0.0.4 from 168.63.129.16
-+ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
-Validate https://github.com/canonical/cloud-init/commit/22e683df
-echo "Azure needs to use __builtin__ agent by default on all releases"
-Azure needs to use __builtin__ agent by default on all releases
-2020-06-18 18:36:52,070 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
-2020-06-18 18:36:52,070 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
-2020-06-18 18:36:52,071 - azure.py[DEBUG]: Generating certificate for communication with fabric...
-2020-06-18 18:36:52,181 - azure.py[DEBUG]: Reporting ready to Azure fabric.
-2020-06-18 18:36:52,186 - azure.py[INFO]: Reported ready to Azure fabric.
-2020-06-18 18:36:52,187 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
-
-
-+ SRU_VARS=./sru-scripts/sru-vars.template
-+ [ ! -f ./sru-scripts/sru-vars.template ]
-+ . ./sru-scripts/sru-vars.template
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=UNSET
-+ PROPOSED_SCRIPT=setup_proposed.sh
-+ USE_DEV_PPA=0
-+ SAMPLE_CLOUDCONFIG=sethostname.yaml
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=UNSET
-+ AZURE_VNET_NAME=UNSET
-+ AZURE_NETWORK_SECURITY_GROUP=UNSET
-+ AZURE_NIC_NAME=UNSET
-+ AZURE_RESOURCE_GROUP=UNSET
-+ AZURE_BOOT_DIAG=UNSET
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
-+ SRU_VARS_RC=.sru-vars.rc
-+ [ -f .sru-vars.rc ]
-+ [ -f /root/.sru-vars.rc ]
-+ . /root/.sru-vars.rc
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=chad.smith
-+ USE_DEV_PPA=0
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=eastus2
-+ AZURE_VNET_NAME=sruVnet
-+ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
-+ AZURE_NIC_NAME=sruNic
-+ AZURE_RESOURCE_GROUP=srugroupIPV6
-+ AZURE_BOOT_DIAG=storeitsru
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
-+ parse_args ./sru-scripts/manual/azure-sru bionic
-+ script=./sru-scripts/manual/azure-sru
-+ shift
-+ [ 1 = 0 ]
-+ [ 1 -ne 0 ]
-+ UBUNTU_RELEASE=bionic
-+ shift
-+ [ 0 -ne 0 ]
-+ [ -z bionic ]
-+ assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
-+ local value=
-+ eval value=$PROPOSED_SCRIPT > /dev/null
-+ value=setup_proposed.sh
-+ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
-+ eval value=$AZURE_REGION > /dev/null
-+ value=eastus2
-+ [ -z eastus2 -o eastus2 = UNSET ]
-+ eval value=$AZURE_VNET_NAME > /dev/null
-+ value=sruVnet
-+ [ -z sruVnet -o sruVnet = UNSET ]
-+ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
-+ value=sruNetSecGroup
-+ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
-+ eval value=$AZURE_NIC_NAME > /dev/null
-+ value=sruNic
-+ [ -z sruNic -o sruNic = UNSET ]
-+ eval value=$AZURE_RESOURCE_GROUP > /dev/null
-+ value=srugroupIPV6
-+ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
-+ eval value=$AZURE_BOOT_DIAG > /dev/null
-+ value=storeitsru
-+ [ -z storeitsru -o storeitsru = UNSET ]
-+ eval value=$SSH_KEY > /dev/null
-+ value=/root/.ssh/id_rsa.pub
-+ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
-+ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
-+ value=sethostname.yaml
-+ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
-+ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
-+ value=true
-+ [ -z true -o true = UNSET ]
-+ create_samplecloudconfig
-+ filename=sethostname.yaml
-+ cat
-+ create_setup_proposed_script
-+ [ 0 -eq 0 ]
-+ cat
-+ AZURE_VNET_NAME=sruVnet-bionic
-+ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
-+ jq -r .properties.state
-+ IPV6_NET_REGISTERED=Registered
-+ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
-+ jq -r .properties.state
-+ IPV6_CA_LB_REGISTERED=Registered
-+ [ Registered != Registered -o Registered != Registered ]
-+ az provider show -n Microsoft.Network
-+ jq -r .registrationState
-+ IPV6_REGISTRATION_COMPLETE=Registered
-+ echo Waiting for Microsoft.Network IPv6 feature registration
-Waiting for Microsoft.Network IPv6 feature registration
-+ [ Registered != Registered ]
-+ echo ### BEGIN bionic
-### BEGIN bionic
-+ az group show -g srugroupIPV6
-+ [ -n storeitsru ]
-+ az storage account show --name storeitsru
-+ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
-+ az network nsg show --name sruNetSecGroup -g srugroupIPV6
-+ az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
-+ az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
-+ az network vnet show --name sruVnet-bionic -g srugroupIPV6
-+ az network vnet create --resource-group srugroupIPV6 --location eastus2 --name sruVnet-bionic --address-prefixes 10.0.0.0/16 ace:cab:deca::/48
-{
-  "newVNet": {
-    "addressSpace": {
-      "addressPrefixes": [
-        "10.0.0.0/16",
-        "ace:cab:deca::/48"
-      ]
-    },
-    "ddosProtectionPlan": null,
-    "dhcpOptions": {
-      "dnsServers": []
-    },
-    "enableDdosProtection": false,
-    "enableVmProtection": false,
-    "etag": "W/\"d22a4b86-116c-46f8-8c55-3d80b205b2bd\"",
-    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-bionic",
-    "location": "eastus2",
-    "name": "sruVnet-bionic",
-    "provisioningState": "Succeeded",
-    "resourceGroup": "srugroupIPV6",
-    "resourceGuid": "ed2059fb-2027-4c24-9fe6-4cd46c86e9db",
-    "subnets": [],
-    "tags": {},
-    "type": "Microsoft.Network/virtualNetworks",
-    "virtualNetworkPeerings": []
-  }
-}
-+ az network vnet subnet show --name sruSubnet --vnet-name sruVnet-bionic -g srugroupIPV6
-+ az network vnet subnet create --name sruSubnet --resource-group srugroupIPV6 --vnet-name sruVnet-bionic --address-prefixes 10.0.0.0/24 ace:cab:deca:deed::/64 --network-security-group sruNetSecGroup
-{
-  "addressPrefix": null,
-  "addressPrefixes": [
-    "10.0.0.0/24",
-    "ace:cab:deca:deed::/64"
-  ],
-  "delegations": [],
-  "etag": "W/\"9d3479ad-eef6-4e82-b793-7e2a39aa4667\"",
-  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-bionic/subnets/sruSubnet",
-  "ipConfigurationProfiles": null,
-  "ipConfigurations": null,
-  "name": "sruSubnet",
-  "natGateway": null,
-  "networkSecurityGroup": {
-    "defaultSecurityRules": null,
-    "etag": null,
-    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
-    "location": null,
-    "name": null,
-    "networkInterfaces": null,
-    "provisioningState": null,
-    "resourceGroup": "srugroupIPV6",
-    "resourceGuid": null,
-    "securityRules": null,
-    "subnets": null,
-    "tags": null,
-    "type": null
-  },
-  "privateEndpointNetworkPolicies": "Enabled",
-  "privateEndpoints": null,
-  "privateLinkServiceNetworkPolicies": "Enabled",
-  "provisioningState": "Succeeded",
-  "purpose": null,
-  "resourceGroup": "srugroupIPV6",
-  "resourceNavigationLinks": null,
-  "routeTable": null,
-  "serviceAssociationLinks": null,
-  "serviceEndpointPolicies": null,
-  "serviceEndpoints": null,
-  "type": "Microsoft.Network/virtualNetworks/subnets"
-}
-+ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
-+ netcfg=/etc/netplan/50-cloud-init.yaml
-+ image_version=Canonical:UbuntuServer:18.04-DAILY-LTS
-+ [  =  ]
-+ echo Creating standard network vm
-Creating standard network vm
-+ name=test-sru-bionic
-+ az vm show --name test-sru-bionic -g srugroupIPV6
-+ az vm create --name=test-sru-bionic --image=Canonical:UbuntuServer:18.04-DAILY-LTS:latest --admin-username=root --admin-username=ubuntu -g srugroupIPV6 --ssh-key-value /root/.ssh/id_rsa.pub --boot-diagnostics-storage storeitsru --custom-data sethostname.yaml
-{
-  "fqdns": "",
-  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-bionic",
-  "location": "eastus2",
-  "macAddress": "00-0D-3A-7A-71-1B",
-  "powerState": "VM running",
-  "privateIpAddress": "10.0.0.4",
-  "publicIpAddress": "20.186.104.66",
-  "resourceGroup": "srugroupIPV6",
-  "zones": ""
-}
-+ az vm list-ip-addresses --name test-sru-bionic
-+ jq -r+  .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
-awk {printf "ubuntu@%s", $1}
-+ IP=ubuntu@20.186.104.66
-+ echo Created test-sru-bionic: ubuntu@ubuntu@20.186.104.66
-Created test-sru-bionic: ubuntu@ubuntu@20.186.104.66
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init status --wait --long
-
-status: done
-time: Thu, 18 Jun 2020 18:40:11 +0000
-detail:
-DataSourceAzure [seed=/dev/sr0]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- dpkg-query --show cloud-init
-cloud-init	19.4-33-gbb4131a2-0ubuntu1~18.04.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo cat /run/cloud-init/result.json
-{
- "v1": {
-  "datasource": "DataSourceAzure [seed=/dev/sr0]",
-  "errors": []
- }
-}
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- systemd-analyze
-Startup finished in 7.664s (kernel) + 32.061s (userspace) = 39.726s
-graphical.target reached after 31.144s in userspace
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- systemd-analyze blame
-          9.773s cloud-init.service
-          5.598s cloud-init-local.service
-          4.236s cloud-config.service
-          2.135s dev-sda1.device
-          1.957s pollinate.service
-          1.821s lxd-containers.service
-          1.792s systemd-networkd-wait-online.service
-          1.776s snapd.seeded.service
-          1.689s snapd.service
-          1.444s apparmor.service
-           918ms cloud-final.service
-           824ms networkd-dispatcher.service
-           822ms accounts-daemon.service
-           722ms grub-common.service
-           671ms apport.service
-           458ms systemd-timesyncd.service
-           440ms systemd-modules-load.service
-           366ms keyboard-setup.service
-           361ms lvm2-monitor.service
-           348ms systemd-udev-trigger.service
-           317ms polkit.service
-           302ms rsyslog.service
-           282ms systemd-logind.service
-           260ms dev-mqueue.mount
-           254ms kmod-static-nodes.service
-           249ms ufw.service
-           230ms ebtables.service
-           228ms dev-hugepages.mount
-           228ms systemd-remount-fs.service
-           226ms systemd-journald.service
-           193ms systemd-journal-flush.service
-           182ms systemd-tmpfiles-setup-dev.service
-           180ms sys-kernel-debug.mount
-           173ms systemd-networkd.service
-           149ms systemd-sysctl.service
-           137ms snapd.socket
-           128ms setvtrgb.service
-           124ms systemd-udevd.service
-           123ms lxd.socket
-           113ms systemd-machine-id-commit.service
-           111ms console-setup.service
-           102ms systemd-tmpfiles-setup.service
-           101ms ssh.service
-           101ms systemd-user-sessions.service
-            90ms systemd-resolved.service
-            83ms plymouth-read-write.service
-            72ms blk-availability.service
-            46ms plymouth-quit.service
-            43ms user@1000.service
-            38ms sys-fs-fuse-connections.mount
-            37ms systemd-random-seed.service
-            37ms ephemeral-disk-warning.service
-            36ms sys-kernel-config.mount
-            33ms systemd-update-utmp.service
-            29ms boot-efi.mount
-            21ms systemd-update-utmp-runlevel.service
-            16ms plymouth-quit-wait.service
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze show
+          2.231s cloud-config.service
+          1.873s cloud-init-local.service
+          1.798s cloud-init.service
+          1.404s dev-sda1.device
+          1.307s snapd.service
+           895ms lxd-containers.service
+           705ms cloud-final.service
+           685ms apparmor.service
+           640ms networking.service
+           521ms iscsid.service
+           500ms systemd-timesyncd.service
+           465ms grub-common.service
+           460ms accounts-daemon.service
+           437ms mdadm.service
+           287ms systemd-logind.service
+           260ms resolvconf.service
+           249ms lvm2-monitor.service
+           244ms systemd-update-utmp.service
+           239ms rsyslog.service
+           228ms polkitd.service
+           217ms console-setup.service
+           212ms apport.service
+           210ms ssh.service
+           209ms systemd-journald.service
+           208ms open-iscsi.service
+           206ms systemd-remount-fs.service
+           200ms irqbalance.service
+           182ms dev-hugepages.mount
+           182ms kmod-static-nodes.service
+           181ms ondemand.service
+           168ms systemd-modules-load.service
+           163ms systemd-udev-trigger.service
+           159ms rc-local.service
+           157ms snapd.socket
+           156ms dev-mqueue.mount
+           153ms ufw.service
+           129ms keyboard-setup.service
+           128ms sys-kernel-debug.mount
+           103ms systemd-journal-flush.service
+           102ms lxd.socket
+            97ms systemd-sysctl.service
+            92ms systemd-tmpfiles-setup-dev.service
+            89ms sys-kernel-config.mount
+            88ms systemd-random-seed.service
+            84ms sys-fs-fuse-connections.mount
+            50ms snapd.seeded.service
+            48ms systemd-udevd.service
+            46ms setvtrgb.service
+            42ms systemd-tmpfiles-setup.service
+            41ms plymouth-quit.service
+            38ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+            28ms systemd-user-sessions.service
+            28ms systemd-update-utmp-runlevel.service
+            25ms plymouth-read-write.service
+            23ms user@1000.service
+            16ms boot-efi.mount
+            16ms ephemeral-disk-warning.service
+            12ms plymouth-quit-wait.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cloud-init analyze show
 -- Boot Record 01 --
 The total time elapsed since completing an event is printed after the "@" character.
 The time the event takes is printed after the "+" character.
@@ -1804,207 +1254,710 @@ Starting stage: init-local
 |`->no cache found @00.00400s +00.00100s
 Starting stage: init-local/search-Azure
 Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.15000s +00.01000s
-|`->get_boot_telemetry @00.16000s +00.01500s
-|`->get_system_info @00.17500s +00.00100s
+|`->found azure asset tag @00.04500s +00.00600s
+|`->get_boot_telemetry @00.05100s +00.01000s
+|`->get_system_info @00.06100s +00.00000s
 Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.17600s +00.04500s
-|`->load_azure_ds_dir @00.22200s +00.00000s
+|`->list_possible_azure_ds_devs @00.06100s +00.17600s
+|`->load_azure_ds_dir @00.23700s +00.00100s
 Starting stage: azure-ds/load_azure_ds_dir
 Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.34800s +00.00000s
-|`->_extract_preprovisioned_vm_setting @00.34900s +00.00000s
-Finished stage: (azure-ds/read_azure_ovf) 00.00800 seconds
+|`->load_azure_ovf_pubkeys @00.24100s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.24200s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00300 seconds
 
-Finished stage: (azure-ds/load_azure_ds_dir) 00.01300 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00400 seconds
 
 Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.39100s +00.42100s
-|`->_get_metadata_from_imds @00.81200s +00.02000s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.46500 seconds
+|`->obtain dhcp lease @00.26300s +00.29700s
+|`->_get_metadata_from_imds @00.56000s +00.01100s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.32500 seconds
 
-|`->_get_random_seed @00.85600s +00.00000s
-Finished stage: (azure-ds/crawl_metadata) 00.69000 seconds
+|`->_get_random_seed @00.58900s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.53500 seconds
 
-|`->maybe_remove_ubuntu_network_config_scripts @00.86700s +00.00000s
-|`->write_files @00.86800s +00.01000s
-Finished stage: (azure-ds/_get_data) 00.72800 seconds
+|`->write_files @00.59600s +00.00300s
+Finished stage: (azure-ds/_get_data) 00.55400 seconds
 
-Finished stage: (init-local/search-Azure) 00.73100 seconds
+Finished stage: (init-local/search-Azure) 00.55900 seconds
 
-|`->network config from imds @00.94200s +00.00100s
-Finished stage: (init-local) 01.16900 seconds
+|`->network config from fallback @00.66000s +00.01900s
+Finished stage: (init-local) 00.69300 seconds
 
 Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.71700s +00.03400s
-|`->network config from imds @03.79800s +00.00000s
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @01.75200s +00.01900s
+|`->network config from fallback @01.82300s +00.02000s
 Starting stage: init-network/setup-datasource
 Starting stage: azure-ds/setup
 Starting stage: azure-ds/_negotiate
 Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @03.80800s +00.00000s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+|`->temporary_hostname @01.85100s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
 
 Starting stage: azure-ds/get_metadata_from_fabric
 Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @03.81300s +00.15700s
+|`->generate_certificate @01.85500s +00.13400s
 Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @03.97100s +00.00000s
-Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+|`->_networkd_get_value_from_leases @01.99000s +00.00000s
+|`->_load_dhclient_json @01.99000s +00.02400s
+|`->_get_value_from_dhcpoptions @02.01400s +00.00000s
+|`->_get_value_from_leases_file @02.01500s +00.00000s
+Finished stage: (azure-ds/find_endpoint) 00.02600 seconds
 
 Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @04.00300s +00.01400s
+|`->_decrypt_certs_from_xml @02.03900s +00.01100s
 Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @04.01800s +00.00600s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.13200 seconds
+|`->_run_x509_action @02.05100s +00.00500s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01000 seconds
 
 Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @04.15100s +00.00700s
-Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00900 seconds
+|`->_run_x509_action @02.06100s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
 
-Finished stage: (azure-ds/parse_certificates) 00.15600 seconds
+Finished stage: (azure-ds/parse_certificates) 00.02800 seconds
 
-|`->_report_ready @04.15900s +02.75500s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 03.10200 seconds
+|`->_report_ready @02.06700s +00.00600s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.21800 seconds
 
-Finished stage: (azure-ds/get_metadata_from_fabric) 03.10200 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.22000 seconds
 
-Finished stage: (azure-ds/_negotiate) 03.10700 seconds
+Finished stage: (azure-ds/_negotiate) 00.22300 seconds
 
-Finished stage: (azure-ds/setup) 03.10700 seconds
+Finished stage: (azure-ds/setup) 00.22300 seconds
 
-Finished stage: (init-network/setup-datasource) 03.10800 seconds
+Finished stage: (init-network/setup-datasource) 00.22300 seconds
 
-|`->reading and applying user-data @06.93100s +00.00800s
-|`->reading and applying vendor-data @06.93900s +00.00100s
+|`->reading and applying user-data @02.08100s +00.00700s
+|`->reading and applying vendor-data @02.08800s +00.00100s
 Starting stage: init-network/activate-datasource
 Starting stage: azure-ds/activate
 Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @06.97800s +00.00100s
+|`->wait for ephemeral disk @02.11600s +00.00000s
 Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @06.97900s +00.16200s
-Starting stage: azure-ds/mount-ntfs-and-count
-|`->count_files @07.25400s +00.00500s
-Finished stage: (azure-ds/mount-ntfs-and-count) 00.13200 seconds
+|`->_has_ntfs_filesystem @02.11700s +00.08900s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.09000 seconds
 
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.29400 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.09000 seconds
 
-Finished stage: (azure-ds/address_ephemeral_resize) 00.29600 seconds
+Finished stage: (azure-ds/activate) 00.09000 seconds
 
-Finished stage: (azure-ds/activate) 00.29600 seconds
+Finished stage: (init-network/activate-datasource) 00.09200 seconds
 
-Finished stage: (init-network/activate-datasource) 00.30200 seconds
-
-|`->config-migrator ran successfully @07.32800s +00.00100s
-|`->config-seed_random ran successfully @07.33000s +00.00100s
-|`->config-bootcmd ran successfully @07.33100s +00.00100s
-|`->config-write-files ran successfully @07.33200s +00.00100s
-|`->config-growpart ran successfully @07.33300s +00.59900s
-|`->config-resizefs ran successfully @07.93300s +01.69600s
-|`->config-disk_setup ran successfully @09.63000s +02.49900s
-|`->config-mounts ran successfully @12.13000s +00.19700s
-|`->config-set_hostname ran successfully @12.32800s +00.00800s
-|`->config-update_hostname ran successfully @12.33700s +00.00100s
-|`->config-update_etc_hosts ran successfully @12.33800s +00.00100s
-|`->config-ca-certs ran successfully @12.33900s +00.00100s
-|`->config-rsyslog ran successfully @12.34000s +00.00100s
-|`->config-users-groups ran successfully @12.34200s +00.29000s
-|`->config-ssh ran successfully @12.63200s +00.25300s
-Finished stage: (init-network) 09.18700 seconds
+|`->config-migrator ran successfully @02.22700s +00.00100s
+|`->config-seed_random ran successfully @02.22800s +00.00100s
+|`->config-bootcmd ran successfully @02.23000s +00.00000s
+|`->config-write-files ran successfully @02.23000s +00.00100s
+|`->config-growpart ran successfully @02.23200s +00.05100s
+|`->config-resizefs ran successfully @02.28400s +00.01600s
+|`->config-disk_setup ran successfully @02.30000s +00.19000s
+|`->config-mounts ran successfully @02.49000s +00.14300s
+|`->config-set_hostname ran successfully @02.63300s +00.00600s
+|`->config-update_hostname ran successfully @02.64000s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.64200s +00.00000s
+|`->config-ca-certs ran successfully @02.64200s +00.00100s
+|`->config-rsyslog ran successfully @02.64400s +00.00000s
+|`->config-users-groups ran successfully @02.64500s +00.11300s
+|`->config-ssh ran successfully @02.75800s +00.34700s
+Finished stage: (init-network) 01.36800 seconds
 
 Starting stage: modules-config
-|`->config-emit_upstart ran successfully @18.16800s +00.00000s
-|`->config-snap ran successfully @18.16900s +00.00100s
-|`->config-ssh-import-id ran successfully @18.17000s +01.12000s
-|`->config-locale ran successfully @19.29700s +00.00200s
-|`->config-set-passwords ran successfully @19.30000s +00.00100s
-|`->config-grub-dpkg ran successfully @19.30100s +01.95100s
-|`->config-apt-pipelining ran successfully @21.25300s +00.00100s
-|`->config-apt-configure ran successfully @21.25500s +00.25100s
-|`->config-ubuntu-advantage ran successfully @21.50700s +00.00100s
-|`->config-ntp ran successfully @21.50900s +00.00000s
-|`->config-timezone ran successfully @21.51000s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @21.51100s +00.00100s
-|`->config-runcmd ran successfully @21.51200s +00.00100s
-|`->config-byobu ran successfully @21.51400s +00.00100s
-Finished stage: (modules-config) 03.40300 seconds
+|`->config-emit_upstart ran successfully @05.96100s +00.00000s
+|`->config-snap ran successfully @05.96200s +00.00100s
+|`->config-ssh-import-id ran successfully @05.96900s +00.77100s
+|`->config-locale ran successfully @06.74100s +00.00200s
+|`->config-set-passwords ran successfully @06.74600s +00.00200s
+|`->config-grub-dpkg ran successfully @06.74800s +00.39500s
+|`->config-apt-pipelining ran successfully @07.14400s +00.00100s
+|`->config-apt-configure ran successfully @07.14600s +00.13100s
+|`->config-ubuntu-advantage ran successfully @07.27700s +00.00100s
+|`->config-ntp ran successfully @07.27900s +00.00100s
+|`->config-timezone ran successfully @07.28000s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @07.28100s +00.00000s
+|`->config-runcmd ran successfully @07.28200s +00.00100s
+|`->config-byobu ran successfully @07.28300s +00.00100s
+Finished stage: (modules-config) 01.35800 seconds
 
 Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @22.26600s +00.00100s
-|`->config-fan ran successfully @22.26700s +00.00100s
-|`->config-landscape ran successfully @22.26900s +00.00000s
-|`->config-lxd ran successfully @22.27000s +00.00100s
-|`->config-ubuntu-drivers ran successfully @22.27100s +00.00100s
-|`->config-puppet ran successfully @22.27200s +00.00100s
-|`->config-chef ran successfully @22.27300s +00.00100s
-|`->config-mcollective ran successfully @22.27400s +00.00100s
-|`->config-salt-minion ran successfully @22.27500s +00.00100s
-|`->config-rightscale_userdata ran successfully @22.27700s +00.00000s
-|`->config-scripts-vendor ran successfully @22.27800s +00.00000s
-|`->config-scripts-per-once ran successfully @22.27900s +00.00100s
-|`->config-scripts-per-boot ran successfully @22.28000s +00.00000s
-|`->config-scripts-per-instance ran successfully @22.28100s +00.00100s
-|`->config-scripts-user ran successfully @22.28200s +00.00100s
-|`->config-ssh-authkey-fingerprints ran successfully @22.28300s +00.02700s
-|`->config-keys-to-console ran successfully @22.31500s +00.11400s
-|`->config-phone-home ran successfully @22.43100s +00.00500s
-|`->config-final-message ran successfully @22.47500s +00.00500s
-|`->config-power-state-change ran successfully @22.48000s +00.00100s
-Finished stage: (modules-final) 00.23500 seconds
+|`->config-package-update-upgrade-install ran successfully @07.80400s +00.00100s
+|`->config-fan ran successfully @07.80500s +00.00100s
+|`->config-landscape ran successfully @07.80600s +00.00100s
+|`->config-lxd ran successfully @07.80800s +00.00000s
+|`->config-ubuntu-drivers ran successfully @07.80900s +00.00100s
+|`->config-puppet ran successfully @07.81000s +00.00100s
+|`->config-chef ran successfully @07.81100s +00.00100s
+|`->config-mcollective ran successfully @07.81200s +00.00100s
+|`->config-salt-minion ran successfully @07.81400s +00.00000s
+|`->config-rightscale_userdata ran successfully @07.81500s +00.00000s
+|`->config-scripts-vendor ran successfully @07.81600s +00.00100s
+|`->config-scripts-per-once ran successfully @07.81700s +00.00100s
+|`->config-scripts-per-boot ran successfully @07.81900s +00.00000s
+|`->config-scripts-per-instance ran successfully @07.81900s +00.00100s
+|`->config-scripts-user ran successfully @07.82100s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @07.82200s +00.09700s
+|`->config-keys-to-console ran successfully @07.91900s +00.11100s
+|`->config-phone-home ran successfully @08.03000s +00.00200s
+|`->config-final-message ran successfully @08.03200s +00.00400s
+|`->config-power-state-change ran successfully @08.03700s +00.00000s
+Finished stage: (modules-final) 00.25800 seconds
 
-Total Time: 33.77700 seconds
+Total Time: 7.19900 seconds
 
 1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze blame
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cloud-init analyze blame
 -- Boot Record 01 --
-     02.75500s (azure-ds/_report_ready)
-     02.49900s (init-network/config-disk_setup)
-     01.95100s (modules-config/config-grub-dpkg)
-     01.69600s (init-network/config-resizefs)
-     01.12000s (modules-config/config-ssh-import-id)
-     00.59900s (init-network/config-growpart)
-     00.42100s (azure-ds/obtain-dhcp-lease)
-     00.29000s (init-network/config-users-groups)
-     00.25300s (init-network/config-ssh)
-     00.25100s (modules-config/config-apt-configure)
-     00.19700s (init-network/config-mounts)
-     00.16200s (azure-ds/_has_ntfs_filesystem)
-     00.15700s (azure-ds/generate_certificate)
-     00.11400s (modules-final/config-keys-to-console)
-     00.04500s (azure-ds/list_possible_azure_ds_devs)
-     00.03400s (init-network/check-cache)
-     00.02700s (modules-final/config-ssh-authkey-fingerprints)
-     00.02000s (azure-ds/_get_metadata_from_imds)
-     00.01500s (azure-ds/get_boot_telemetry)
-     00.01400s (azure-ds/_decrypt_certs_from_xml)
-     00.01000s (azure-ds/write_files)
-     00.01000s (azure-ds/check-platform-viability)
-     00.00800s (init-network/consume-user-data)
-     00.00800s (init-network/config-set_hostname)
-     00.00700s (azure-ds/_run_x509_action)
+     00.77100s (modules-config/config-ssh-import-id)
+     00.39500s (modules-config/config-grub-dpkg)
+     00.34700s (init-network/config-ssh)
+     00.29700s (azure-ds/obtain-dhcp-lease)
+     00.19000s (init-network/config-disk_setup)
+     00.17600s (azure-ds/list_possible_azure_ds_devs)
+     00.14300s (init-network/config-mounts)
+     00.13400s (azure-ds/generate_certificate)
+     00.13100s (modules-config/config-apt-configure)
+     00.11300s (init-network/config-users-groups)
+     00.11100s (modules-final/config-keys-to-console)
+     00.09700s (modules-final/config-ssh-authkey-fingerprints)
+     00.08900s (azure-ds/_has_ntfs_filesystem)
+     00.05100s (init-network/config-growpart)
+     00.02400s (azure-ds/_load_dhclient_json)
+     00.02000s (azure-ds/parse_network_config)
+     00.01900s (init-network/check-cache)
+     00.01900s (azure-ds/parse_network_config)
+     00.01600s (init-network/config-resizefs)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.01100s (azure-ds/_decrypt_certs_from_xml)
+     00.01000s (azure-ds/get_boot_telemetry)
+     00.00700s (init-network/consume-user-data)
+     00.00600s (init-network/config-set_hostname)
+     00.00600s (azure-ds/check-platform-viability)
      00.00600s (azure-ds/_run_x509_action)
-     00.00500s (modules-final/config-phone-home)
-     00.00500s (modules-final/config-final-message)
-     00.00500s (azure-ds/count_files)
+     00.00600s (azure-ds/_report_ready)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00300s (azure-ds/write_files)
+     00.00200s (modules-final/config-phone-home)
+     00.00200s (modules-config/config-set-passwords)
      00.00200s (modules-config/config-locale)
      00.00100s (modules-final/config-ubuntu-drivers)
-     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-vendor)
      00.00100s (modules-final/config-scripts-per-once)
      00.00100s (modules-final/config-scripts-per-instance)
-     00.00100s (modules-final/config-salt-minion)
      00.00100s (modules-final/config-puppet)
-     00.00100s (modules-final/config-power-state-change)
      00.00100s (modules-final/config-package-update-upgrade-install)
      00.00100s (modules-final/config-mcollective)
-     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
      00.00100s (modules-final/config-fan)
      00.00100s (modules-final/config-chef)
      00.00100s (modules-config/config-ubuntu-advantage)
      00.00100s (modules-config/config-timezone)
      00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/consume-vendor-data)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (azure-ds/_get_value_from_leases_file)
+     00.00000s (azure-ds/_get_value_from_dhcpoptions)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo 'After upgrade write network config: upgrade-network.out'
+After upgrade write network config: upgrade-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- cat /etc/network/interfaces.d/50-cloud-init.cfg
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.44 -- grep DHCP /var/log/syslog
++ echo '------- Diff previous-network to post-upgrade-network ------'
+------- Diff previous-network to post-upgrade-network ------
++ diff -urN previous-network.out upgrade-network.out
+--- previous-network.out	2020-06-24 20:07:08.434288185 +0000
++++ upgrade-network.out	2020-06-24 20:08:47.443854108 +0000
+@@ -40,3 +40,14 @@
+ Jun 24 20:06:22 SRU-worked-azure ifup[909]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
+ Jun 24 20:06:22 SRU-worked-azure dhclient[1004]: DHCPACK of 10.0.0.4 from 168.63.129.16
+ Jun 24 20:06:22 SRU-worked-azure ifup[909]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 24 20:08:00 SRU-worked-azure dhclient[856]: Internet Systems Consortium DHCP Client 4.3.3
++Jun 24 20:08:00 SRU-worked-azure dhclient[856]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xddeb1f55)
++Jun 24 20:08:00 SRU-worked-azure dhclient[856]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x551febdd)
++Jun 24 20:08:00 SRU-worked-azure dhclient[856]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
++Jun 24 20:08:00 SRU-worked-azure dhclient[856]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 24 20:08:00 SRU-worked-azure dhclient[999]: Internet Systems Consortium DHCP Client 4.3.3
++Jun 24 20:08:00 SRU-worked-azure ifup[903]: Internet Systems Consortium DHCP Client 4.3.3
++Jun 24 20:08:00 SRU-worked-azure dhclient[999]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x348587c9)
++Jun 24 20:08:00 SRU-worked-azure ifup[903]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x348587c9)
++Jun 24 20:08:00 SRU-worked-azure dhclient[999]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 24 20:08:00 SRU-worked-azure ifup[903]: DHCPACK of 10.0.0.4 from 168.63.129.16
+
+
+
++ SRU_VARS=./sru-scripts/sru-vars.template
++ '[' '!' -f ./sru-scripts/sru-vars.template ']'
++ . ./sru-scripts/sru-vars.template
+++ PRESERVE_INSTANCE=false
+++ UBUNTU_RELEASE=
+++ LP_USER=UNSET
+++ PROPOSED_SCRIPT=setup_proposed.sh
+++ USE_DEV_PPA=0
+++ ENI_NETCFG_FILE=/etc/network/interfaces.d/50-cloud-init.cfg
+++ NETPLAN_NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
+++ SAMPLE_CLOUDCONFIG=sethostname.yaml
+++ SSH_KEY=/root/.ssh/id_rsa.pub
+++ SSHOPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+++ AZURE_REGION=UNSET
+++ AZURE_VNET_NAME=UNSET
+++ AZURE_NETWORK_SECURITY_GROUP=UNSET
+++ AZURE_NIC_NAME=UNSET
+++ AZURE_RESOURCE_GROUP=UNSET
+++ AZURE_BOOT_DIAG=UNSET
+++ AZURE_ADVANCED_NIC_TESTS=true
+++ GCE_ZONE=UNSET
+++ OPENSTACK_ADMIN_NET_ID=UNSET
+++ OPENSTACK_SSH_KEY_NAME=UNSET
+++ SRU_VARS_RC=.sru-vars.rc
+++ '[' -f .sru-vars.rc ']'
+++ '[' -f /root/.sru-vars.rc ']'
+++ . /root/.sru-vars.rc
++++ PRESERVE_INSTANCE=false
++++ UBUNTU_RELEASE=
++++ LP_USER=chad.smith
++++ USE_DEV_PPA=0
++++ SSH_KEY=/root/.ssh/id_rsa.pub
++++ AZURE_REGION=eastus2
++++ AZURE_VNET_NAME=sruVnet
++++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++++ AZURE_NIC_NAME=sruNic
++++ AZURE_RESOURCE_GROUP=srugroupIPV6
++++ AZURE_BOOT_DIAG=storeitsru
++++ AZURE_ADVANCED_NIC_TESTS=true
++++ GCE_ZONE=UNSET
++++ OPENSTACK_ADMIN_NET_ID=UNSET
++++ OPENSTACK_SSH_KEY_NAME=UNSET
++ parse_args ./sru-scripts/manual/azure-sru bionic
++ script=./sru-scripts/manual/azure-sru
++ shift
++ '[' 1 = 0 ']'
++ '[' 1 -ne 0 ']'
++ case "$1" in
++ UBUNTU_RELEASE=bionic
++ NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
++ shift
++ '[' 0 -ne 0 ']'
++ '[' -z bionic ']'
++ assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
++ local value=
++ for var in $@
++ eval 'value=$PROPOSED_SCRIPT > /dev/null'
+++ value=setup_proposed.sh
++ '[' -z setup_proposed.sh -o setup_proposed.sh = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_REGION > /dev/null'
+++ value=eastus2
++ '[' -z eastus2 -o eastus2 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_VNET_NAME > /dev/null'
+++ value=sruVnet
++ '[' -z sruVnet -o sruVnet = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null'
+++ value=sruNetSecGroup
++ '[' -z sruNetSecGroup -o sruNetSecGroup = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NIC_NAME > /dev/null'
+++ value=sruNic
++ '[' -z sruNic -o sruNic = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_RESOURCE_GROUP > /dev/null'
+++ value=srugroupIPV6
++ '[' -z srugroupIPV6 -o srugroupIPV6 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_BOOT_DIAG > /dev/null'
+++ value=storeitsru
++ '[' -z storeitsru -o storeitsru = UNSET ']'
++ for var in $@
++ eval 'value=$SSH_KEY > /dev/null'
+++ value=/root/.ssh/id_rsa.pub
++ '[' -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ']'
++ for var in $@
++ eval 'value=$SAMPLE_CLOUDCONFIG > /dev/null'
+++ value=sethostname.yaml
++ '[' -z sethostname.yaml -o sethostname.yaml = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_ADVANCED_NIC_TESTS > /dev/null'
+++ value=true
++ '[' -z true -o true = UNSET ']'
++ create_samplecloudconfig SAMPLE_CLOUDCONFIG
++ filename=SAMPLE_CLOUDCONFIG
++ cat
++ create_setup_proposed_script
++ '[' 0 -eq 0 ']'
++ cat
++ AZURE_VNET_NAME=sruVnet-bionic
+++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
+++ jq -r .properties.state
++ IPV6_NET_REGISTERED=Registered
+++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
+++ jq -r .properties.state
++ IPV6_CA_LB_REGISTERED=Registered
++ '[' Registered '!=' Registered -o Registered '!=' Registered ']'
+++ az provider show -n Microsoft.Network
+++ jq -r .registrationState
++ IPV6_REGISTRATION_COMPLETE=Registered
++ echo 'Waiting for Microsoft.Network IPv6 feature registration'
+Waiting for Microsoft.Network IPv6 feature registration
++ '[' Registered '!=' Registered ']'
++ echo '### BEGIN bionic'
+### BEGIN bionic
++ az group show -g srugroupIPV6
++ '[' -n storeitsru ']'
++ az storage account show --name storeitsru
++ AZURE_BOOT_DIAG_ARG='--boot-diagnostics-storage storeitsru'
++ az network nsg show --name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network vnet show --name sruVnet-bionic -g srugroupIPV6
++ az network vnet subnet show --name sruSubnet --vnet-name sruVnet-bionic -g srugroupIPV6
++ sshopts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR'
++ netcfg=/etc/netplan/50-cloud-init.yaml
++ case $UBUNTU_RELEASE in
++ image_version=Canonical:UbuntuServer:18.04-DAILY-LTS
++ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELEASE --size Standard_DS2_v2"
++ '[' '' = '' ']'
++ echo 'Creating standard network vm'
+Creating standard network vm
++ name=test-sru-bionic
++ az vm show --name test-sru-bionic -g srugroupIPV6
++ az vm create --name=test-sru-bionic --image=Canonical:UbuntuServer:18.04-DAILY-LTS:latest --admin-username=root --admin-username=ubuntu -g srugroupIPV6 --ssh-key-value /root/.ssh/id_rsa.pub --boot-diagnostics-storage storeitsru --custom-data sethostname.yaml
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-bionic",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-E6-61-83",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.4",
+  "publicIpAddress": "40.65.204.147",
+  "resourceGroup": "srugroupIPV6",
+  "zones": ""
+}
+++ az vm list-ip-addresses --name test-sru-bionic
+++ jq -r '.[] | .virtualMachine.network.publicIpAddresses[].ipAddress'
+++ awk '{printf "ubuntu@%s", $1}'
++ IP=ubuntu@40.65.204.147
++ echo 'Created test-sru-bionic: ubuntu@ubuntu@40.65.204.147'
+Created test-sru-bionic: ubuntu@ubuntu@40.65.204.147
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cloud-init status --wait --long
+
+status: done
+time: Wed, 24 Jun 2020 20:15:09 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~18.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/dev/sr0]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- systemd-analyze
+Startup finished in 6.847s (kernel) + 34.111s (userspace) = 40.959s
+graphical.target reached after 33.332s in userspace
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- systemd-analyze blame
+          9.870s cloud-init.service
+          5.612s cloud-init-local.service
+          4.588s snapd.seeded.service
+          2.529s cloud-config.service
+          2.400s keyboard-setup.service
+          2.367s snapd.service
+          2.361s lxd-containers.service
+          2.309s dev-sda1.device
+          2.038s apparmor.service
+          1.898s console-setup.service
+          1.872s pollinate.service
+          1.628s systemd-networkd-wait-online.service
+           845ms networkd-dispatcher.service
+           833ms accounts-daemon.service
+           771ms cloud-final.service
+           764ms grub-common.service
+           586ms systemd-logind.service
+           463ms systemd-timesyncd.service
+           392ms lvm2-monitor.service
+           321ms rsyslog.service
+           300ms systemd-udev-trigger.service
+           292ms systemd-modules-load.service
+           255ms polkit.service
+           235ms ufw.service
+           226ms systemd-journald.service
+           217ms systemd-remount-fs.service
+           216ms dev-mqueue.mount
+           211ms lxd.socket
+           188ms apport.service
+           177ms systemd-networkd.service
+           157ms systemd-tmpfiles-setup-dev.service
+           157ms systemd-udevd.service
+           155ms ebtables.service
+           151ms dev-hugepages.mount
+           133ms ssh.service
+           119ms systemd-journal-flush.service
+           116ms snapd.socket
+           113ms systemd-user-sessions.service
+            95ms kmod-static-nodes.service
+            85ms systemd-resolved.service
+            79ms sys-kernel-debug.mount
+            74ms systemd-machine-id-commit.service
+            62ms plymouth-read-write.service
+            59ms systemd-sysctl.service
+            55ms systemd-tmpfiles-setup.service
+            52ms plymouth-quit.service
+            51ms systemd-random-seed.service
+            48ms boot-efi.mount
+            48ms user@1000.service
+            47ms sys-kernel-config.mount
+            46ms sys-fs-fuse-connections.mount
+            41ms setvtrgb.service
+            34ms blk-availability.service
+            26ms plymouth-quit-wait.service
+            26ms systemd-update-utmp.service
+            24ms ephemeral-disk-warning.service
+            10ms systemd-update-utmp-runlevel.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00300s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.13300s +00.00800s
+|`->get_boot_telemetry @00.14100s +00.01200s
+|`->get_system_info @00.15300s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.15400s +00.04500s
+|`->load_azure_ds_dir @00.19900s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.32200s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.32200s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.01000 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01400 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.35800s +00.43900s
+|`->_get_metadata_from_imds @00.79700s +00.05900s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.52100 seconds
+
+|`->_get_random_seed @00.87800s +00.00100s
+Finished stage: (azure-ds/crawl_metadata) 00.73300 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.88700s +00.00000s
+|`->write_files @00.88800s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.75700 seconds
+
+Finished stage: (init-local/search-Azure) 00.76000 seconds
+
+|`->network config from imds @01.00400s +00.00000s
+Finished stage: (init-local) 01.19900 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.56200s +00.03000s
+|`->network config from imds @03.63700s +00.00100s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.64600s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.65300s +00.11800s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @03.77100s +00.00100s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @03.79700s +00.01200s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @03.81000s +00.00600s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.15200 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @03.96200s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.17100 seconds
+
+|`->_report_ready @03.96800s +02.89500s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 03.21000 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 03.21100 seconds
+
+Finished stage: (azure-ds/_negotiate) 03.21900 seconds
+
+Finished stage: (azure-ds/setup) 03.21900 seconds
+
+Finished stage: (init-network/setup-datasource) 03.21900 seconds
+
+|`->reading and applying user-data @06.93700s +00.00900s
+|`->reading and applying vendor-data @06.94600s +00.00100s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @06.98200s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @06.98200s +00.13900s
+Starting stage: azure-ds/mount-ntfs-and-count
+|`->count_files @07.20400s +00.00300s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.09700 seconds
+
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.23600 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.23800 seconds
+
+Finished stage: (azure-ds/activate) 00.23800 seconds
+
+Finished stage: (init-network/activate-datasource) 00.24700 seconds
+
+|`->config-migrator ran successfully @07.27000s +00.00100s
+|`->config-seed_random ran successfully @07.27100s +00.00100s
+|`->config-bootcmd ran successfully @07.27300s +00.00000s
+|`->config-write-files ran successfully @07.27300s +00.00100s
+|`->config-growpart ran successfully @07.27400s +00.50400s
+|`->config-resizefs ran successfully @07.77800s +01.57200s
+|`->config-disk_setup ran successfully @09.35100s +02.61700s
+|`->config-mounts ran successfully @11.96800s +00.18300s
+|`->config-set_hostname ran successfully @12.15100s +00.01000s
+|`->config-update_hostname ran successfully @12.16100s +00.00100s
+|`->config-update_etc_hosts ran successfully @12.16200s +00.00100s
+|`->config-ca-certs ran successfully @12.16300s +00.00100s
+|`->config-rsyslog ran successfully @12.16400s +00.00100s
+|`->config-users-groups ran successfully @12.16500s +00.62400s
+|`->config-ssh ran successfully @12.79000s +00.12400s
+Finished stage: (init-network) 09.36600 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @21.32400s +00.00100s
+|`->config-snap ran successfully @21.32500s +00.00100s
+|`->config-ssh-import-id ran successfully @21.32600s +00.81900s
+|`->config-locale ran successfully @22.14600s +00.00700s
+|`->config-set-passwords ran successfully @22.15300s +00.00100s
+|`->config-grub-dpkg ran successfully @22.16100s +00.97000s
+|`->config-apt-pipelining ran successfully @23.13200s +00.00100s
+|`->config-apt-configure ran successfully @23.13300s +00.15100s
+|`->config-ubuntu-advantage ran successfully @23.28500s +00.00000s
+|`->config-ntp ran successfully @23.28600s +00.00000s
+|`->config-timezone ran successfully @23.28700s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @23.28800s +00.00000s
+|`->config-runcmd ran successfully @23.28800s +00.00100s
+|`->config-byobu ran successfully @23.28900s +00.00100s
+Finished stage: (modules-config) 01.98200 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @23.90100s +00.00100s
+|`->config-fan ran successfully @23.90200s +00.00100s
+|`->config-landscape ran successfully @23.90300s +00.00100s
+|`->config-lxd ran successfully @23.90400s +00.00100s
+|`->config-ubuntu-drivers ran successfully @23.90500s +00.00100s
+|`->config-puppet ran successfully @23.90600s +00.00100s
+|`->config-chef ran successfully @23.90700s +00.00100s
+|`->config-mcollective ran successfully @23.90800s +00.00100s
+|`->config-salt-minion ran successfully @23.90900s +00.00100s
+|`->config-rightscale_userdata ran successfully @23.91000s +00.00000s
+|`->config-scripts-vendor ran successfully @23.91100s +00.00000s
+|`->config-scripts-per-once ran successfully @23.91100s +00.00100s
+|`->config-scripts-per-boot ran successfully @23.91200s +00.00100s
+|`->config-scripts-per-instance ran successfully @23.91300s +00.00100s
+|`->config-scripts-user ran successfully @23.91400s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @23.91500s +00.05300s
+|`->config-keys-to-console ran successfully @23.96900s +00.10000s
+|`->config-phone-home ran successfully @24.07000s +00.00100s
+|`->config-final-message ran successfully @24.07200s +00.00500s
+|`->config-power-state-change ran successfully @24.07800s +00.00100s
+Finished stage: (modules-final) 00.19600 seconds
+
+Total Time: 33.00500 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cloud-init analyze blame
+-- Boot Record 01 --
+     02.89500s (azure-ds/_report_ready)
+     02.61700s (init-network/config-disk_setup)
+     01.57200s (init-network/config-resizefs)
+     00.97000s (modules-config/config-grub-dpkg)
+     00.81900s (modules-config/config-ssh-import-id)
+     00.62400s (init-network/config-users-groups)
+     00.50400s (init-network/config-growpart)
+     00.43900s (azure-ds/obtain-dhcp-lease)
+     00.18300s (init-network/config-mounts)
+     00.15100s (modules-config/config-apt-configure)
+     00.13900s (azure-ds/_has_ntfs_filesystem)
+     00.12400s (init-network/config-ssh)
+     00.11800s (azure-ds/generate_certificate)
+     00.10000s (modules-final/config-keys-to-console)
+     00.05900s (azure-ds/_get_metadata_from_imds)
+     00.05300s (modules-final/config-ssh-authkey-fingerprints)
+     00.04500s (azure-ds/list_possible_azure_ds_devs)
+     00.03000s (init-network/check-cache)
+     00.01200s (azure-ds/get_boot_telemetry)
+     00.01200s (azure-ds/_decrypt_certs_from_xml)
+     00.01000s (init-network/config-set_hostname)
+     00.00900s (init-network/consume-user-data)
+     00.00800s (azure-ds/check-platform-viability)
+     00.00700s (modules-config/config-locale)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00500s (modules-final/config-final-message)
+     00.00300s (azure-ds/count_files)
+     00.00200s (azure-ds/write_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
      00.00100s (modules-config/config-set-passwords)
      00.00100s (modules-config/config-runcmd)
-     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-emit_upstart)
      00.00100s (modules-config/config-byobu)
      00.00100s (modules-config/config-apt-pipelining)
      00.00100s (init-network/consume-vendor-data)
@@ -2015,500 +1968,504 @@ Total Time: 33.77700 seconds
      00.00100s (init-network/config-rsyslog)
      00.00100s (init-network/config-migrator)
      00.00100s (init-network/config-ca-certs)
-     00.00100s (init-network/config-bootcmd)
-     00.00100s (init-local/check-cache)
-     00.00100s (azure-ds/wait-for-ephemeral-disk)
      00.00100s (azure-ds/parse_network_config)
-     00.00100s (azure-ds/get_system_info)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00100s (azure-ds/_get_random_seed)
      00.00000s (modules-final/config-scripts-vendor)
-     00.00000s (modules-final/config-scripts-per-boot)
      00.00000s (modules-final/config-rightscale_userdata)
-     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-config/config-ubuntu-advantage)
      00.00000s (modules-config/config-ntp)
-     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
      00.00000s (azure-ds/temporary_hostname)
      00.00000s (azure-ds/parse_network_config)
      00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
      00.00000s (azure-ds/load_azure_ovf_pubkeys)
      00.00000s (azure-ds/load_azure_ds_dir)
-     00.00000s (azure-ds/_networkd_get_value_from_leases)
-     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/get_system_info)
      00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
 
 1 boot records analyzed
-+ echo Writing networking config: previous-network.out
++ echo 'Writing networking config: previous-network.out'
 Writing networking config: previous-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cat /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- grep DHCP /var/log/syslog
-+ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@20.186.104.66:.
-PROPOSED_SCRIPT                               100%  196     3.5KB/s   00:00    
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo bash PROPOSED_SCRIPT
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@40.65.204.147:.
+PROPOSED_SCRIPT                               100%  196     3.0KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo bash PROPOSED_SCRIPT
 + egrep cloud-init
   cloud-init
 Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~18.04.1 [422 kB]
 Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~18.04.1_all.deb ...
 Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) over (19.4-33-gbb4131a2-0ubuntu1~18.04.1) ...
 Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) ...
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- dpkg-query --show cloud-init
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- dpkg-query --show cloud-init
 cloud-init	20.2-45-g5f7825e2-0ubuntu1~18.04.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo hostname SRU-didnt-work
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo cloud-init clean --logs --reboot
-Connection to 20.186.104.66 closed by remote host.
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo cloud-init clean --logs --reboot
+Connection to 40.65.204.147 closed by remote host.
 + true
 + sleep 60
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init status --wait --long
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cloud-init status --wait --long
 
 status: done
-time: Thu, 18 Jun 2020 18:41:53 +0000
+time: Wed, 24 Jun 2020 20:16:52 +0000
 detail:
 DataSourceAzure [seed=/var/lib/waagent]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo cat /run/cloud-init/result.json
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo cat /run/cloud-init/result.json
 {
  "v1": {
   "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
   "errors": []
  }
 }
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo systemd-analyze blame
-          2.888s cloud-config.service
-          2.303s cloud-init.service
-          1.803s dev-sda1.device
-          1.737s cloud-init-local.service
-          1.539s systemd-networkd-wait-online.service
-          1.182s snapd.service
-          1.051s networkd-dispatcher.service
-          1.000s lxd-containers.service
-           876ms cloud-final.service
-           632ms apparmor.service
-           600ms systemd-udev-trigger.service
-           510ms accounts-daemon.service
-           461ms systemd-timesyncd.service
-           426ms systemd-modules-load.service
-           424ms keyboard-setup.service
-           424ms grub-common.service
-           418ms apport.service
-           385ms systemd-journald.service
-           342ms systemd-logind.service
-           297ms ssh.service
-           276ms rsyslog.service
-           275ms lxd.socket
-           274ms snapd.socket
-           265ms polkit.service
-           254ms lvm2-monitor.service
-           157ms systemd-journal-flush.service
-           153ms systemd-remount-fs.service
-           153ms kmod-static-nodes.service
-           152ms dev-mqueue.mount
-           147ms ufw.service
-           143ms sys-kernel-debug.mount
-           123ms ebtables.service
-           113ms dev-hugepages.mount
-            99ms systemd-udevd.service
-            97ms systemd-sysctl.service
-            94ms systemd-tmpfiles-setup.service
-            82ms ephemeral-disk-warning.service
-            76ms systemd-resolved.service
-            73ms blk-availability.service
-            68ms sys-fs-fuse-connections.mount
-            68ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
-            66ms snapd.seeded.service
-            56ms systemd-user-sessions.service
-            52ms systemd-tmpfiles-setup-dev.service
-            46ms setvtrgb.service
-            46ms systemd-networkd.service
-            45ms systemd-update-utmp.service
-            44ms user@1000.service
-            40ms sys-kernel-config.mount
-            39ms plymouth-quit.service
-            34ms systemd-update-utmp-runlevel.service
-            34ms plymouth-quit-wait.service
-            28ms systemd-random-seed.service
-            24ms plymouth-read-write.service
-            19ms boot-efi.mount
-            18ms console-setup.service
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze show
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- sudo systemd-analyze blame
+          2.481s cloud-config.service
+          1.748s cloud-init.service
+          1.681s cloud-init-local.service
+          1.589s dev-sda1.device
+          1.448s systemd-networkd-wait-online.service
+          1.320s snapd.service
+          1.153s lxd-containers.service
+          1.055s networkd-dispatcher.service
+           765ms cloud-final.service
+           691ms apparmor.service
+           560ms grub-common.service
+           457ms apport.service
+           427ms systemd-timesyncd.service
+           373ms accounts-daemon.service
+           283ms ssh.service
+           271ms rsyslog.service
+           263ms systemd-udev-trigger.service
+           260ms ebtables.service
+           254ms dev-hugepages.mount
+           254ms keyboard-setup.service
+           252ms lvm2-monitor.service
+           234ms systemd-modules-load.service
+           225ms systemd-journal-flush.service
+           212ms kmod-static-nodes.service
+           204ms sys-kernel-debug.mount
+           177ms systemd-logind.service
+           177ms systemd-remount-fs.service
+           153ms ufw.service
+           152ms polkit.service
+           108ms systemd-udevd.service
+           108ms systemd-user-sessions.service
+           106ms snapd.socket
+           106ms lxd.socket
+           105ms dev-mqueue.mount
+            95ms systemd-random-seed.service
+            80ms systemd-tmpfiles-setup-dev.service
+            78ms sys-fs-fuse-connections.mount
+            77ms systemd-sysctl.service
+            70ms sys-kernel-config.mount
+            64ms console-setup.service
+            63ms systemd-journald.service
+            59ms blk-availability.service
+            55ms systemd-resolved.service
+            51ms systemd-update-utmp.service
+            47ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+            45ms systemd-networkd.service
+            43ms snapd.seeded.service
+            41ms systemd-tmpfiles-setup.service
+            36ms user@1000.service
+            35ms plymouth-quit-wait.service
+            33ms setvtrgb.service
+            32ms systemd-update-utmp-runlevel.service
+            30ms plymouth-quit.service
+            16ms boot-efi.mount
+            16ms plymouth-read-write.service
+            15ms ephemeral-disk-warning.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cloud-init analyze show
 -- Boot Record 01 --
 The total time elapsed since completing an event is printed after the "@" character.
 The time the event takes is printed after the "+" character.
 
 Starting stage: init-local
-|`->no cache found @00.00400s +00.00100s
+|`->no cache found @00.00300s +00.00100s
 Starting stage: init-local/search-Azure
 Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.03300s +00.00900s
-|`->get_boot_telemetry @00.04200s +00.01600s
-|`->get_system_info @00.05800s +00.00000s
+|`->found azure asset tag @00.03000s +00.00900s
+|`->get_boot_telemetry @00.03900s +00.01300s
+|`->get_system_info @00.05200s +00.00000s
 Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.05800s +00.18200s
-|`->load_azure_ds_dir @00.24100s +00.00000s
+|`->list_possible_azure_ds_devs @00.05200s +00.18400s
+|`->load_azure_ds_dir @00.23600s +00.00100s
 Starting stage: azure-ds/load_azure_ds_dir
 Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.24500s +00.00100s
-|`->_extract_preprovisioned_vm_setting @00.24600s +00.00000s
-Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
+|`->load_azure_ovf_pubkeys @00.24100s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.24200s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
 
 Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
 
 Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.26600s +00.29000s
-|`->_get_metadata_from_imds @00.55700s +00.01100s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.32600 seconds
+|`->obtain dhcp lease @00.26000s +00.26200s
+|`->_get_metadata_from_imds @00.52200s +00.01000s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.29300 seconds
 
-|`->_get_random_seed @00.59200s +00.00000s
-Finished stage: (azure-ds/crawl_metadata) 00.54300 seconds
+|`->_get_random_seed @00.55400s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.50900 seconds
 
-|`->maybe_remove_ubuntu_network_config_scripts @00.60200s +00.00000s
-|`->write_files @00.60200s +00.00300s
-Finished stage: (azure-ds/_get_data) 00.57200 seconds
+|`->maybe_remove_ubuntu_network_config_scripts @00.56200s +00.00000s
+|`->write_files @00.56200s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.53400 seconds
 
-Finished stage: (init-local/search-Azure) 00.57500 seconds
+Finished stage: (init-local/search-Azure) 00.53700 seconds
 
-|`->network config from imds @00.66200s +00.00000s
-Finished stage: (init-local) 00.87800 seconds
+|`->network config from imds @00.61300s +00.00100s
+Finished stage: (init-local) 00.80700 seconds
 
 Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.10200s +00.01800s
-|`->network config from imds @03.16800s +00.00000s
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @02.79600s +00.01500s
+|`->network config from imds @02.85100s +00.00100s
 Starting stage: init-network/setup-datasource
 Starting stage: azure-ds/setup
 Starting stage: azure-ds/_negotiate
 Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @03.17900s +00.00000s
+|`->temporary_hostname @02.85800s +00.00000s
 Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
 
 Starting stage: azure-ds/get_metadata_from_fabric
 Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @03.18300s +00.08100s
+|`->generate_certificate @02.86100s +00.05300s
 Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @03.26500s +00.00000s
+|`->_networkd_get_value_from_leases @02.91400s +00.00100s
 Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
 
 Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @03.28900s +00.01400s
+|`->_decrypt_certs_from_xml @02.93600s +00.01000s
 Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @03.30400s +00.00700s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04100 seconds
+|`->_run_x509_action @02.94700s +00.00500s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04500 seconds
 
 Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @03.34500s +00.00800s
-Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00800 seconds
+|`->_run_x509_action @02.99200s +00.00500s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
 
-Finished stage: (azure-ds/parse_certificates) 00.06500 seconds
+Finished stage: (azure-ds/parse_certificates) 00.06200 seconds
 
-|`->_report_ready @03.35400s +00.01900s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.19000 seconds
+|`->_report_ready @02.99800s +00.00700s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.14400 seconds
 
-Finished stage: (azure-ds/get_metadata_from_fabric) 00.19100 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.14500 seconds
 
-Finished stage: (azure-ds/_negotiate) 00.19500 seconds
+Finished stage: (azure-ds/_negotiate) 00.14900 seconds
 
-Finished stage: (azure-ds/setup) 00.19600 seconds
+Finished stage: (azure-ds/setup) 00.14900 seconds
 
-Finished stage: (init-network/setup-datasource) 00.19700 seconds
+Finished stage: (init-network/setup-datasource) 00.14900 seconds
 
-|`->reading and applying user-data @03.38300s +00.01000s
-|`->reading and applying vendor-data @03.39300s +00.00000s
+|`->reading and applying user-data @03.01400s +00.00700s
+|`->reading and applying vendor-data @03.02100s +00.00000s
 Starting stage: init-network/activate-datasource
 Starting stage: azure-ds/activate
 Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @03.44500s +00.00000s
+|`->wait for ephemeral disk @03.05300s +00.00000s
 Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @03.44600s +00.16600s
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.16700 seconds
+|`->_has_ntfs_filesystem @03.05400s +00.14100s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.14200 seconds
 
-Finished stage: (azure-ds/address_ephemeral_resize) 00.16800 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.14200 seconds
 
-Finished stage: (azure-ds/activate) 00.16900 seconds
+Finished stage: (azure-ds/activate) 00.14200 seconds
 
-Finished stage: (init-network/activate-datasource) 00.17100 seconds
+Finished stage: (init-network/activate-datasource) 00.14400 seconds
 
-|`->config-migrator ran successfully @03.66900s +00.00100s
-|`->config-seed_random ran successfully @03.67100s +00.02900s
-|`->config-bootcmd ran successfully @03.70100s +00.00400s
-|`->config-write-files ran successfully @03.70500s +00.00100s
-|`->config-growpart ran successfully @03.70600s +00.24700s
-|`->config-resizefs ran successfully @03.95400s +00.02900s
-|`->config-disk_setup ran successfully @03.98300s +00.19000s
-|`->config-mounts ran successfully @04.17400s +00.19600s
-|`->config-set_hostname ran successfully @04.37100s +00.00800s
-|`->config-update_hostname ran successfully @04.37900s +00.00200s
-|`->config-update_etc_hosts ran successfully @04.38100s +00.00000s
-|`->config-ca-certs ran successfully @04.38200s +00.00100s
-|`->config-rsyslog ran successfully @04.38300s +00.00100s
-|`->config-users-groups ran successfully @04.38400s +00.19600s
-|`->config-ssh ran successfully @04.58100s +00.18400s
-Finished stage: (init-network) 01.68000 seconds
+|`->config-migrator ran successfully @03.24000s +00.00200s
+|`->config-seed_random ran successfully @03.24400s +00.00400s
+|`->config-bootcmd ran successfully @03.24900s +00.00500s
+|`->config-write-files ran successfully @03.25500s +00.00100s
+|`->config-growpart ran successfully @03.25700s +00.10600s
+|`->config-resizefs ran successfully @03.36300s +00.02400s
+|`->config-disk_setup ran successfully @03.38800s +00.15700s
+|`->config-mounts ran successfully @03.54600s +00.17300s
+|`->config-set_hostname ran successfully @03.71900s +00.00700s
+|`->config-update_hostname ran successfully @03.72600s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.72800s +00.00000s
+|`->config-ca-certs ran successfully @03.72800s +00.00100s
+|`->config-rsyslog ran successfully @03.72900s +00.00100s
+|`->config-users-groups ran successfully @03.73000s +00.21400s
+|`->config-ssh ran successfully @03.94500s +00.09900s
+Finished stage: (init-network) 01.26200 seconds
 
 Starting stage: modules-config
-|`->config-emit_upstart ran successfully @08.05400s +00.00400s
-|`->config-snap ran successfully @08.05900s +00.00100s
-|`->config-ssh-import-id ran successfully @08.06000s +00.98900s
-|`->config-locale ran successfully @09.05000s +00.01900s
-|`->config-set-passwords ran successfully @09.06900s +00.00100s
-|`->config-grub-dpkg ran successfully @09.08500s +00.45300s
-|`->config-apt-pipelining ran successfully @09.53900s +00.00200s
-|`->config-apt-configure ran successfully @09.54100s +00.13900s
-|`->config-ubuntu-advantage ran successfully @09.68100s +00.00100s
-|`->config-ntp ran successfully @09.68200s +00.00100s
-|`->config-timezone ran successfully @09.68300s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @09.68400s +00.00100s
-|`->config-runcmd ran successfully @09.68500s +00.00100s
-|`->config-byobu ran successfully @09.68600s +00.00100s
-Finished stage: (modules-config) 01.66500 seconds
+|`->config-emit_upstart ran successfully @06.97500s +00.00100s
+|`->config-snap ran successfully @06.97600s +00.00300s
+|`->config-ssh-import-id ran successfully @06.97900s +00.95100s
+|`->config-locale ran successfully @07.93000s +00.01700s
+|`->config-set-passwords ran successfully @07.94700s +00.00100s
+|`->config-grub-dpkg ran successfully @07.94900s +00.45700s
+|`->config-apt-pipelining ran successfully @08.40800s +00.00200s
+|`->config-apt-configure ran successfully @08.41000s +00.11700s
+|`->config-ubuntu-advantage ran successfully @08.52700s +00.00100s
+|`->config-ntp ran successfully @08.53000s +00.00100s
+|`->config-timezone ran successfully @08.53100s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @08.53200s +00.00100s
+|`->config-runcmd ran successfully @08.53300s +00.00100s
+|`->config-byobu ran successfully @08.53400s +00.00100s
+Finished stage: (modules-config) 01.58900 seconds
 
 Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @10.46100s +00.00100s
-|`->config-fan ran successfully @10.46200s +00.00100s
-|`->config-landscape ran successfully @10.46300s +00.00100s
-|`->config-lxd ran successfully @10.46500s +00.00000s
-|`->config-ubuntu-drivers ran successfully @10.46600s +00.00100s
-|`->config-puppet ran successfully @10.46700s +00.00100s
-|`->config-chef ran successfully @10.46800s +00.00100s
-|`->config-mcollective ran successfully @10.46900s +00.00100s
-|`->config-salt-minion ran successfully @10.47000s +00.00100s
-|`->config-rightscale_userdata ran successfully @10.47200s +00.00000s
-|`->config-scripts-vendor ran successfully @10.47300s +00.00100s
-|`->config-scripts-per-once ran successfully @10.47400s +00.00100s
-|`->config-scripts-per-boot ran successfully @10.47500s +00.00100s
-|`->config-scripts-per-instance ran successfully @10.47600s +00.00100s
-|`->config-scripts-user ran successfully @10.47800s +00.00000s
-|`->config-ssh-authkey-fingerprints ran successfully @10.47900s +00.08800s
-|`->config-keys-to-console ran successfully @10.56700s +00.10900s
-|`->config-phone-home ran successfully @10.67700s +00.00100s
-|`->config-final-message ran successfully @10.67900s +00.00500s
-|`->config-power-state-change ran successfully @10.68400s +00.00200s
-Finished stage: (modules-final) 00.24900 seconds
+|`->config-package-update-upgrade-install ran successfully @09.15600s +00.00100s
+|`->config-fan ran successfully @09.15700s +00.00100s
+|`->config-landscape ran successfully @09.15800s +00.00000s
+|`->config-lxd ran successfully @09.15900s +00.00100s
+|`->config-ubuntu-drivers ran successfully @09.16000s +00.00000s
+|`->config-puppet ran successfully @09.16100s +00.00000s
+|`->config-chef ran successfully @09.16200s +00.00000s
+|`->config-mcollective ran successfully @09.16300s +00.00000s
+|`->config-salt-minion ran successfully @09.16300s +00.00100s
+|`->config-rightscale_userdata ran successfully @09.16400s +00.00100s
+|`->config-scripts-vendor ran successfully @09.16500s +00.00100s
+|`->config-scripts-per-once ran successfully @09.16600s +00.00100s
+|`->config-scripts-per-boot ran successfully @09.16700s +00.00100s
+|`->config-scripts-per-instance ran successfully @09.16800s +00.00100s
+|`->config-scripts-user ran successfully @09.16900s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @09.17000s +00.08800s
+|`->config-keys-to-console ran successfully @09.25800s +00.09600s
+|`->config-phone-home ran successfully @09.35500s +00.00100s
+|`->config-final-message ran successfully @09.35600s +00.00400s
+|`->config-power-state-change ran successfully @09.36100s +00.00000s
+Finished stage: (modules-final) 00.22900 seconds
 
-Total Time: 8.26000 seconds
+Total Time: 7.19200 seconds
 
 1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze blame
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cloud-init analyze blame
 -- Boot Record 01 --
-     00.98900s (modules-config/config-ssh-import-id)
-     00.45300s (modules-config/config-grub-dpkg)
-     00.29000s (azure-ds/obtain-dhcp-lease)
-     00.24700s (init-network/config-growpart)
-     00.19600s (init-network/config-users-groups)
-     00.19600s (init-network/config-mounts)
-     00.19000s (init-network/config-disk_setup)
-     00.18400s (init-network/config-ssh)
-     00.18200s (azure-ds/list_possible_azure_ds_devs)
-     00.16600s (azure-ds/_has_ntfs_filesystem)
-     00.13900s (modules-config/config-apt-configure)
-     00.10900s (modules-final/config-keys-to-console)
+     00.95100s (modules-config/config-ssh-import-id)
+     00.45700s (modules-config/config-grub-dpkg)
+     00.26200s (azure-ds/obtain-dhcp-lease)
+     00.21400s (init-network/config-users-groups)
+     00.18400s (azure-ds/list_possible_azure_ds_devs)
+     00.17300s (init-network/config-mounts)
+     00.15700s (init-network/config-disk_setup)
+     00.14100s (azure-ds/_has_ntfs_filesystem)
+     00.11700s (modules-config/config-apt-configure)
+     00.10600s (init-network/config-growpart)
+     00.09900s (init-network/config-ssh)
+     00.09600s (modules-final/config-keys-to-console)
      00.08800s (modules-final/config-ssh-authkey-fingerprints)
-     00.08100s (azure-ds/generate_certificate)
-     00.02900s (init-network/config-seed_random)
-     00.02900s (init-network/config-resizefs)
-     00.01900s (modules-config/config-locale)
-     00.01900s (azure-ds/_report_ready)
-     00.01800s (init-network/check-cache)
-     00.01600s (azure-ds/get_boot_telemetry)
-     00.01400s (azure-ds/_decrypt_certs_from_xml)
-     00.01100s (azure-ds/_get_metadata_from_imds)
-     00.01000s (init-network/consume-user-data)
+     00.05300s (azure-ds/generate_certificate)
+     00.02400s (init-network/config-resizefs)
+     00.01700s (modules-config/config-locale)
+     00.01500s (init-network/check-cache)
+     00.01300s (azure-ds/get_boot_telemetry)
+     00.01000s (azure-ds/_get_metadata_from_imds)
+     00.01000s (azure-ds/_decrypt_certs_from_xml)
      00.00900s (azure-ds/check-platform-viability)
-     00.00800s (init-network/config-set_hostname)
-     00.00800s (azure-ds/_run_x509_action)
-     00.00700s (azure-ds/_run_x509_action)
-     00.00500s (modules-final/config-final-message)
-     00.00400s (modules-config/config-emit_upstart)
-     00.00400s (init-network/config-bootcmd)
-     00.00300s (azure-ds/write_files)
-     00.00200s (modules-final/config-power-state-change)
+     00.00700s (init-network/consume-user-data)
+     00.00700s (init-network/config-set_hostname)
+     00.00700s (azure-ds/_report_ready)
+     00.00500s (init-network/config-bootcmd)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (init-network/config-seed_random)
+     00.00300s (modules-config/config-snap)
      00.00200s (modules-config/config-apt-pipelining)
-     00.00200s (init-network/config-update_hostname)
-     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00200s (init-network/config-migrator)
+     00.00200s (azure-ds/write_files)
      00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
      00.00100s (modules-final/config-scripts-per-once)
      00.00100s (modules-final/config-scripts-per-instance)
      00.00100s (modules-final/config-scripts-per-boot)
      00.00100s (modules-final/config-salt-minion)
-     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-rightscale_userdata)
      00.00100s (modules-final/config-phone-home)
      00.00100s (modules-final/config-package-update-upgrade-install)
-     00.00100s (modules-final/config-mcollective)
-     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-lxd)
      00.00100s (modules-final/config-fan)
-     00.00100s (modules-final/config-chef)
      00.00100s (modules-config/config-ubuntu-advantage)
      00.00100s (modules-config/config-timezone)
-     00.00100s (modules-config/config-snap)
      00.00100s (modules-config/config-set-passwords)
      00.00100s (modules-config/config-runcmd)
      00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
      00.00100s (modules-config/config-disable-ec2-metadata)
      00.00100s (modules-config/config-byobu)
      00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
      00.00100s (init-network/config-rsyslog)
-     00.00100s (init-network/config-migrator)
      00.00100s (init-network/config-ca-certs)
      00.00100s (init-local/check-cache)
-     00.00100s (azure-ds/load_azure_ovf_pubkeys)
-     00.00000s (modules-final/config-scripts-user)
-     00.00000s (modules-final/config-rightscale_userdata)
-     00.00000s (modules-final/config-lxd)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-chef)
      00.00000s (init-network/consume-vendor-data)
      00.00000s (init-network/config-update_etc_hosts)
      00.00000s (azure-ds/wait-for-ephemeral-disk)
      00.00000s (azure-ds/temporary_hostname)
-     00.00000s (azure-ds/parse_network_config)
-     00.00000s (azure-ds/parse_network_config)
      00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
-     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
      00.00000s (azure-ds/get_system_info)
-     00.00000s (azure-ds/_networkd_get_value_from_leases)
      00.00000s (azure-ds/_get_random_seed)
      00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
 
 1 boot records analyzed
-+ echo After upgrade write network config: upgrade-network.out
++ echo 'After upgrade write network config: upgrade-network.out'
 After upgrade write network config: upgrade-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cat /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- grep DHCP /var/log/syslog
-+ echo ------- Diff previous-network to post-upgrade-network ------
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@40.65.204.147 -- grep DHCP /var/log/syslog
++ echo '------- Diff previous-network to post-upgrade-network ------'
 ------- Diff previous-network to post-upgrade-network ------
 + diff -urN previous-network.out upgrade-network.out
---- previous-network.out	2020-06-18 18:40:47.485188739 +0000
-+++ upgrade-network.out	2020-06-18 18:42:33.870829153 +0000
+--- previous-network.out	2020-06-24 20:15:48.982464609 +0000
++++ upgrade-network.out	2020-06-24 20:17:35.340122859 +0000
 @@ -38,3 +38,9 @@
- Jun 18 18:40:03 SRU-worked-azure dhclient[810]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
- Jun 18 18:40:03 SRU-worked-azure dhclient[810]: DHCPACK of 10.0.0.4 from 168.63.129.16
- Jun 18 18:40:03 SRU-worked-azure systemd-networkd[846]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
-+Jun 18 18:41:48 SRU-worked-azure dhclient[821]: Internet Systems Consortium DHCP Client 4.3.5
-+Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x8f23af27)
-+Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x27af238f)
-+Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
-+Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPACK of 10.0.0.4 from 168.63.129.16
-+Jun 18 18:41:48 SRU-worked-azure systemd-networkd[856]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
-+ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
-Validate https://github.com/canonical/cloud-init/commit/22e683df
-+ echo "Azure needs to use __builtin__ agent by default on all releases"
-Azure needs to use __builtin__ agent by default on all releases
-2020-06-18 18:41:45,859 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
-2020-06-18 18:41:45,859 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
-2020-06-18 18:41:45,859 - azure.py[DEBUG]: Generating certificate for communication with fabric...
-2020-06-18 18:41:46,030 - azure.py[DEBUG]: Reporting ready to Azure fabric.
-2020-06-18 18:41:46,049 - azure.py[INFO]: Reported ready to Azure fabric.
-2020-06-18 18:41:46,050 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
+ Jun 24 20:14:59 SRU-worked-azure dhclient[1047]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
+ Jun 24 20:14:59 SRU-worked-azure dhclient[1047]: DHCPACK of 10.0.0.4 from 168.63.129.16
+ Jun 24 20:14:59 SRU-worked-azure systemd-networkd[1077]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
++Jun 24 20:16:48 SRU-worked-azure dhclient[837]: Internet Systems Consortium DHCP Client 4.3.5
++Jun 24 20:16:48 SRU-worked-azure dhclient[837]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xce1f8904)
++Jun 24 20:16:48 SRU-worked-azure dhclient[837]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x4891fce)
++Jun 24 20:16:48 SRU-worked-azure dhclient[837]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
++Jun 24 20:16:48 SRU-worked-azure dhclient[837]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 24 20:16:48 SRU-worked-azure systemd-networkd[873]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
+
+
 + SRU_VARS=./sru-scripts/sru-vars.template
-+ [ ! -f ./sru-scripts/sru-vars.template ]
++ '[' '!' -f ./sru-scripts/sru-vars.template ']'
 + . ./sru-scripts/sru-vars.template
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=UNSET
-+ PROPOSED_SCRIPT=setup_proposed.sh
-+ USE_DEV_PPA=0
-+ SAMPLE_CLOUDCONFIG=sethostname.yaml
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=UNSET
-+ AZURE_VNET_NAME=UNSET
-+ AZURE_NETWORK_SECURITY_GROUP=UNSET
-+ AZURE_NIC_NAME=UNSET
-+ AZURE_RESOURCE_GROUP=UNSET
-+ AZURE_BOOT_DIAG=UNSET
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
-+ SRU_VARS_RC=.sru-vars.rc
-+ [ -f .sru-vars.rc ]
-+ [ -f /root/.sru-vars.rc ]
-+ . /root/.sru-vars.rc
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=chad.smith
-+ USE_DEV_PPA=0
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=eastus2
-+ AZURE_VNET_NAME=sruVnet
-+ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
-+ AZURE_NIC_NAME=sruNic
-+ AZURE_RESOURCE_GROUP=srugroupIPV6
-+ AZURE_BOOT_DIAG=storeitsru
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
+++ PRESERVE_INSTANCE=false
+++ UBUNTU_RELEASE=
+++ LP_USER=UNSET
+++ PROPOSED_SCRIPT=setup_proposed.sh
+++ USE_DEV_PPA=0
+++ ENI_NETCFG_FILE=/etc/network/interfaces.d/50-cloud-init.cfg
+++ NETPLAN_NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
+++ SAMPLE_CLOUDCONFIG=sethostname.yaml
+++ SSH_KEY=/root/.ssh/id_rsa.pub
+++ SSHOPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+++ AZURE_REGION=UNSET
+++ AZURE_VNET_NAME=UNSET
+++ AZURE_NETWORK_SECURITY_GROUP=UNSET
+++ AZURE_NIC_NAME=UNSET
+++ AZURE_RESOURCE_GROUP=UNSET
+++ AZURE_BOOT_DIAG=UNSET
+++ AZURE_ADVANCED_NIC_TESTS=true
+++ GCE_ZONE=UNSET
+++ OPENSTACK_ADMIN_NET_ID=UNSET
+++ OPENSTACK_SSH_KEY_NAME=UNSET
+++ SRU_VARS_RC=.sru-vars.rc
+++ '[' -f .sru-vars.rc ']'
+++ '[' -f /root/.sru-vars.rc ']'
+++ . /root/.sru-vars.rc
++++ PRESERVE_INSTANCE=false
++++ UBUNTU_RELEASE=
++++ LP_USER=chad.smith
++++ USE_DEV_PPA=0
++++ SSH_KEY=/root/.ssh/id_rsa.pub
++++ AZURE_REGION=eastus2
++++ AZURE_VNET_NAME=sruVnet
++++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++++ AZURE_NIC_NAME=sruNic
++++ AZURE_RESOURCE_GROUP=srugroupIPV6
++++ AZURE_BOOT_DIAG=storeitsru
++++ AZURE_ADVANCED_NIC_TESTS=true
++++ GCE_ZONE=UNSET
++++ OPENSTACK_ADMIN_NET_ID=UNSET
++++ OPENSTACK_SSH_KEY_NAME=UNSET
 + parse_args ./sru-scripts/manual/azure-sru eoan
 + script=./sru-scripts/manual/azure-sru
 + shift
-+ [ 1 = 0 ]
-+ [ 1 -ne 0 ]
++ '[' 1 = 0 ']'
++ '[' 1 -ne 0 ']'
++ case "$1" in
 + UBUNTU_RELEASE=eoan
++ NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
 + shift
-+ [ 0 -ne 0 ]
-+ [ -z eoan ]
++ '[' 0 -ne 0 ']'
++ '[' -z eoan ']'
 + assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
 + local value=
-+ eval value=$PROPOSED_SCRIPT > /dev/null
-+ value=setup_proposed.sh
-+ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
-+ eval value=$AZURE_REGION > /dev/null
-+ value=eastus2
-+ [ -z eastus2 -o eastus2 = UNSET ]
-+ eval value=$AZURE_VNET_NAME > /dev/null
-+ value=sruVnet
-+ [ -z sruVnet -o sruVnet = UNSET ]
-+ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
-+ value=sruNetSecGroup
-+ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
-+ eval value=$AZURE_NIC_NAME > /dev/null
-+ value=sruNic
-+ [ -z sruNic -o sruNic = UNSET ]
-+ eval value=$AZURE_RESOURCE_GROUP > /dev/null
-+ value=srugroupIPV6
-+ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
-+ eval value=$AZURE_BOOT_DIAG > /dev/null
-+ value=storeitsru
-+ [ -z storeitsru -o storeitsru = UNSET ]
-+ eval value=$SSH_KEY > /dev/null
-+ value=/root/.ssh/id_rsa.pub
-+ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
-+ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
-+ value=sethostname.yaml
-+ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
-+ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
-+ value=true
-+ [ -z true -o true = UNSET ]
-+ create_samplecloudconfig
-+ filename=sethostname.yaml
++ for var in $@
++ eval 'value=$PROPOSED_SCRIPT > /dev/null'
+++ value=setup_proposed.sh
++ '[' -z setup_proposed.sh -o setup_proposed.sh = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_REGION > /dev/null'
+++ value=eastus2
++ '[' -z eastus2 -o eastus2 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_VNET_NAME > /dev/null'
+++ value=sruVnet
++ '[' -z sruVnet -o sruVnet = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null'
+++ value=sruNetSecGroup
++ '[' -z sruNetSecGroup -o sruNetSecGroup = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NIC_NAME > /dev/null'
+++ value=sruNic
++ '[' -z sruNic -o sruNic = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_RESOURCE_GROUP > /dev/null'
+++ value=srugroupIPV6
++ '[' -z srugroupIPV6 -o srugroupIPV6 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_BOOT_DIAG > /dev/null'
+++ value=storeitsru
++ '[' -z storeitsru -o storeitsru = UNSET ']'
++ for var in $@
++ eval 'value=$SSH_KEY > /dev/null'
+++ value=/root/.ssh/id_rsa.pub
++ '[' -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ']'
++ for var in $@
++ eval 'value=$SAMPLE_CLOUDCONFIG > /dev/null'
+++ value=sethostname.yaml
++ '[' -z sethostname.yaml -o sethostname.yaml = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_ADVANCED_NIC_TESTS > /dev/null'
+++ value=true
++ '[' -z true -o true = UNSET ']'
++ create_samplecloudconfig SAMPLE_CLOUDCONFIG
++ filename=SAMPLE_CLOUDCONFIG
 + cat
 + create_setup_proposed_script
-+ [ 0 -eq 0 ]
++ '[' 0 -eq 0 ']'
 + cat
 + AZURE_VNET_NAME=sruVnet-eoan
-+ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
-+ jq -r .properties.state
+++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
+++ jq -r .properties.state
 + IPV6_NET_REGISTERED=Registered
-+ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
-+ jq -r .properties.state
+++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
+++ jq -r .properties.state
 + IPV6_CA_LB_REGISTERED=Registered
-+ [ Registered != Registered -o Registered != Registered ]
-+ az provider show -n Microsoft.Network
-+ jq -r .registrationState
++ '[' Registered '!=' Registered -o Registered '!=' Registered ']'
+++ az provider show -n Microsoft.Network
+++ jq -r .registrationState
 + IPV6_REGISTRATION_COMPLETE=Registered
-+ echo Waiting for Microsoft.Network IPv6 feature registration
++ echo 'Waiting for Microsoft.Network IPv6 feature registration'
 Waiting for Microsoft.Network IPv6 feature registration
-+ [ Registered != Registered ]
-+ echo ### BEGIN eoan
++ '[' Registered '!=' Registered ']'
++ echo '### BEGIN eoan'
 ### BEGIN eoan
 + az group show -g srugroupIPV6
-+ [ -n storeitsru ]
++ '[' -n storeitsru ']'
 + az storage account show --name storeitsru
-+ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ AZURE_BOOT_DIAG_ARG='--boot-diagnostics-storage storeitsru'
 + az network nsg show --name sruNetSecGroup -g srugroupIPV6
 + az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
 + az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
@@ -2528,13 +2485,13 @@ Waiting for Microsoft.Network IPv6 feature registration
     },
     "enableDdosProtection": false,
     "enableVmProtection": false,
-    "etag": "W/\"be5cca5e-5e74-4a28-9cce-8123226baa7b\"",
+    "etag": "W/\"95908010-f846-4b7d-944e-a42666ac40eb\"",
     "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-eoan",
     "location": "eastus2",
     "name": "sruVnet-eoan",
     "provisioningState": "Succeeded",
     "resourceGroup": "srugroupIPV6",
-    "resourceGuid": "a34e9b15-469c-49aa-805a-4334611ae2fa",
+    "resourceGuid": "2849d96b-a23c-4157-85ad-8b7655889b7e",
     "subnets": [],
     "tags": {},
     "type": "Microsoft.Network/virtualNetworks",
@@ -2550,7 +2507,7 @@ Waiting for Microsoft.Network IPv6 feature registration
     "ace:cab:deca:deed::/64"
   ],
   "delegations": [],
-  "etag": "W/\"2fca82f3-c951-4958-80fd-867bf44132c7\"",
+  "etag": "W/\"31cedb5a-d38b-4bad-8ddc-0cb64f4d3935\"",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-eoan/subnets/sruSubnet",
   "ipConfigurationProfiles": null,
   "ipConfigurations": null,
@@ -2584,11 +2541,13 @@ Waiting for Microsoft.Network IPv6 feature registration
   "serviceEndpoints": null,
   "type": "Microsoft.Network/virtualNetworks/subnets"
 }
-+ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ sshopts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR'
 + netcfg=/etc/netplan/50-cloud-init.yaml
++ case $UBUNTU_RELEASE in
 + image_version=Canonical:UbuntuServer:19.10-DAILY
-+ [  =  ]
-+ echo Creating standard network vm
++ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELEASE --size Standard_DS2_v2"
++ '[' '' = '' ']'
++ echo 'Creating standard network vm'
 Creating standard network vm
 + name=test-sru-eoan
 + az vm show --name test-sru-eoan -g srugroupIPV6
@@ -2597,456 +2556,108 @@ Creating standard network vm
   "fqdns": "",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-eoan",
   "location": "eastus2",
-  "macAddress": "00-0D-3A-00-25-59",
+  "macAddress": "00-0D-3A-E6-6F-1B",
   "powerState": "VM running",
   "privateIpAddress": "10.0.0.5",
-  "publicIpAddress": "52.254.87.225",
+  "publicIpAddress": "20.186.42.89",
   "resourceGroup": "srugroupIPV6",
   "zones": ""
 }
-+ az vm list-ip-addresses --name test-sru-eoan
-+ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
-+ awk {printf "ubuntu@%s", $1}
-+ IP=ubuntu@52.254.87.225
-+ echo Created test-sru-eoan: ubuntu@ubuntu@52.254.87.225
-Created test-sru-eoan: ubuntu@ubuntu@52.254.87.225
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init status --wait --long
-..........................................................................
+++ az vm list-ip-addresses --name test-sru-eoan
+++ jq -r '.[] | .virtualMachine.network.publicIpAddresses[].ipAddress'
+++ awk '{printf "ubuntu@%s", $1}'
++ IP=ubuntu@20.186.42.89
++ echo 'Created test-sru-eoan: ubuntu@ubuntu@20.186.42.89'
+Created test-sru-eoan: ubuntu@ubuntu@20.186.42.89
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cloud-init status --wait --long
+......................................................................
 status: done
-time: Thu, 18 Jun 2020 18:44:38 +0000
+time: Wed, 24 Jun 2020 20:09:34 +0000
 detail:
 DataSourceAzure [seed=/dev/sr0]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- dpkg-query --show cloud-init
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- dpkg-query --show cloud-init
 cloud-init	19.4-33-gbb4131a2-0ubuntu1~19.10.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo cat /run/cloud-init/result.json
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo cat /run/cloud-init/result.json
 {
  "v1": {
   "datasource": "DataSourceAzure [seed=/dev/sr0]",
   "errors": []
  }
 }
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- systemd-analyze
-Startup finished in 3.543s (kernel) + 57.231s (userspace) = 1min 775ms 
-graphical.target reached after 56.462s in userspace
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- systemd-analyze blame
-         26.851s snapd.seeded.service
-         11.450s cloud-init.service
-          4.846s cloud-init-local.service
-          2.897s lvm2-monitor.service
-          2.639s dev-sda1.device
-          2.490s cloud-config.service
-          2.414s systemd-udev-settle.service
-          2.374s pollinate.service
-          1.543s systemd-networkd-wait-online.service
-          1.214s snapd.service
-          1.189s systemd-logind.service
-          1.091s accounts-daemon.service
-           872ms rsyslog.service
-           781ms networkd-dispatcher.service
-           775ms apparmor.service
-           772ms cloud-final.service
-           709ms apport.service
-           704ms grub-common.service
-           516ms systemd-journald.service
-           515ms systemd-networkd.service
-           503ms systemd-resolved.service
-           434ms user@1000.service
-           430ms snap.lxd.activate.service
-           411ms systemd-udev-trigger.service
-           356ms systemd-udevd.service
-           342ms chrony.service
-           337ms atd.service
-           274ms keyboard-setup.service
-           238ms sys-kernel-debug.mount
-           238ms systemd-modules-load.service
-           235ms blk-availability.service
-           230ms systemd-remount-fs.service
-           223ms dev-hugepages.mount
-           221ms ufw.service
-           209ms grub-initrd-fallback.service
-           204ms multipathd.service
-           195ms systemd-user-sessions.service
-           176ms kmod-static-nodes.service
-           174ms systemd-sysusers.service
-           169ms dev-mqueue.mount
-           166ms plymouth-quit-wait.service
-           161ms systemd-journal-flush.service
-           153ms polkit.service
-           147ms plymouth-quit.service
-           116ms sys-fs-fuse-connections.mount
-           112ms plymouth-read-write.service
-           110ms sys-kernel-config.mount
-           110ms systemd-tmpfiles-setup.service
-           108ms finalrd.service
-           102ms systemd-machine-id-commit.service
-           102ms ssh.service
-            99ms systemd-sysctl.service
-            97ms console-setup.service
-            93ms setvtrgb.service
-            81ms snapd.socket
-            71ms systemd-random-seed.service
-            52ms systemd-tmpfiles-setup-dev.service
-            47ms snap-snapd-7777.mount
-            42ms snap-core18-1754.mount
-            40ms user-runtime-dir@1000.service
-            37ms snap-lxd-15457.mount
-            37ms systemd-update-utmp-runlevel.service
-            35ms dev-loop2.device
-            31ms dev-loop0.device
-            30ms ephemeral-disk-warning.service
-            30ms systemd-update-utmp.service
-            30ms boot-efi.mount
-            23ms dev-loop1.device
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze show
--- Boot Record 01 --
-The total time elapsed since completing an event is printed after the "@" character.
-The time the event takes is printed after the "+" character.
-
-Starting stage: init-local
-|`->no cache found @00.00300s +00.00000s
-Starting stage: init-local/search-Azure
-Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.14100s +00.00900s
-|`->get_boot_telemetry @00.15000s +00.06800s
-|`->get_system_info @00.21800s +00.00000s
-Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.21800s +00.05600s
-|`->load_azure_ds_dir @00.27400s +00.00000s
-Starting stage: azure-ds/load_azure_ds_dir
-Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.38700s +00.00100s
-|`->_extract_preprovisioned_vm_setting @00.38800s +00.00000s
-Finished stage: (azure-ds/read_azure_ovf) 00.00300 seconds
-
-Finished stage: (azure-ds/load_azure_ds_dir) 00.01100 seconds
-
-Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.42200s +00.38900s
-|`->_get_metadata_from_imds @00.81100s +00.08800s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.50200 seconds
-
-|`->_get_random_seed @00.92300s +00.00100s
-Finished stage: (azure-ds/crawl_metadata) 00.71400 seconds
-
-|`->maybe_remove_ubuntu_network_config_scripts @00.93200s +00.00100s
-|`->write_files @00.93300s +00.01000s
-Finished stage: (azure-ds/_get_data) 00.80200 seconds
-
-Finished stage: (init-local/search-Azure) 00.80400 seconds
-
-|`->network config from imds @01.00700s +00.00000s
-Finished stage: (init-local) 01.26100 seconds
-
-Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.84200s +00.02100s
-|`->network config from imds @03.91900s +00.00000s
-Starting stage: init-network/setup-datasource
-Starting stage: azure-ds/setup
-Starting stage: azure-ds/_negotiate
-Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @03.92800s +00.00000s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
-
-Starting stage: azure-ds/get_metadata_from_fabric
-Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @03.93200s +00.28500s
-Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @04.21700s +00.00100s
-Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
-
-Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @04.24000s +00.01300s
-Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @04.25300s +00.00600s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04700 seconds
-
-Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @04.30000s +00.00600s
-Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00700 seconds
-
-Finished stage: (azure-ds/parse_certificates) 00.06700 seconds
-
-|`->_report_ready @04.30700s +02.55600s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 02.93300 seconds
-
-Finished stage: (azure-ds/get_metadata_from_fabric) 02.93300 seconds
-
-Finished stage: (azure-ds/_negotiate) 02.93700 seconds
-
-Finished stage: (azure-ds/setup) 02.93800 seconds
-
-Finished stage: (init-network/setup-datasource) 02.93800 seconds
-
-|`->reading and applying user-data @06.87700s +00.00700s
-|`->reading and applying vendor-data @06.88400s +00.00100s
-Starting stage: init-network/activate-datasource
-Starting stage: azure-ds/activate
-Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @06.91900s +00.00100s
-Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @06.92000s +00.13700s
-Starting stage: azure-ds/mount-ntfs-and-count
-|`->count_files @07.14000s +00.00100s
-Finished stage: (azure-ds/mount-ntfs-and-count) 00.09600 seconds
-
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.23300 seconds
-
-Finished stage: (azure-ds/address_ephemeral_resize) 00.23500 seconds
-
-Finished stage: (azure-ds/activate) 00.23500 seconds
-
-Finished stage: (init-network/activate-datasource) 00.23600 seconds
-
-|`->config-migrator ran successfully @07.23500s +00.00100s
-|`->config-seed_random ran successfully @07.23600s +00.00100s
-|`->config-bootcmd ran successfully @07.23800s +00.00000s
-|`->config-write-files ran successfully @07.23800s +00.00100s
-|`->config-growpart ran successfully @07.23900s +00.72300s
-|`->config-resizefs ran successfully @07.96200s +02.69800s
-|`->config-disk_setup ran successfully @10.66000s +02.51800s
-|`->config-mounts ran successfully @13.18100s +00.26300s
-|`->config-set_hostname ran successfully @13.44400s +00.00700s
-|`->config-update_hostname ran successfully @13.45100s +00.00100s
-|`->config-update_etc_hosts ran successfully @13.45300s +00.00000s
-|`->config-ca-certs ran successfully @13.45400s +00.00000s
-|`->config-rsyslog ran successfully @13.45500s +00.00000s
-|`->config-users-groups ran successfully @13.45600s +00.84800s
-|`->config-ssh ran successfully @14.30500s +00.49000s
-Finished stage: (init-network) 10.96700 seconds
-
-Starting stage: modules-config
-|`->config-emit_upstart ran successfully @44.99700s +00.00000s
-|`->config-snap ran successfully @44.99800s +00.00000s
-|`->config-ssh-import-id ran successfully @44.99900s +00.83700s
-|`->config-locale ran successfully @45.83600s +00.00200s
-|`->config-set-passwords ran successfully @45.83800s +00.00100s
-|`->config-grub-dpkg ran successfully @45.83900s +00.97200s
-|`->config-apt-pipelining ran successfully @46.81200s +00.00100s
-|`->config-apt-configure ran successfully @46.81300s +00.12700s
-|`->config-ubuntu-advantage ran successfully @46.94100s +00.00100s
-|`->config-ntp ran successfully @46.94200s +00.00100s
-|`->config-timezone ran successfully @46.94300s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @46.94400s +00.00100s
-|`->config-runcmd ran successfully @46.94500s +00.00100s
-|`->config-byobu ran successfully @46.94600s +00.00100s
-Finished stage: (modules-config) 01.99800 seconds
-
-Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @47.59600s +00.00100s
-|`->config-fan ran successfully @47.59700s +00.00100s
-|`->config-landscape ran successfully @47.59800s +00.00100s
-|`->config-lxd ran successfully @47.59900s +00.00100s
-|`->config-ubuntu-drivers ran successfully @47.60100s +00.00000s
-|`->config-puppet ran successfully @47.60200s +00.00000s
-|`->config-chef ran successfully @47.60300s +00.00000s
-|`->config-mcollective ran successfully @47.60400s +00.00000s
-|`->config-salt-minion ran successfully @47.60500s +00.00000s
-|`->config-rightscale_userdata ran successfully @47.60600s +00.00100s
-|`->config-scripts-vendor ran successfully @47.60700s +00.00100s
-|`->config-scripts-per-once ran successfully @47.60800s +00.00100s
-|`->config-scripts-per-boot ran successfully @47.60900s +00.00000s
-|`->config-scripts-per-instance ran successfully @47.61000s +00.00000s
-|`->config-scripts-user ran successfully @47.61100s +00.00000s
-|`->config-ssh-authkey-fingerprints ran successfully @47.61200s +00.05500s
-|`->config-keys-to-console ran successfully @47.66700s +00.11000s
-|`->config-phone-home ran successfully @47.77700s +00.00100s
-|`->config-final-message ran successfully @47.77900s +00.00400s
-|`->config-power-state-change ran successfully @47.78300s +00.00100s
-Finished stage: (modules-final) 00.21600 seconds
-
-Total Time: 33.11700 seconds
-
-1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze blame
--- Boot Record 01 --
-     02.69800s (init-network/config-resizefs)
-     02.55600s (azure-ds/_report_ready)
-     02.51800s (init-network/config-disk_setup)
-     00.97200s (modules-config/config-grub-dpkg)
-     00.84800s (init-network/config-users-groups)
-     00.83700s (modules-config/config-ssh-import-id)
-     00.72300s (init-network/config-growpart)
-     00.49000s (init-network/config-ssh)
-     00.38900s (azure-ds/obtain-dhcp-lease)
-     00.28500s (azure-ds/generate_certificate)
-     00.26300s (init-network/config-mounts)
-     00.13700s (azure-ds/_has_ntfs_filesystem)
-     00.12700s (modules-config/config-apt-configure)
-     00.11000s (modules-final/config-keys-to-console)
-     00.08800s (azure-ds/_get_metadata_from_imds)
-     00.06800s (azure-ds/get_boot_telemetry)
-     00.05600s (azure-ds/list_possible_azure_ds_devs)
-     00.05500s (modules-final/config-ssh-authkey-fingerprints)
-     00.02100s (init-network/check-cache)
-     00.01300s (azure-ds/_decrypt_certs_from_xml)
-     00.01000s (azure-ds/write_files)
-     00.00900s (azure-ds/check-platform-viability)
-     00.00700s (init-network/consume-user-data)
-     00.00700s (init-network/config-set_hostname)
-     00.00600s (azure-ds/_run_x509_action)
-     00.00600s (azure-ds/_run_x509_action)
-     00.00400s (modules-final/config-final-message)
-     00.00200s (modules-config/config-locale)
-     00.00100s (modules-final/config-scripts-vendor)
-     00.00100s (modules-final/config-scripts-per-once)
-     00.00100s (modules-final/config-rightscale_userdata)
-     00.00100s (modules-final/config-power-state-change)
-     00.00100s (modules-final/config-phone-home)
-     00.00100s (modules-final/config-package-update-upgrade-install)
-     00.00100s (modules-final/config-lxd)
-     00.00100s (modules-final/config-landscape)
-     00.00100s (modules-final/config-fan)
-     00.00100s (modules-config/config-ubuntu-advantage)
-     00.00100s (modules-config/config-timezone)
-     00.00100s (modules-config/config-set-passwords)
-     00.00100s (modules-config/config-runcmd)
-     00.00100s (modules-config/config-ntp)
-     00.00100s (modules-config/config-disable-ec2-metadata)
-     00.00100s (modules-config/config-byobu)
-     00.00100s (modules-config/config-apt-pipelining)
-     00.00100s (init-network/consume-vendor-data)
-     00.00100s (init-network/config-write-files)
-     00.00100s (init-network/config-update_hostname)
-     00.00100s (init-network/config-seed_random)
-     00.00100s (init-network/config-migrator)
-     00.00100s (azure-ds/wait-for-ephemeral-disk)
-     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
-     00.00100s (azure-ds/load_azure_ovf_pubkeys)
-     00.00100s (azure-ds/count_files)
-     00.00100s (azure-ds/_networkd_get_value_from_leases)
-     00.00100s (azure-ds/_get_random_seed)
-     00.00000s (modules-final/config-ubuntu-drivers)
-     00.00000s (modules-final/config-scripts-user)
-     00.00000s (modules-final/config-scripts-per-instance)
-     00.00000s (modules-final/config-scripts-per-boot)
-     00.00000s (modules-final/config-salt-minion)
-     00.00000s (modules-final/config-puppet)
-     00.00000s (modules-final/config-mcollective)
-     00.00000s (modules-final/config-chef)
-     00.00000s (modules-config/config-snap)
-     00.00000s (modules-config/config-emit_upstart)
-     00.00000s (init-network/config-update_etc_hosts)
-     00.00000s (init-network/config-rsyslog)
-     00.00000s (init-network/config-ca-certs)
-     00.00000s (init-network/config-bootcmd)
-     00.00000s (init-local/check-cache)
-     00.00000s (azure-ds/temporary_hostname)
-     00.00000s (azure-ds/parse_network_config)
-     00.00000s (azure-ds/parse_network_config)
-     00.00000s (azure-ds/load_azure_ds_dir)
-     00.00000s (azure-ds/get_system_info)
-     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
-
-1 boot records analyzed
-+ echo Writing networking config: previous-network.out
-Writing networking config: previous-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cat /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- grep DHCP /var/log/syslog
-+ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@52.254.87.225:.
-PROPOSED_SCRIPT                               100%  196     2.9KB/s   00:00    
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo bash PROPOSED_SCRIPT
-+ egrep cloud-init
-  cloud-init
-Get:1 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~19.10.1 [420 kB]
-Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~19.10.1_all.deb ...
-Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) over (19.4-33-gbb4131a2-0ubuntu1~19.10.1) ...
-Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) ...
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- dpkg-query --show cloud-init
-cloud-init	20.2-45-g5f7825e2-0ubuntu1~19.10.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo hostname SRU-didnt-work
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo cloud-init clean --logs --reboot
-Connection to 52.254.87.225 closed by remote host.
-+ true
-+ sleep 60
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init status --wait --long
-
-status: done
-time: Thu, 18 Jun 2020 18:45:55 +0000
-detail:
-DataSourceAzure [seed=/var/lib/waagent]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo cat /run/cloud-init/result.json
-{
- "v1": {
-  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
-  "errors": []
- }
-}
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo systemd-analyze blame
-          3.178s snapd.service
-          2.743s snap.lxd.activate.service
-          2.625s cloud-init.service
-          2.171s lvm2-monitor.service
-          2.049s dev-sda1.device
-          1.943s systemd-logind.service
-          1.870s systemd-networkd-wait-online.service
-          1.754s cloud-config.service
-          1.677s systemd-udev-settle.service
-          1.640s accounts-daemon.service
-          1.553s cloud-init-local.service
-          1.439s rsyslog.service
-          1.416s grub-common.service
-          1.300s apport.service
-          1.020s systemd-user-sessions.service
-           971ms grub-initrd-fallback.service
-           838ms networkd-dispatcher.service
-           815ms cloud-final.service
-           768ms atd.service
-           649ms systemd-journald.service
-           377ms systemd-networkd.service
-           365ms ssh.service
-           359ms systemd-resolved.service
-           349ms chrony.service
-           335ms systemd-udev-trigger.service
-           334ms systemd-remount-fs.service
-           329ms dev-mqueue.mount
-           329ms ufw.service
-           325ms keyboard-setup.service
-           322ms kmod-static-nodes.service
-           316ms sys-kernel-debug.mount
-           304ms dev-hugepages.mount
-           300ms systemd-modules-load.service
-           217ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
-           216ms polkit.service
-           199ms apparmor.service
-           194ms systemd-journal-flush.service
-           161ms snapd.socket
-           132ms systemd-tmpfiles-setup.service
-           121ms console-setup.service
-           120ms sys-kernel-config.mount
-           120ms systemd-sysctl.service
-           119ms sys-fs-fuse-connections.mount
-           118ms plymouth-read-write.service
-           116ms finalrd.service
-           106ms systemd-random-seed.service
-           103ms boot-efi.mount
-           102ms snap-core18-1754.mount
-           101ms user@1000.service
-            98ms systemd-sysusers.service
-            94ms snap-lxd-15457.mount
-            88ms plymouth-quit-wait.service
-            87ms ephemeral-disk-warning.service
-            84ms setvtrgb.service
-            81ms snap-snapd-7777.mount
-            78ms snapd.seeded.service
-            69ms plymouth-quit.service
-            67ms multipathd.service
-            55ms dev-loop0.device
-            54ms systemd-udevd.service
-            54ms dev-loop1.device
-            52ms dev-loop2.device
-            47ms systemd-update-utmp.service
-            34ms blk-availability.service
-            34ms systemd-tmpfiles-setup-dev.service
-            19ms user-runtime-dir@1000.service
-            16ms systemd-update-utmp-runlevel.service
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze show
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- systemd-analyze
+Startup finished in 3.720s (kernel) + 57.855s (userspace) = 1min 1.575s 
+graphical.target reached after 57.081s in userspace
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- systemd-analyze blame
+         24.408s snapd.seeded.service
+         10.147s cloud-init.service
+          5.473s cloud-init-local.service
+          3.398s pollinate.service
+          3.062s lvm2-monitor.service
+          2.934s dev-sda1.device
+          2.810s systemd-udev-settle.service
+          2.347s cloud-config.service
+          2.274s accounts-daemon.service
+          2.039s systemd-networkd-wait-online.service
+          2.018s networkd-dispatcher.service
+          1.093s systemd-logind.service
+           924ms snapd.service
+           824ms chrony.service
+           811ms apparmor.service
+           726ms cloud-final.service
+           725ms grub-common.service
+           585ms apport.service
+           525ms systemd-journald.service
+           516ms systemd-networkd.service
+           515ms systemd-resolved.service
+           502ms grub-initrd-fallback.service
+           500ms rsyslog.service
+           451ms systemd-udevd.service
+           445ms snap.lxd.activate.service
+           425ms ssh.service
+           367ms user@1000.service
+           350ms systemd-udev-trigger.service
+           277ms keyboard-setup.service
+           268ms kmod-static-nodes.service
+           263ms ufw.service
+           257ms dev-mqueue.mount
+           253ms systemd-modules-load.service
+           237ms multipathd.service
+           212ms systemd-remount-fs.service
+           209ms dev-hugepages.mount
+           201ms sys-kernel-debug.mount
+           165ms systemd-sysusers.service
+           154ms systemd-user-sessions.service
+           152ms atd.service
+           140ms polkit.service
+           136ms plymouth-quit-wait.service
+           113ms user-runtime-dir@1000.service
+           112ms snapd.socket
+            99ms finalrd.service
+            89ms systemd-machine-id-commit.service
+            89ms setvtrgb.service
+            86ms console-setup.service
+            84ms systemd-sysctl.service
+            82ms sys-fs-fuse-connections.mount
+            82ms sys-kernel-config.mount
+            79ms systemd-journal-flush.service
+            78ms systemd-tmpfiles-setup.service
+            78ms plymouth-read-write.service
+            62ms plymouth-quit.service
+            62ms systemd-random-seed.service
+            51ms systemd-update-utmp-runlevel.service
+            50ms systemd-tmpfiles-setup-dev.service
+            45ms snap-snapd-7777.mount
+            39ms dev-loop2.device
+            38ms snap-core18-1754.mount
+            35ms snap-lxd-15457.mount
+            32ms ephemeral-disk-warning.service
+            32ms dev-loop0.device
+            32ms boot-efi.mount
+            32ms systemd-update-utmp.service
+            30ms blk-availability.service
+            24ms dev-loop1.device
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cloud-init analyze show
 -- Boot Record 01 --
 The total time elapsed since completing an event is printed after the "@" character.
 The time the event takes is printed after the "+" character.
@@ -3055,197 +2666,194 @@ Starting stage: init-local
 |`->no cache found @00.00400s +00.00000s
 Starting stage: init-local/search-Azure
 Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.04600s +00.00800s
-|`->get_boot_telemetry @00.05400s +00.01600s
-|`->get_system_info @00.07100s +00.00000s
+|`->found azure asset tag @00.14500s +00.00800s
+|`->get_boot_telemetry @00.15300s +00.07500s
+|`->get_system_info @00.22900s +00.00000s
 Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.07100s +00.20000s
-|`->load_azure_ds_dir @00.27100s +00.00100s
+|`->list_possible_azure_ds_devs @00.22900s +00.07400s
+|`->load_azure_ds_dir @00.30300s +00.00000s
 Starting stage: azure-ds/load_azure_ds_dir
 Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.27500s +00.00100s
-|`->_extract_preprovisioned_vm_setting @00.27600s +00.00000s
+|`->load_azure_ovf_pubkeys @00.42200s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.42300s +00.00000s
 Finished stage: (azure-ds/read_azure_ovf) 00.00300 seconds
 
-Finished stage: (azure-ds/load_azure_ds_dir) 00.00400 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01100 seconds
 
 Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.29600s +00.34500s
-|`->_get_metadata_from_imds @00.64100s +00.00900s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.37300 seconds
+|`->obtain dhcp lease @00.45600s +00.44200s
+|`->_get_metadata_from_imds @00.89800s +00.09800s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.56100 seconds
 
-|`->_get_random_seed @00.67000s +00.00000s
-Finished stage: (azure-ds/crawl_metadata) 00.60800 seconds
+|`->_get_random_seed @01.01800s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.79700 seconds
 
-|`->maybe_remove_ubuntu_network_config_scripts @00.67900s +00.00100s
-|`->write_files @00.68000s +00.00200s
-Finished stage: (azure-ds/_get_data) 00.63700 seconds
+|`->maybe_remove_ubuntu_network_config_scripts @01.02600s +00.00000s
+|`->write_files @01.02700s +00.01000s
+Finished stage: (azure-ds/_get_data) 00.89200 seconds
 
-Finished stage: (init-local/search-Azure) 00.64000 seconds
+Finished stage: (init-local/search-Azure) 00.89500 seconds
 
-|`->network config from imds @00.73300s +00.00100s
-Finished stage: (init-local) 00.84100 seconds
+|`->network config from imds @01.09800s +00.00000s
+Finished stage: (init-local) 01.37000 seconds
 
 Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.61200s +00.03200s
-|`->network config from imds @03.68500s +00.00100s
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @04.43700s +00.02200s
+|`->network config from imds @04.51600s +00.00100s
 Starting stage: init-network/setup-datasource
 Starting stage: azure-ds/setup
 Starting stage: azure-ds/_negotiate
 Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @03.69500s +00.00000s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+|`->temporary_hostname @04.52500s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
 
 Starting stage: azure-ds/get_metadata_from_fabric
 Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @03.69900s +00.13800s
+|`->generate_certificate @04.52900s +00.16800s
 Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @03.83700s +00.00100s
+|`->_networkd_get_value_from_leases @04.69700s +00.00100s
 Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
 
 Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @03.86000s +00.01200s
+|`->_decrypt_certs_from_xml @04.72300s +00.01200s
 Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @03.87300s +00.00500s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01200 seconds
+|`->_run_x509_action @04.73600s +00.00600s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04900 seconds
 
 Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @03.88500s +00.00600s
+|`->_run_x509_action @04.78500s +00.00600s
 Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
 
-Finished stage: (azure-ds/parse_certificates) 00.03100 seconds
+Finished stage: (azure-ds/parse_certificates) 00.06800 seconds
 
-|`->_report_ready @03.89100s +00.00600s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.19800 seconds
+|`->_report_ready @04.79100s +02.16200s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 02.42600 seconds
 
-Finished stage: (azure-ds/get_metadata_from_fabric) 00.19900 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 02.42600 seconds
 
-Finished stage: (azure-ds/_negotiate) 00.20300 seconds
+Finished stage: (azure-ds/_negotiate) 02.42900 seconds
 
-Finished stage: (azure-ds/setup) 00.20400 seconds
+Finished stage: (azure-ds/setup) 02.43000 seconds
 
-Finished stage: (init-network/setup-datasource) 00.20400 seconds
+Finished stage: (init-network/setup-datasource) 02.43000 seconds
 
-|`->reading and applying user-data @03.90400s +00.00700s
-|`->reading and applying vendor-data @03.91100s +00.00000s
+|`->reading and applying user-data @07.02100s +00.00700s
+|`->reading and applying vendor-data @07.02800s +00.00000s
 Starting stage: init-network/activate-datasource
 Starting stage: azure-ds/activate
 Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @03.94600s +00.00000s
+|`->wait for ephemeral disk @07.06000s +00.00000s
 Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @03.94700s +00.15100s
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.15300 seconds
+|`->_has_ntfs_filesystem @07.06100s +00.15400s
+Starting stage: azure-ds/mount-ntfs-and-count
+|`->count_files @07.30000s +00.00100s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.09400 seconds
 
-Finished stage: (azure-ds/address_ephemeral_resize) 00.15300 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.24800 seconds
 
-Finished stage: (azure-ds/activate) 00.15300 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.25000 seconds
 
-Finished stage: (init-network/activate-datasource) 00.15500 seconds
+Finished stage: (azure-ds/activate) 00.25000 seconds
 
-|`->config-migrator ran successfully @04.13900s +00.00100s
-|`->config-seed_random ran successfully @04.14000s +00.00400s
-|`->config-bootcmd ran successfully @04.14400s +00.00100s
-|`->config-write-files ran successfully @04.14500s +00.00700s
-|`->config-growpart ran successfully @04.15200s +00.11200s
-|`->config-resizefs ran successfully @04.26500s +00.15100s
-|`->config-disk_setup ran successfully @04.41700s +00.71000s
-|`->config-mounts ran successfully @05.12800s +00.25000s
-|`->config-set_hostname ran successfully @05.37800s +00.00700s
-|`->config-update_hostname ran successfully @05.38500s +00.00200s
-|`->config-update_etc_hosts ran successfully @05.38700s +00.00000s
-|`->config-ca-certs ran successfully @05.38800s +00.00000s
-|`->config-rsyslog ran successfully @05.38900s +00.00000s
-|`->config-users-groups ran successfully @05.39000s +00.06600s
-|`->config-ssh ran successfully @05.45700s +00.26400s
-Finished stage: (init-network) 02.12800 seconds
+Finished stage: (init-network/activate-datasource) 00.25500 seconds
+
+|`->config-migrator ran successfully @07.40100s +00.00000s
+|`->config-seed_random ran successfully @07.40200s +00.00100s
+|`->config-bootcmd ran successfully @07.40300s +00.00000s
+|`->config-write-files ran successfully @07.40400s +00.00000s
+|`->config-growpart ran successfully @07.40500s +00.73100s
+|`->config-resizefs ran successfully @08.13600s +02.73300s
+|`->config-disk_setup ran successfully @10.87000s +02.49600s
+|`->config-mounts ran successfully @13.36600s +00.28000s
+|`->config-set_hostname ran successfully @13.64700s +00.00700s
+|`->config-update_hostname ran successfully @13.65500s +00.00100s
+|`->config-update_etc_hosts ran successfully @13.65600s +00.00100s
+|`->config-ca-certs ran successfully @13.65700s +00.00100s
+|`->config-rsyslog ran successfully @13.65800s +00.00100s
+|`->config-users-groups ran successfully @13.65900s +00.27900s
+|`->config-ssh ran successfully @13.93800s +00.15500s
+Finished stage: (init-network) 09.67000 seconds
 
 Starting stage: modules-config
-|`->config-emit_upstart ran successfully @11.11300s +00.00000s
-|`->config-snap ran successfully @11.11400s +00.00000s
-|`->config-ssh-import-id ran successfully @11.11500s +00.75500s
-|`->config-locale ran successfully @11.87100s +00.00600s
-|`->config-set-passwords ran successfully @11.87700s +00.00100s
-|`->config-grub-dpkg ran successfully @11.87900s +00.30800s
-|`->config-apt-pipelining ran successfully @12.18800s +00.00100s
-|`->config-apt-configure ran successfully @12.18900s +00.12000s
-|`->config-ubuntu-advantage ran successfully @12.31000s +00.00100s
-|`->config-ntp ran successfully @12.31100s +00.00100s
-|`->config-timezone ran successfully @12.31200s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @12.31300s +00.00100s
-|`->config-runcmd ran successfully @12.31400s +00.00100s
-|`->config-byobu ran successfully @12.31500s +00.00100s
-Finished stage: (modules-config) 01.21900 seconds
+|`->config-emit_upstart ran successfully @44.35200s +00.00100s
+|`->config-snap ran successfully @44.35300s +00.00100s
+|`->config-ssh-import-id ran successfully @44.35400s +00.85800s
+|`->config-locale ran successfully @45.21300s +00.00100s
+|`->config-set-passwords ran successfully @45.21500s +00.00200s
+|`->config-grub-dpkg ran successfully @45.21700s +00.83100s
+|`->config-apt-pipelining ran successfully @46.04900s +00.00100s
+|`->config-apt-configure ran successfully @46.05000s +00.12200s
+|`->config-ubuntu-advantage ran successfully @46.17300s +00.00100s
+|`->config-ntp ran successfully @46.17400s +00.00100s
+|`->config-timezone ran successfully @46.17500s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @46.17600s +00.00000s
+|`->config-runcmd ran successfully @46.17700s +00.00000s
+|`->config-byobu ran successfully @46.17800s +00.00000s
+Finished stage: (modules-config) 01.87500 seconds
 
 Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @12.98100s +00.00100s
-|`->config-fan ran successfully @12.98200s +00.00100s
-|`->config-landscape ran successfully @12.98300s +00.00100s
-|`->config-lxd ran successfully @12.98400s +00.00100s
-|`->config-ubuntu-drivers ran successfully @12.98500s +00.00100s
-|`->config-puppet ran successfully @12.98600s +00.00100s
-|`->config-chef ran successfully @12.98700s +00.00100s
-|`->config-mcollective ran successfully @12.98800s +00.00100s
-|`->config-salt-minion ran successfully @12.98900s +00.00100s
-|`->config-rightscale_userdata ran successfully @12.99000s +00.00100s
-|`->config-scripts-vendor ran successfully @12.99100s +00.00100s
-|`->config-scripts-per-once ran successfully @12.99200s +00.00100s
-|`->config-scripts-per-boot ran successfully @12.99300s +00.00100s
-|`->config-scripts-per-instance ran successfully @12.99400s +00.00100s
-|`->config-scripts-user ran successfully @12.99500s +00.00100s
-|`->config-ssh-authkey-fingerprints ran successfully @12.99600s +00.08600s
-|`->config-keys-to-console ran successfully @13.08200s +00.11400s
-|`->config-phone-home ran successfully @13.19700s +00.00100s
-|`->config-final-message ran successfully @13.19900s +00.00400s
-|`->config-power-state-change ran successfully @13.20300s +00.00100s
-Finished stage: (modules-final) 00.23900 seconds
+|`->config-package-update-upgrade-install ran successfully @46.80300s +00.00100s
+|`->config-fan ran successfully @46.80400s +00.00100s
+|`->config-landscape ran successfully @46.80500s +00.00100s
+|`->config-lxd ran successfully @46.80600s +00.00100s
+|`->config-ubuntu-drivers ran successfully @46.80700s +00.00100s
+|`->config-puppet ran successfully @46.80800s +00.00100s
+|`->config-chef ran successfully @46.80900s +00.00100s
+|`->config-mcollective ran successfully @46.81000s +00.00100s
+|`->config-salt-minion ran successfully @46.81100s +00.00100s
+|`->config-rightscale_userdata ran successfully @46.81200s +00.00100s
+|`->config-scripts-vendor ran successfully @46.81300s +00.00100s
+|`->config-scripts-per-once ran successfully @46.81400s +00.00100s
+|`->config-scripts-per-boot ran successfully @46.81500s +00.00000s
+|`->config-scripts-per-instance ran successfully @46.81600s +00.00000s
+|`->config-scripts-user ran successfully @46.81700s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @46.81800s +00.05300s
+|`->config-keys-to-console ran successfully @46.87200s +00.11800s
+|`->config-phone-home ran successfully @46.99100s +00.00200s
+|`->config-final-message ran successfully @46.99300s +00.00400s
+|`->config-power-state-change ran successfully @46.99800s +00.00000s
+Finished stage: (modules-final) 00.22400 seconds
 
-Total Time: 8.36800 seconds
+Total Time: 29.66300 seconds
 
 1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze blame
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cloud-init analyze blame
 -- Boot Record 01 --
-     00.75500s (modules-config/config-ssh-import-id)
-     00.71000s (init-network/config-disk_setup)
-     00.34500s (azure-ds/obtain-dhcp-lease)
-     00.30800s (modules-config/config-grub-dpkg)
-     00.26400s (init-network/config-ssh)
-     00.25000s (init-network/config-mounts)
-     00.20000s (azure-ds/list_possible_azure_ds_devs)
-     00.15100s (init-network/config-resizefs)
-     00.15100s (azure-ds/_has_ntfs_filesystem)
-     00.13800s (azure-ds/generate_certificate)
-     00.12000s (modules-config/config-apt-configure)
-     00.11400s (modules-final/config-keys-to-console)
-     00.11200s (init-network/config-growpart)
-     00.08600s (modules-final/config-ssh-authkey-fingerprints)
-     00.06600s (init-network/config-users-groups)
-     00.03200s (init-network/check-cache)
-     00.01600s (azure-ds/get_boot_telemetry)
+     02.73300s (init-network/config-resizefs)
+     02.49600s (init-network/config-disk_setup)
+     02.16200s (azure-ds/_report_ready)
+     00.85800s (modules-config/config-ssh-import-id)
+     00.83100s (modules-config/config-grub-dpkg)
+     00.73100s (init-network/config-growpart)
+     00.44200s (azure-ds/obtain-dhcp-lease)
+     00.28000s (init-network/config-mounts)
+     00.27900s (init-network/config-users-groups)
+     00.16800s (azure-ds/generate_certificate)
+     00.15500s (init-network/config-ssh)
+     00.15400s (azure-ds/_has_ntfs_filesystem)
+     00.12200s (modules-config/config-apt-configure)
+     00.11800s (modules-final/config-keys-to-console)
+     00.09800s (azure-ds/_get_metadata_from_imds)
+     00.07500s (azure-ds/get_boot_telemetry)
+     00.07400s (azure-ds/list_possible_azure_ds_devs)
+     00.05300s (modules-final/config-ssh-authkey-fingerprints)
+     00.02200s (init-network/check-cache)
      00.01200s (azure-ds/_decrypt_certs_from_xml)
-     00.00900s (azure-ds/_get_metadata_from_imds)
+     00.01000s (azure-ds/write_files)
      00.00800s (azure-ds/check-platform-viability)
      00.00700s (init-network/consume-user-data)
-     00.00700s (init-network/config-write-files)
      00.00700s (init-network/config-set_hostname)
-     00.00600s (modules-config/config-locale)
      00.00600s (azure-ds/_run_x509_action)
-     00.00600s (azure-ds/_report_ready)
-     00.00500s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_run_x509_action)
      00.00400s (modules-final/config-final-message)
-     00.00400s (init-network/config-seed_random)
-     00.00200s (init-network/config-update_hostname)
-     00.00200s (azure-ds/write_files)
+     00.00200s (modules-final/config-phone-home)
+     00.00200s (modules-config/config-set-passwords)
      00.00100s (modules-final/config-ubuntu-drivers)
      00.00100s (modules-final/config-scripts-vendor)
-     00.00100s (modules-final/config-scripts-user)
      00.00100s (modules-final/config-scripts-per-once)
-     00.00100s (modules-final/config-scripts-per-instance)
-     00.00100s (modules-final/config-scripts-per-boot)
      00.00100s (modules-final/config-salt-minion)
      00.00100s (modules-final/config-rightscale_userdata)
      00.00100s (modules-final/config-puppet)
-     00.00100s (modules-final/config-power-state-change)
-     00.00100s (modules-final/config-phone-home)
      00.00100s (modules-final/config-package-update-upgrade-install)
      00.00100s (modules-final/config-mcollective)
      00.00100s (modules-final/config-lxd)
@@ -3254,175 +2862,568 @@ Total Time: 8.36800 seconds
      00.00100s (modules-final/config-chef)
      00.00100s (modules-config/config-ubuntu-advantage)
      00.00100s (modules-config/config-timezone)
-     00.00100s (modules-config/config-set-passwords)
-     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-snap)
      00.00100s (modules-config/config-ntp)
-     00.00100s (modules-config/config-disable-ec2-metadata)
-     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-locale)
+     00.00100s (modules-config/config-emit_upstart)
      00.00100s (modules-config/config-apt-pipelining)
-     00.00100s (init-network/config-migrator)
-     00.00100s (init-network/config-bootcmd)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-ca-certs)
      00.00100s (azure-ds/parse_network_config)
-     00.00100s (azure-ds/parse_network_config)
-     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
-     00.00100s (azure-ds/load_azure_ovf_pubkeys)
-     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/count_files)
      00.00100s (azure-ds/_networkd_get_value_from_leases)
-     00.00000s (modules-config/config-snap)
-     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-instance)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
      00.00000s (init-network/consume-vendor-data)
-     00.00000s (init-network/config-update_etc_hosts)
-     00.00000s (init-network/config-rsyslog)
-     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-bootcmd)
      00.00000s (init-local/check-cache)
      00.00000s (azure-ds/wait-for-ephemeral-disk)
      00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/load_azure_ds_dir)
      00.00000s (azure-ds/get_system_info)
      00.00000s (azure-ds/_get_random_seed)
      00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
 
 1 boot records analyzed
-+ echo After upgrade write network config: upgrade-network.out
++ echo 'Writing networking config: previous-network.out'
+Writing networking config: previous-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@20.186.42.89:.
+PROPOSED_SCRIPT                               100%  196     3.4KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo bash PROPOSED_SCRIPT
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~19.10.1 [420 kB]
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~19.10.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) over (19.4-33-gbb4131a2-0ubuntu1~19.10.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- dpkg-query --show cloud-init
+cloud-init	20.2-45-g5f7825e2-0ubuntu1~19.10.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo cloud-init clean --logs --reboot
++ sleep 60
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cloud-init status --wait --long
+
+status: done
+time: Wed, 24 Jun 2020 20:10:53 +0000
+detail:
+DataSourceAzure [seed=/var/lib/waagent]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- sudo systemd-analyze blame
+          2.661s cloud-config.service
+          2.601s snapd.service
+          2.350s cloud-init.service
+          2.256s snap.lxd.activate.service
+          2.071s lvm2-monitor.service
+          1.983s dev-sdb1.device
+          1.887s systemd-udev-settle.service
+          1.540s systemd-logind.service
+          1.479s cloud-init-local.service
+          1.214s systemd-networkd-wait-online.service
+          1.209s accounts-daemon.service
+          1.065s grub-common.service
+           954ms grub-initrd-fallback.service
+           940ms apport.service
+           914ms networkd-dispatcher.service
+           850ms systemd-user-sessions.service
+           771ms chrony.service
+           761ms rsyslog.service
+           758ms cloud-final.service
+           716ms ssh.service
+           690ms systemd-journald.service
+           503ms atd.service
+           430ms systemd-udev-trigger.service
+           408ms systemd-networkd.service
+           400ms polkit.service
+           289ms systemd-resolved.service
+           288ms systemd-modules-load.service
+           284ms dev-hugepages.mount
+           273ms keyboard-setup.service
+           263ms ufw.service
+           252ms sys-kernel-debug.mount
+           250ms plymouth-quit-wait.service
+           244ms dev-mqueue.mount
+           242ms blk-availability.service
+           240ms plymouth-quit.service
+           209ms systemd-remount-fs.service
+           203ms kmod-static-nodes.service
+           190ms snapd.socket
+           165ms apparmor.service
+           143ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+           119ms snap-core18-1754.mount
+           113ms snapd.seeded.service
+           111ms console-setup.service
+           106ms boot-efi.mount
+           105ms systemd-tmpfiles-setup.service
+            99ms snap-snapd-7777.mount
+            96ms user@1000.service
+            92ms finalrd.service
+            87ms snap-lxd-15457.mount
+            83ms plymouth-read-write.service
+            81ms systemd-sysusers.service
+            79ms systemd-random-seed.service
+            75ms sys-fs-fuse-connections.mount
+            71ms sys-kernel-config.mount
+            70ms dev-loop1.device
+            69ms multipathd.service
+            69ms dev-loop0.device
+            65ms systemd-sysctl.service
+            55ms systemd-udevd.service
+            47ms setvtrgb.service
+            46ms dev-loop2.device
+            43ms systemd-journal-flush.service
+            27ms systemd-update-utmp.service
+            22ms systemd-update-utmp-runlevel.service
+            19ms systemd-tmpfiles-setup-dev.service
+            18ms user-runtime-dir@1000.service
+            11ms ephemeral-disk-warning.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.04500s +00.00800s
+|`->get_boot_telemetry @00.05400s +00.01500s
+|`->get_system_info @00.06900s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.06900s +00.20400s
+|`->load_azure_ds_dir @00.27400s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.27700s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.27800s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00300 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00400 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.29800s +00.24900s
+|`->_get_metadata_from_imds @00.54800s +00.01100s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.28200 seconds
+
+|`->_get_random_seed @00.58000s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.52200 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.59100s +00.00000s
+|`->write_files @00.59200s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.55000 seconds
+
+Finished stage: (init-local/search-Azure) 00.55300 seconds
+
+|`->network config from imds @00.64600s +00.00000s
+Finished stage: (init-local) 00.74600 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @02.85700s +00.03200s
+|`->network config from imds @02.92900s +00.00100s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @02.93800s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @02.94100s +00.02600s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @02.96700s +00.00100s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @02.98700s +00.01400s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @03.00200s +00.00500s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01200 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @03.01400s +00.00500s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00500 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.03200 seconds
+
+|`->_report_ready @03.02000s +00.00600s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.08500 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.08600 seconds
+
+Finished stage: (azure-ds/_negotiate) 00.08900 seconds
+
+Finished stage: (azure-ds/setup) 00.09000 seconds
+
+Finished stage: (init-network/setup-datasource) 00.09000 seconds
+
+|`->reading and applying user-data @03.03300s +00.00600s
+|`->reading and applying vendor-data @03.03900s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @03.07100s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @03.07100s +00.15400s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.15400 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.15400 seconds
+
+Finished stage: (azure-ds/activate) 00.15400 seconds
+
+Finished stage: (init-network/activate-datasource) 00.15600 seconds
+
+|`->config-migrator ran successfully @03.26300s +00.00100s
+|`->config-seed_random ran successfully @03.26400s +00.00600s
+|`->config-bootcmd ran successfully @03.27000s +00.00000s
+|`->config-write-files ran successfully @03.27100s +00.00000s
+|`->config-growpart ran successfully @03.27200s +00.09000s
+|`->config-resizefs ran successfully @03.36300s +00.04900s
+|`->config-disk_setup ran successfully @03.41300s +00.63200s
+|`->config-mounts ran successfully @04.04500s +00.22100s
+|`->config-set_hostname ran successfully @04.26700s +00.00600s
+|`->config-update_hostname ran successfully @04.27300s +00.00100s
+|`->config-update_etc_hosts ran successfully @04.27400s +00.00100s
+|`->config-ca-certs ran successfully @04.27500s +00.00000s
+|`->config-rsyslog ran successfully @04.27500s +00.00100s
+|`->config-users-groups ran successfully @04.27600s +00.08600s
+|`->config-ssh ran successfully @04.36300s +00.36400s
+Finished stage: (init-network) 01.88900 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @09.91300s +00.00000s
+|`->config-snap ran successfully @09.91400s +00.00100s
+|`->config-ssh-import-id ran successfully @09.91500s +00.76100s
+|`->config-locale ran successfully @10.67700s +00.00500s
+|`->config-set-passwords ran successfully @10.68300s +00.00100s
+|`->config-grub-dpkg ran successfully @10.68400s +00.60600s
+|`->config-apt-pipelining ran successfully @11.29200s +00.00100s
+|`->config-apt-configure ran successfully @11.29400s +00.12300s
+|`->config-ubuntu-advantage ran successfully @11.41800s +00.00000s
+|`->config-ntp ran successfully @11.41900s +00.00000s
+|`->config-timezone ran successfully @11.42000s +00.00000s
+|`->config-disable-ec2-metadata ran successfully @11.42100s +00.00000s
+|`->config-runcmd ran successfully @11.42100s +00.00100s
+|`->config-byobu ran successfully @11.42200s +00.00100s
+Finished stage: (modules-config) 01.54900 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @11.97200s +00.00100s
+|`->config-fan ran successfully @11.97400s +00.00000s
+|`->config-landscape ran successfully @11.97500s +00.00000s
+|`->config-lxd ran successfully @11.97600s +00.00000s
+|`->config-ubuntu-drivers ran successfully @11.97700s +00.00100s
+|`->config-puppet ran successfully @11.97800s +00.00000s
+|`->config-chef ran successfully @11.97900s +00.00000s
+|`->config-mcollective ran successfully @11.98000s +00.00000s
+|`->config-salt-minion ran successfully @11.98100s +00.00100s
+|`->config-rightscale_userdata ran successfully @11.98200s +00.00000s
+|`->config-scripts-vendor ran successfully @11.98300s +00.00000s
+|`->config-scripts-per-once ran successfully @11.98400s +00.00000s
+|`->config-scripts-per-boot ran successfully @11.98500s +00.00000s
+|`->config-scripts-per-instance ran successfully @11.98500s +00.00100s
+|`->config-scripts-user ran successfully @11.98600s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @11.98700s +00.08500s
+|`->config-keys-to-console ran successfully @12.07300s +00.10300s
+|`->config-phone-home ran successfully @12.17600s +00.00100s
+|`->config-final-message ran successfully @12.17800s +00.00400s
+|`->config-power-state-change ran successfully @12.18200s +00.00100s
+Finished stage: (modules-final) 00.22800 seconds
+
+Total Time: 7.43700 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cloud-init analyze blame
+-- Boot Record 01 --
+     00.76100s (modules-config/config-ssh-import-id)
+     00.63200s (init-network/config-disk_setup)
+     00.60600s (modules-config/config-grub-dpkg)
+     00.36400s (init-network/config-ssh)
+     00.24900s (azure-ds/obtain-dhcp-lease)
+     00.22100s (init-network/config-mounts)
+     00.20400s (azure-ds/list_possible_azure_ds_devs)
+     00.15400s (azure-ds/_has_ntfs_filesystem)
+     00.12300s (modules-config/config-apt-configure)
+     00.10300s (modules-final/config-keys-to-console)
+     00.09000s (init-network/config-growpart)
+     00.08600s (init-network/config-users-groups)
+     00.08500s (modules-final/config-ssh-authkey-fingerprints)
+     00.04900s (init-network/config-resizefs)
+     00.03200s (init-network/check-cache)
+     00.02600s (azure-ds/generate_certificate)
+     00.01500s (azure-ds/get_boot_telemetry)
+     00.01400s (azure-ds/_decrypt_certs_from_xml)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.00800s (azure-ds/check-platform-viability)
+     00.00600s (init-network/consume-user-data)
+     00.00600s (init-network/config-set_hostname)
+     00.00600s (init-network/config-seed_random)
+     00.00600s (azure-ds/_report_ready)
+     00.00500s (modules-config/config-locale)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00200s (azure-ds/write_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-fan)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-timezone)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo 'After upgrade write network config: upgrade-network.out'
 After upgrade write network config: upgrade-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cat /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- grep DHCP /var/log/syslog
-+ echo ------- Diff previous-network to post-upgrade-network ------
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.42.89 -- grep DHCP /var/log/syslog
++ echo '------- Diff previous-network to post-upgrade-network ------'
 ------- Diff previous-network to post-upgrade-network ------
 + diff -urN previous-network.out upgrade-network.out
---- previous-network.out	2020-06-18 18:44:52.444953133 +0000
-+++ upgrade-network.out	2020-06-18 18:46:32.902485798 +0000
-@@ -38,3 +38,9 @@
- Jun 18 18:44:07 SRU-worked-azure dhclient[496]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x5d57032b)
- Jun 18 18:44:07 SRU-worked-azure dhclient[496]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0x2b03575d)
- Jun 18 18:44:07 SRU-worked-azure systemd-networkd[521]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
-+Jun 18 18:45:50 SRU-worked-azure dhclient[518]: Internet Systems Consortium DHCP Client 4.4.1
-+Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xe60a9272)
-+Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPOFFER of 10.0.0.5 from 168.63.129.16
-+Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x72920ae6)
-+Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0xe60a9272)
-+Jun 18 18:45:50 SRU-worked-azure systemd-networkd[543]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
-+ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
-Validate https://github.com/canonical/cloud-init/commit/22e683df
-+ echo "Azure needs to use __builtin__ agent by default on all releases"
-Azure needs to use __builtin__ agent by default on all releases
-2020-06-18 18:45:46,061 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
-2020-06-18 18:45:46,061 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
-2020-06-18 18:45:46,061 - azure.py[DEBUG]: Generating certificate for communication with fabric...
-2020-06-18 18:45:46,253 - azure.py[DEBUG]: Reporting ready to Azure fabric.
-2020-06-18 18:45:46,259 - azure.py[INFO]: Reported ready to Azure fabric.
-2020-06-18 18:45:46,260 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
+--- previous-network.out	2020-06-24 20:09:59.172984686 +0000
++++ upgrade-network.out	2020-06-24 20:11:35.542499339 +0000
+@@ -11,18 +11,18 @@
+                 route-metric: 100
+             dhcp6: false
+             match:
+-                macaddress: 00:0d:3a:e6:6f:27
++                macaddress: 00:0d:3a:e6:6f:1b
+             set-name: eth0
+     version: 2
+-default via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.6 metric 100 
+-10.0.0.0/24 dev eth0 proto kernel scope link src 10.0.0.6 
+-168.63.129.16 via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.6 metric 100 
+-169.254.169.254 via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.6 metric 100 
++default via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.5 metric 100 
++10.0.0.0/24 dev eth0 proto kernel scope link src 10.0.0.5 
++168.63.129.16 via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.5 metric 100 
++169.254.169.254 via 10.0.0.1 dev eth0 proto dhcp src 10.0.0.5 metric 100 
+ 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+     inet 127.0.0.1/8 scope host lo
+        valid_lft forever preferred_lft forever
+ 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+-    inet 10.0.0.6/24 brd 10.0.0.255 scope global eth0
++    inet 10.0.0.5/24 brd 10.0.0.255 scope global eth0
+        valid_lft forever preferred_lft forever
+ ::1 dev lo proto kernel metric 256 pref medium
+ fe80::/64 dev eth0 proto kernel metric 256 pref medium
+@@ -30,11 +30,17 @@
+     inet6 ::1/128 scope host 
+        valid_lft forever preferred_lft forever
+ 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
+-    inet6 fe80::20d:3aff:fee6:6f27/64 scope link 
++    inet6 fe80::20d:3aff:fee6:6f1b/64 scope link 
+        valid_lft forever preferred_lft forever
+-Jun 24 20:09:15 SRU-worked-azure dhclient[503]: Internet Systems Consortium DHCP Client 4.4.1
+-Jun 24 20:09:15 SRU-worked-azure dhclient[503]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x89274635)
+-Jun 24 20:09:15 SRU-worked-azure dhclient[503]: DHCPOFFER of 10.0.0.6 from 168.63.129.16
+-Jun 24 20:09:15 SRU-worked-azure dhclient[503]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x35462789)
+-Jun 24 20:09:15 SRU-worked-azure dhclient[503]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0x89274635)
+-Jun 24 20:09:15 SRU-worked-azure systemd-networkd[531]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
++Jun 24 20:09:02 SRU-worked-azure dhclient[499]: Internet Systems Consortium DHCP Client 4.4.1
++Jun 24 20:09:02 SRU-worked-azure dhclient[499]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x46beb136)
++Jun 24 20:09:02 SRU-worked-azure dhclient[499]: DHCPOFFER of 10.0.0.5 from 168.63.129.16
++Jun 24 20:09:02 SRU-worked-azure dhclient[499]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x36b1be46)
++Jun 24 20:09:02 SRU-worked-azure dhclient[499]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0x46beb136)
++Jun 24 20:09:02 SRU-worked-azure systemd-networkd[524]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
++Jun 24 20:10:47 SRU-worked-azure dhclient[520]: Internet Systems Consortium DHCP Client 4.4.1
++Jun 24 20:10:47 SRU-worked-azure dhclient[520]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xdac7b267)
++Jun 24 20:10:47 SRU-worked-azure dhclient[520]: DHCPOFFER of 10.0.0.5 from 168.63.129.16
++Jun 24 20:10:47 SRU-worked-azure dhclient[520]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x67b2c7da)
++Jun 24 20:10:47 SRU-worked-azure dhclient[520]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0xdac7b267)
++Jun 24 20:10:47 SRU-worked-azure systemd-networkd[545]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
+
 + SRU_VARS=./sru-scripts/sru-vars.template
-+ [ ! -f ./sru-scripts/sru-vars.template ]
++ '[' '!' -f ./sru-scripts/sru-vars.template ']'
 + . ./sru-scripts/sru-vars.template
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=UNSET
-+ PROPOSED_SCRIPT=setup_proposed.sh
-+ USE_DEV_PPA=0
-+ SAMPLE_CLOUDCONFIG=sethostname.yaml
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=UNSET
-+ AZURE_VNET_NAME=UNSET
-+ AZURE_NETWORK_SECURITY_GROUP=UNSET
-+ AZURE_NIC_NAME=UNSET
-+ AZURE_RESOURCE_GROUP=UNSET
-+ AZURE_BOOT_DIAG=UNSET
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
-+ SRU_VARS_RC=.sru-vars.rc
-+ [ -f .sru-vars.rc ]
-+ [ -f /root/.sru-vars.rc ]
-+ . /root/.sru-vars.rc
-+ PRESERVE_INSTANCE=false
-+ UBUNTU_RELEASE=
-+ LP_USER=chad.smith
-+ USE_DEV_PPA=0
-+ SSH_KEY=/root/.ssh/id_rsa.pub
-+ AZURE_REGION=eastus2
-+ AZURE_VNET_NAME=sruVnet
-+ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
-+ AZURE_NIC_NAME=sruNic
-+ AZURE_RESOURCE_GROUP=srugroupIPV6
-+ AZURE_BOOT_DIAG=storeitsru
-+ AZURE_ADVANCED_NIC_TESTS=true
-+ GCE_ZONE=UNSET
-+ OPENSTACK_ADMIN_NET_ID=UNSET
-+ OPENSTACK_SSH_KEY_NAME=UNSET
-+ VMWARE_PASSWORD=UNSET
+++ PRESERVE_INSTANCE=false
+++ UBUNTU_RELEASE=
+++ LP_USER=UNSET
+++ PROPOSED_SCRIPT=setup_proposed.sh
+++ USE_DEV_PPA=0
+++ ENI_NETCFG_FILE=/etc/network/interfaces.d/50-cloud-init.cfg
+++ NETPLAN_NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
+++ SAMPLE_CLOUDCONFIG=sethostname.yaml
+++ SSH_KEY=/root/.ssh/id_rsa.pub
+++ SSHOPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+++ AZURE_REGION=UNSET
+++ AZURE_VNET_NAME=UNSET
+++ AZURE_NETWORK_SECURITY_GROUP=UNSET
+++ AZURE_NIC_NAME=UNSET
+++ AZURE_RESOURCE_GROUP=UNSET
+++ AZURE_BOOT_DIAG=UNSET
+++ AZURE_ADVANCED_NIC_TESTS=true
+++ GCE_ZONE=UNSET
+++ OPENSTACK_ADMIN_NET_ID=UNSET
+++ OPENSTACK_SSH_KEY_NAME=UNSET
+++ SRU_VARS_RC=.sru-vars.rc
+++ '[' -f .sru-vars.rc ']'
+++ '[' -f /root/.sru-vars.rc ']'
+++ . /root/.sru-vars.rc
++++ PRESERVE_INSTANCE=false
++++ UBUNTU_RELEASE=
++++ LP_USER=chad.smith
++++ USE_DEV_PPA=0
++++ SSH_KEY=/root/.ssh/id_rsa.pub
++++ AZURE_REGION=eastus2
++++ AZURE_VNET_NAME=sruVnet
++++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++++ AZURE_NIC_NAME=sruNic
++++ AZURE_RESOURCE_GROUP=srugroupIPV6
++++ AZURE_BOOT_DIAG=storeitsru
++++ AZURE_ADVANCED_NIC_TESTS=true
++++ GCE_ZONE=UNSET
++++ OPENSTACK_ADMIN_NET_ID=UNSET
++++ OPENSTACK_SSH_KEY_NAME=UNSET
 + parse_args ./sru-scripts/manual/azure-sru focal
 + script=./sru-scripts/manual/azure-sru
 + shift
-+ [ 1 = 0 ]
-+ [ 1 -ne 0 ]
++ '[' 1 = 0 ']'
++ '[' 1 -ne 0 ']'
++ case "$1" in
 + UBUNTU_RELEASE=focal
++ NETCFG_FILE=/etc/netplan/50-cloud-init.yaml
 + shift
-+ [ 0 -ne 0 ]
-+ [ -z focal ]
++ '[' 0 -ne 0 ']'
++ '[' -z focal ']'
 + assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
 + local value=
-+ eval value=$PROPOSED_SCRIPT > /dev/null
-+ value=setup_proposed.sh
-+ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
-+ eval value=$AZURE_REGION > /dev/null
-+ value=eastus2
-+ [ -z eastus2 -o eastus2 = UNSET ]
-+ eval value=$AZURE_VNET_NAME > /dev/null
-+ value=sruVnet
-+ [ -z sruVnet -o sruVnet = UNSET ]
-+ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
-+ value=sruNetSecGroup
-+ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
-+ eval value=$AZURE_NIC_NAME > /dev/null
-+ value=sruNic
-+ [ -z sruNic -o sruNic = UNSET ]
-+ eval value=$AZURE_RESOURCE_GROUP > /dev/null
-+ value=srugroupIPV6
-+ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
-+ eval value=$AZURE_BOOT_DIAG > /dev/null
-+ value=storeitsru
-+ [ -z storeitsru -o storeitsru = UNSET ]
-+ eval value=$SSH_KEY > /dev/null
-+ value=/root/.ssh/id_rsa.pub
-+ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
-+ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
-+ value=sethostname.yaml
-+ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
-+ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
-+ value=true
-+ [ -z true -o true = UNSET ]
-+ create_samplecloudconfig
-+ filename=sethostname.yaml
++ for var in $@
++ eval 'value=$PROPOSED_SCRIPT > /dev/null'
+++ value=setup_proposed.sh
++ '[' -z setup_proposed.sh -o setup_proposed.sh = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_REGION > /dev/null'
+++ value=eastus2
++ '[' -z eastus2 -o eastus2 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_VNET_NAME > /dev/null'
+++ value=sruVnet
++ '[' -z sruVnet -o sruVnet = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null'
+++ value=sruNetSecGroup
++ '[' -z sruNetSecGroup -o sruNetSecGroup = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_NIC_NAME > /dev/null'
+++ value=sruNic
++ '[' -z sruNic -o sruNic = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_RESOURCE_GROUP > /dev/null'
+++ value=srugroupIPV6
++ '[' -z srugroupIPV6 -o srugroupIPV6 = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_BOOT_DIAG > /dev/null'
+++ value=storeitsru
++ '[' -z storeitsru -o storeitsru = UNSET ']'
++ for var in $@
++ eval 'value=$SSH_KEY > /dev/null'
+++ value=/root/.ssh/id_rsa.pub
++ '[' -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ']'
++ for var in $@
++ eval 'value=$SAMPLE_CLOUDCONFIG > /dev/null'
+++ value=sethostname.yaml
++ '[' -z sethostname.yaml -o sethostname.yaml = UNSET ']'
++ for var in $@
++ eval 'value=$AZURE_ADVANCED_NIC_TESTS > /dev/null'
+++ value=true
++ '[' -z true -o true = UNSET ']'
++ create_samplecloudconfig SAMPLE_CLOUDCONFIG
++ filename=SAMPLE_CLOUDCONFIG
 + cat
 + create_setup_proposed_script
-+ [ 0 -eq 0 ]
++ '[' 0 -eq 0 ']'
 + cat
 + AZURE_VNET_NAME=sruVnet-focal
-+ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
-+ jq -r .properties.state
+++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
+++ jq -r .properties.state
 + IPV6_NET_REGISTERED=Registered
-+ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
-+ jq -r .properties.state
+++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
+++ jq -r .properties.state
 + IPV6_CA_LB_REGISTERED=Registered
-+ [ Registered != Registered -o Registered != Registered ]
-+ az provider show -n Microsoft.Network
-+ jq -r .registrationState
++ '[' Registered '!=' Registered -o Registered '!=' Registered ']'
+++ az provider show -n Microsoft.Network
+++ jq -r .registrationState
 + IPV6_REGISTRATION_COMPLETE=Registered
-+ echo Waiting for Microsoft.Network IPv6 feature registration
++ echo 'Waiting for Microsoft.Network IPv6 feature registration'
 Waiting for Microsoft.Network IPv6 feature registration
-+ [ Registered != Registered ]
-+ echo ### BEGIN focal
++ '[' Registered '!=' Registered ']'
++ echo '### BEGIN focal'
 ### BEGIN focal
 + az group show -g srugroupIPV6
-+ [ -n storeitsru ]
++ '[' -n storeitsru ']'
 + az storage account show --name storeitsru
-+ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ AZURE_BOOT_DIAG_ARG='--boot-diagnostics-storage storeitsru'
 + az network nsg show --name sruNetSecGroup -g srugroupIPV6
 + az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
 + az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
@@ -3442,13 +3443,13 @@ Waiting for Microsoft.Network IPv6 feature registration
     },
     "enableDdosProtection": false,
     "enableVmProtection": false,
-    "etag": "W/\"ac7ca4c7-c905-4d56-9081-751583dc13e5\"",
+    "etag": "W/\"0613ace8-39ef-4997-9d2a-09b9eacbefa8\"",
     "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-focal",
     "location": "eastus2",
     "name": "sruVnet-focal",
     "provisioningState": "Succeeded",
     "resourceGroup": "srugroupIPV6",
-    "resourceGuid": "f5a27459-e965-40c7-b86d-9c2575c21fd6",
+    "resourceGuid": "e367f5b9-9209-4b86-8133-3ec7f4f776f8",
     "subnets": [],
     "tags": {},
     "type": "Microsoft.Network/virtualNetworks",
@@ -3464,7 +3465,7 @@ Waiting for Microsoft.Network IPv6 feature registration
     "ace:cab:deca:deed::/64"
   ],
   "delegations": [],
-  "etag": "W/\"a2439f1e-f303-4b45-aae8-19d9ae0ce1c0\"",
+  "etag": "W/\"f6e86236-28f5-49e1-bc9a-57db2de51daa\"",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-focal/subnets/sruSubnet",
   "ipConfigurationProfiles": null,
   "ipConfigurations": null,
@@ -3498,11 +3499,13 @@ Waiting for Microsoft.Network IPv6 feature registration
   "serviceEndpoints": null,
   "type": "Microsoft.Network/virtualNetworks/subnets"
 }
-+ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ sshopts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR'
 + netcfg=/etc/netplan/50-cloud-init.yaml
++ case $UBUNTU_RELEASE in
 + image_version=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
-+ [  =  ]
-+ echo Creating standard network vm
++ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELEASE --size Standard_DS2_v2"
++ '[' '' = '' ']'
++ echo 'Creating standard network vm'
 Creating standard network vm
 + name=test-sru-focal
 + az vm show --name test-sru-focal -g srugroupIPV6
@@ -3511,306 +3514,654 @@ Creating standard network vm
   "fqdns": "",
   "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-focal",
   "location": "eastus2",
-  "macAddress": "00-0D-3A-00-2A-A9",
+  "macAddress": "00-0D-3A-E6-6F-27",
   "powerState": "VM running",
   "privateIpAddress": "10.0.0.6",
-  "publicIpAddress": "52.252.115.168",
+  "publicIpAddress": "104.209.150.152",
   "resourceGroup": "srugroupIPV6",
   "zones": ""
 }
-+ az vm list-ip-addresses --name test-sru-focal
-+ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
-+ awk {printf "ubuntu@%s", $1}
-+ IP=ubuntu@52.252.115.168
-+ echo Created test-sru-focal: ubuntu@ubuntu@52.252.115.168
-Created test-sru-focal: ubuntu@ubuntu@52.252.115.168
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init status --wait --long
-..........................................................................................
+++ az vm list-ip-addresses --name test-sru-focal
+++ jq -r '.[] | .virtualMachine.network.publicIpAddresses[].ipAddress'
+++ awk '{printf "ubuntu@%s", $1}'
++ IP=ubuntu@104.209.150.152
++ echo 'Created test-sru-focal: ubuntu@ubuntu@104.209.150.152'
+Created test-sru-focal: ubuntu@ubuntu@104.209.150.152
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cloud-init status --wait --long
+...................................................................................
 status: done
-time: Thu, 18 Jun 2020 18:48:44 +0000
+time: Wed, 24 Jun 2020 20:09:45 +0000
 detail:
 DataSourceAzure [seed=/dev/sr0]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- dpkg-query --show cloud-init
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- dpkg-query --show cloud-init
 cloud-init	20.1-10-g71af48df-0ubuntu5
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo cat /run/cloud-init/result.json
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo cat /run/cloud-init/result.json
 {
  "v1": {
   "datasource": "DataSourceAzure [seed=/dev/sr0]",
   "errors": []
  }
 }
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- systemd-analyze
-Startup finished in 4.490s (kernel) + 59.785s (userspace) = 1min 4.275s 
-graphical.target reached after 58.788s in userspace
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- systemd-analyze blame
-24.803s snapd.seeded.service                
-10.534s cloud-init.service                  
- 7.675s cloud-init-local.service            
- 3.785s lvm2-monitor.service                
- 3.263s dev-sda1.device                     
- 2.788s systemd-udev-settle.service         
- 2.732s cloud-config.service                
- 2.197s accounts-daemon.service             
- 1.836s pollinate.service                   
- 1.268s systemd-logind.service              
- 1.160s networkd-dispatcher.service         
- 1.128s grub-common.service                 
- 1.105s apparmor.service                    
- 1.063s systemd-networkd-wait-online.service
- 1.001s apport.service                      
-  938ms systemd-journald.service            
-  936ms snapd.service                       
-  872ms cloud-final.service                 
-  801ms chrony.service                      
-  772ms sys-kernel-tracing.mount            
-  766ms sys-kernel-debug.mount              
-  753ms dev-mqueue.mount                    
-  748ms dev-hugepages.mount                 
-  681ms atd.service                         
-  645ms systemd-resolved.service            
-  642ms kmod-static-nodes.service           
-  639ms keyboard-setup.service              
-  622ms grub-initrd-fallback.service        
-  615ms systemd-udev-trigger.service        
-  568ms systemd-udevd.service               
-  539ms modprobe@drm.service                
-  517ms snap.lxd.activate.service           
-  513ms e2scrub_reap.service                
-  484ms systemd-modules-load.service        
-  484ms user@1000.service                   
-  464ms systemd-remount-fs.service          
-  456ms rsyslog.service                     
-  455ms systemd-networkd.service            
-  390ms ufw.service                         
-  257ms console-setup.service               
-  253ms plymouth-read-write.service         
-  249ms finalrd.service                     
-  243ms systemd-sysusers.service            
-  240ms multipathd.service                  
-  238ms systemd-machine-id-commit.service   
-  222ms polkit.service                      
-  212ms systemd-user-sessions.service       
-  201ms sys-kernel-config.mount             
-  191ms systemd-journal-flush.service       
-  189ms systemd-random-seed.service         
-  159ms systemd-sysctl.service              
-  158ms ssh.service                         
-  130ms systemd-tmpfiles-setup.service      
-  121ms sys-fs-fuse-connections.mount       
-   99ms snapd.socket                        
-   96ms plymouth-quit-wait.service          
-   92ms plymouth-quit.service               
-   58ms snapd.apparmor.service              
-   58ms dev-loop2.device                    
-   58ms systemd-tmpfiles-setup-dev.service  
-   50ms dev-loop0.device                    
-   47ms systemd-update-utmp-runlevel.service
-   43ms snap-snapd-7777.mount               
-   42ms ephemeral-disk-warning.service      
-   37ms blk-availability.service            
-   32ms snap-lxd-15457.mount                
-   31ms systemd-update-utmp.service         
-   31ms snap-core18-1754.mount              
-   30ms user-runtime-dir@1000.service       
-   29ms boot-efi.mount                      
-   25ms setvtrgb.service                    
-   22ms dev-loop1.device                    
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze show
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- systemd-analyze
+Startup finished in 3.603s (kernel) + 57.332s (userspace) = 1min 936ms 
+graphical.target reached after 56.492s in userspace
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- systemd-analyze blame
+24.823s snapd.seeded.service                
+12.214s cloud-init.service                  
+ 5.284s cloud-init-local.service            
+ 3.376s lvm2-monitor.service                
+ 3.019s dev-sdb1.device                     
+ 2.602s cloud-config.service                
+ 2.494s systemd-udev-settle.service         
+ 1.951s pollinate.service                   
+ 1.945s accounts-daemon.service             
+ 1.180s systemd-logind.service              
+ 1.156s systemd-networkd-wait-online.service
+ 1.000s apparmor.service                    
+  980ms apport.service                      
+  897ms networkd-dispatcher.service         
+  890ms snapd.service                       
+  882ms systemd-journald.service            
+  807ms cloud-final.service                 
+  768ms rsyslog.service                     
+  756ms grub-initrd-fallback.service        
+  748ms grub-common.service                 
+  636ms systemd-resolved.service            
+  611ms chrony.service                      
+  541ms systemd-udev-trigger.service        
+  509ms atd.service                         
+  474ms systemd-networkd.service            
+  454ms sys-kernel-tracing.mount            
+  446ms sys-kernel-debug.mount              
+  442ms kmod-static-nodes.service           
+  440ms keyboard-setup.service              
+  438ms systemd-udevd.service               
+  436ms snap.lxd.activate.service           
+  431ms dev-mqueue.mount                    
+  409ms modprobe@drm.service                
+  388ms dev-hugepages.mount                 
+  369ms user@1000.service                   
+  350ms systemd-modules-load.service        
+  333ms systemd-remount-fs.service          
+  320ms e2scrub_reap.service                
+  291ms ufw.service                         
+  259ms systemd-sysusers.service            
+  215ms multipathd.service                  
+  209ms sys-fs-fuse-connections.mount       
+  191ms plymouth-quit.service               
+  191ms sys-kernel-config.mount             
+  187ms plymouth-quit-wait.service          
+  166ms systemd-user-sessions.service       
+  135ms ssh.service                         
+  133ms systemd-machine-id-commit.service   
+  131ms systemd-tmpfiles-setup.service      
+  130ms plymouth-read-write.service         
+  117ms finalrd.service                     
+  111ms systemd-journal-flush.service       
+  108ms console-setup.service               
+  107ms systemd-random-seed.service         
+  101ms systemd-sysctl.service              
+   78ms snapd.apparmor.service              
+   70ms snapd.socket                        
+   67ms polkit.service                      
+   56ms user-runtime-dir@1000.service       
+   47ms dev-loop2.device                    
+   41ms setvtrgb.service                    
+   41ms snap-snapd-8140.mount               
+   41ms systemd-tmpfiles-setup-dev.service  
+   41ms systemd-update-utmp.service         
+   37ms systemd-update-utmp-runlevel.service
+   35ms ephemeral-disk-warning.service      
+   33ms snap-lxd-15675.mount                
+   29ms snap-core18-1754.mount              
+   26ms blk-availability.service            
+   25ms boot-efi.mount                      
+   20ms dev-loop0.device                    
+   19ms dev-loop1.device                    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cloud-init analyze show
 -- Boot Record 01 --
 The total time elapsed since completing an event is printed after the "@" character.
 The time the event takes is printed after the "+" character.
 
 Starting stage: init-local
-|`->no cache found @00.00400s +00.00000s
+|`->no cache found @00.00300s +00.00100s
 Starting stage: init-local/search-Azure
 Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.29100s +00.01200s
-|`->get_boot_telemetry @00.30300s +00.12600s
-|`->get_system_info @00.42900s +00.00100s
+|`->found azure asset tag @00.22300s +00.00900s
+|`->get_boot_telemetry @00.23200s +00.08500s
+|`->get_system_info @00.31700s +00.00000s
 Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.43000s +00.08700s
-|`->load_azure_ds_dir @00.51800s +00.00000s
+|`->list_possible_azure_ds_devs @00.31700s +00.08000s
+|`->load_azure_ds_dir @00.39700s +00.00000s
 Starting stage: azure-ds/load_azure_ds_dir
 Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.68700s +00.00000s
-|`->_extract_preprovisioned_vm_setting @00.68800s +00.00000s
-Finished stage: (azure-ds/read_azure_ovf) 00.01300 seconds
+|`->load_azure_ovf_pubkeys @00.51200s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.51200s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
 
-Finished stage: (azure-ds/load_azure_ds_dir) 00.01800 seconds
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00900 seconds
 
 Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.72100s +00.47100s
-|`->_get_metadata_from_imds @01.19200s +00.01600s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.51600 seconds
+|`->obtain dhcp lease @00.54900s +00.39000s
+|`->_get_metadata_from_imds @00.93900s +00.01800s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.43000 seconds
 
-|`->_get_random_seed @01.23800s +00.00000s
-Finished stage: (azure-ds/crawl_metadata) 00.82200 seconds
+|`->_get_random_seed @00.97800s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.67000 seconds
 
-|`->maybe_remove_ubuntu_network_config_scripts @01.25200s +00.00100s
-|`->write_files @01.25400s +00.00800s
-Finished stage: (azure-ds/_get_data) 00.97100 seconds
+|`->maybe_remove_ubuntu_network_config_scripts @00.98800s +00.00000s
+|`->write_files @00.98900s +00.00800s
+Finished stage: (azure-ds/_get_data) 00.77400 seconds
 
-Finished stage: (init-local/search-Azure) 00.97500 seconds
+Finished stage: (init-local/search-Azure) 00.77800 seconds
 
-|`->network config from imds @01.32600s +00.00000s
-Finished stage: (init-local) 01.87400 seconds
+|`->network config from imds @01.06500s +00.00000s
+Finished stage: (init-local) 01.36100 seconds
 
 Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.91900s +00.03600s
-|`->network config from imds @04.01000s +00.00000s
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.47300s +00.02800s
+|`->network config from imds @03.54100s +00.00100s
 Starting stage: init-network/setup-datasource
 Starting stage: azure-ds/setup
 Starting stage: azure-ds/_negotiate
 Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @04.01900s +00.00100s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+|`->temporary_hostname @03.55100s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
 
 Starting stage: azure-ds/get_metadata_from_fabric
 Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @04.02400s +00.14600s
+|`->generate_certificate @03.55500s +00.11500s
 Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @04.17000s +00.00100s
+|`->_networkd_get_value_from_leases @03.67100s +00.00100s
 Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
 
 Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @04.20200s +00.01400s
+|`->_decrypt_certs_from_xml @03.70000s +00.01300s
 Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @04.21700s +00.00700s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.08200 seconds
+|`->_run_x509_action @03.71400s +00.00500s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04300 seconds
 
 Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @04.30000s +00.00600s
+|`->_run_x509_action @03.75700s +00.00600s
 Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00700 seconds
 
-Finished stage: (azure-ds/parse_certificates) 00.10400 seconds
+Finished stage: (azure-ds/parse_certificates) 00.06400 seconds
 
-|`->_report_ready @04.30700s +02.96700s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 03.25000 seconds
+|`->_report_ready @03.76400s +03.28200s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 03.49100 seconds
 
-Finished stage: (azure-ds/get_metadata_from_fabric) 03.25100 seconds
+Finished stage: (azure-ds/get_metadata_from_fabric) 03.49100 seconds
 
-Finished stage: (azure-ds/_negotiate) 03.25600 seconds
+Finished stage: (azure-ds/_negotiate) 03.49600 seconds
 
-Finished stage: (azure-ds/setup) 03.25600 seconds
+Finished stage: (azure-ds/setup) 03.49700 seconds
 
-Finished stage: (init-network/setup-datasource) 03.25700 seconds
+Finished stage: (init-network/setup-datasource) 03.49700 seconds
 
-|`->reading and applying user-data @07.28800s +00.00700s
-|`->reading and applying vendor-data @07.29500s +00.00000s
+|`->reading and applying user-data @07.06000s +00.00600s
+|`->reading and applying vendor-data @07.06600s +00.00100s
 Starting stage: init-network/activate-datasource
 Starting stage: azure-ds/activate
 Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @07.33000s +00.00000s
+|`->wait for ephemeral disk @07.10100s +00.00000s
 Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @07.33000s +00.15800s
+|`->_has_ntfs_filesystem @07.10200s +00.14000s
 Starting stage: azure-ds/mount-ntfs-and-count
-|`->count_files @07.60400s +00.00000s
-Finished stage: (azure-ds/mount-ntfs-and-count) 00.13300 seconds
+|`->count_files @07.32000s +00.00200s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.08600 seconds
 
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.29200 seconds
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.22700 seconds
 
-Finished stage: (azure-ds/address_ephemeral_resize) 00.29200 seconds
+Finished stage: (azure-ds/address_ephemeral_resize) 00.22800 seconds
 
-Finished stage: (azure-ds/activate) 00.29200 seconds
+Finished stage: (azure-ds/activate) 00.22800 seconds
 
-Finished stage: (init-network/activate-datasource) 00.29400 seconds
+Finished stage: (init-network/activate-datasource) 00.22900 seconds
 
-|`->config-migrator ran successfully @07.73000s +00.00000s
-|`->config-seed_random ran successfully @07.73100s +00.00100s
-|`->config-bootcmd ran successfully @07.73200s +00.00100s
-|`->config-write-files ran successfully @07.73300s +00.00100s
-|`->config-growpart ran successfully @07.73400s +00.78700s
-|`->config-resizefs ran successfully @08.52200s +01.39100s
-|`->config-disk_setup ran successfully @09.91300s +02.59400s
-|`->config-mounts ran successfully @12.51000s +00.33200s
-|`->config-set_hostname ran successfully @12.84200s +00.00900s
-|`->config-update_hostname ran successfully @12.85100s +00.00200s
-|`->config-update_etc_hosts ran successfully @12.85300s +00.00100s
-|`->config-ca-certs ran successfully @12.85400s +00.00100s
-|`->config-rsyslog ran successfully @12.85500s +00.00100s
-|`->config-users-groups ran successfully @12.85600s +00.24900s
-|`->config-ssh ran successfully @13.10600s +00.78900s
-Finished stage: (init-network) 09.99300 seconds
+|`->config-migrator ran successfully @07.41100s +00.00100s
+|`->config-seed_random ran successfully @07.41200s +00.00100s
+|`->config-bootcmd ran successfully @07.41400s +00.00000s
+|`->config-write-files ran successfully @07.41400s +00.00100s
+|`->config-growpart ran successfully @07.41500s +00.72200s
+|`->config-resizefs ran successfully @08.13800s +03.48500s
+|`->config-disk_setup ran successfully @11.62400s +02.54000s
+|`->config-mounts ran successfully @14.16400s +00.31100s
+|`->config-set_hostname ran successfully @14.47500s +00.00800s
+|`->config-update_hostname ran successfully @14.48400s +00.00100s
+|`->config-update_etc_hosts ran successfully @14.48500s +00.00000s
+|`->config-ca-certs ran successfully @14.48600s +00.00000s
+|`->config-rsyslog ran successfully @14.48700s +00.00000s
+|`->config-users-groups ran successfully @14.48800s +00.40000s
+|`->config-ssh ran successfully @14.88800s +00.31000s
+Finished stage: (init-network) 11.73700 seconds
 
 Starting stage: modules-config
-|`->config-emit_upstart ran successfully @42.29700s +00.00100s
-|`->config-snap ran successfully @42.29900s +00.00100s
-|`->config-ssh-import-id ran successfully @42.30100s +01.05100s
-|`->config-locale ran successfully @43.35300s +00.00100s
-|`->config-set-passwords ran successfully @43.35400s +00.00200s
-|`->config-grub-dpkg ran successfully @43.35600s +00.86000s
-|`->config-apt-pipelining ran successfully @44.21700s +00.00100s
-|`->config-apt-configure ran successfully @44.21800s +00.17900s
-|`->config-ubuntu-advantage ran successfully @44.39800s +00.00100s
-|`->config-ntp ran successfully @44.39900s +00.00200s
-|`->config-timezone ran successfully @44.40100s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @44.40200s +00.00000s
-|`->config-runcmd ran successfully @44.40300s +00.00000s
-|`->config-byobu ran successfully @44.40400s +00.00000s
-Finished stage: (modules-config) 02.17600 seconds
+|`->config-emit_upstart ran successfully @43.43500s +00.00100s
+|`->config-snap ran successfully @43.43600s +00.00100s
+|`->config-ssh-import-id ran successfully @43.43700s +00.90700s
+|`->config-locale ran successfully @44.34400s +00.00200s
+|`->config-set-passwords ran successfully @44.34600s +00.00100s
+|`->config-grub-dpkg ran successfully @44.34800s +00.99900s
+|`->config-apt-pipelining ran successfully @45.34800s +00.00100s
+|`->config-apt-configure ran successfully @45.35000s +00.12300s
+|`->config-ubuntu-advantage ran successfully @45.47400s +00.00100s
+|`->config-ntp ran successfully @45.47500s +00.00100s
+|`->config-timezone ran successfully @45.47600s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @45.47700s +00.00000s
+|`->config-runcmd ran successfully @45.47800s +00.00000s
+|`->config-byobu ran successfully @45.47900s +00.00000s
+Finished stage: (modules-config) 02.12400 seconds
 
 Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @45.13100s +00.00100s
-|`->config-fan ran successfully @45.13300s +00.00100s
-|`->config-landscape ran successfully @45.13400s +00.00100s
-|`->config-lxd ran successfully @45.13500s +00.00100s
-|`->config-ubuntu-drivers ran successfully @45.13600s +00.00100s
-|`->config-puppet ran successfully @45.13700s +00.00100s
-|`->config-chef ran successfully @45.13800s +00.00100s
-|`->config-mcollective ran successfully @45.13900s +00.00100s
-|`->config-salt-minion ran successfully @45.14000s +00.00100s
-|`->config-rightscale_userdata ran successfully @45.14100s +00.00100s
-|`->config-scripts-vendor ran successfully @45.14200s +00.00100s
-|`->config-scripts-per-once ran successfully @45.14300s +00.00100s
-|`->config-scripts-per-boot ran successfully @45.14400s +00.00000s
-|`->config-scripts-per-instance ran successfully @45.14500s +00.00000s
-|`->config-scripts-user ran successfully @45.14600s +00.00000s
-|`->config-ssh-authkey-fingerprints ran successfully @45.14700s +00.00900s
-|`->config-keys-to-console ran successfully @45.15700s +00.15000s
-|`->config-phone-home ran successfully @45.36000s +00.00100s
-|`->config-final-message ran successfully @45.36200s +00.00400s
-|`->config-power-state-change ran successfully @45.36600s +00.00100s
-Finished stage: (modules-final) 00.27600 seconds
+|`->config-package-update-upgrade-install ran successfully @46.15400s +00.00100s
+|`->config-fan ran successfully @46.15500s +00.00100s
+|`->config-landscape ran successfully @46.15700s +00.00000s
+|`->config-lxd ran successfully @46.15700s +00.00100s
+|`->config-ubuntu-drivers ran successfully @46.15800s +00.00100s
+|`->config-puppet ran successfully @46.15900s +00.00100s
+|`->config-chef ran successfully @46.16000s +00.00100s
+|`->config-mcollective ran successfully @46.16200s +00.00000s
+|`->config-salt-minion ran successfully @46.16300s +00.00000s
+|`->config-rightscale_userdata ran successfully @46.16300s +00.00100s
+|`->config-scripts-vendor ran successfully @46.16400s +00.00100s
+|`->config-scripts-per-once ran successfully @46.16500s +00.00100s
+|`->config-scripts-per-boot ran successfully @46.16600s +00.00100s
+|`->config-scripts-per-instance ran successfully @46.16700s +00.00100s
+|`->config-scripts-user ran successfully @46.16800s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @46.16900s +00.07100s
+|`->config-keys-to-console ran successfully @46.24100s +00.03500s
+|`->config-phone-home ran successfully @46.27700s +00.00100s
+|`->config-final-message ran successfully @46.35900s +00.00400s
+|`->config-power-state-change ran successfully @46.36300s +00.00100s
+Finished stage: (modules-final) 00.28500 seconds
 
-Total Time: 35.40500 seconds
+Total Time: 36.76100 seconds
 
 1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze blame
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cloud-init analyze blame
 -- Boot Record 01 --
-     02.96700s (azure-ds/_report_ready)
-     02.59400s (init-network/config-disk_setup)
-     01.39100s (init-network/config-resizefs)
-     01.05100s (modules-config/config-ssh-import-id)
-     00.86000s (modules-config/config-grub-dpkg)
-     00.78900s (init-network/config-ssh)
-     00.78700s (init-network/config-growpart)
-     00.47100s (azure-ds/obtain-dhcp-lease)
-     00.33200s (init-network/config-mounts)
-     00.24900s (init-network/config-users-groups)
-     00.17900s (modules-config/config-apt-configure)
-     00.15800s (azure-ds/_has_ntfs_filesystem)
-     00.15000s (modules-final/config-keys-to-console)
-     00.14600s (azure-ds/generate_certificate)
-     00.12600s (azure-ds/get_boot_telemetry)
-     00.08700s (azure-ds/list_possible_azure_ds_devs)
-     00.03600s (init-network/check-cache)
-     00.01600s (azure-ds/_get_metadata_from_imds)
-     00.01400s (azure-ds/_decrypt_certs_from_xml)
-     00.01200s (azure-ds/check-platform-viability)
-     00.00900s (modules-final/config-ssh-authkey-fingerprints)
-     00.00900s (init-network/config-set_hostname)
+     03.48500s (init-network/config-resizefs)
+     03.28200s (azure-ds/_report_ready)
+     02.54000s (init-network/config-disk_setup)
+     00.99900s (modules-config/config-grub-dpkg)
+     00.90700s (modules-config/config-ssh-import-id)
+     00.72200s (init-network/config-growpart)
+     00.40000s (init-network/config-users-groups)
+     00.39000s (azure-ds/obtain-dhcp-lease)
+     00.31100s (init-network/config-mounts)
+     00.31000s (init-network/config-ssh)
+     00.14000s (azure-ds/_has_ntfs_filesystem)
+     00.12300s (modules-config/config-apt-configure)
+     00.11500s (azure-ds/generate_certificate)
+     00.08500s (azure-ds/get_boot_telemetry)
+     00.08000s (azure-ds/list_possible_azure_ds_devs)
+     00.07100s (modules-final/config-ssh-authkey-fingerprints)
+     00.03500s (modules-final/config-keys-to-console)
+     00.02800s (init-network/check-cache)
+     00.01800s (azure-ds/_get_metadata_from_imds)
+     00.01300s (azure-ds/_decrypt_certs_from_xml)
+     00.00900s (azure-ds/check-platform-viability)
+     00.00800s (init-network/config-set_hostname)
      00.00800s (azure-ds/write_files)
-     00.00700s (init-network/consume-user-data)
-     00.00700s (azure-ds/_run_x509_action)
+     00.00600s (init-network/consume-user-data)
      00.00600s (azure-ds/_run_x509_action)
+     00.00500s (azure-ds/_run_x509_action)
      00.00400s (modules-final/config-final-message)
-     00.00200s (modules-config/config-set-passwords)
-     00.00200s (modules-config/config-ntp)
-     00.00200s (init-network/config-update_hostname)
+     00.00200s (modules-config/config-locale)
+     00.00200s (azure-ds/count_files)
      00.00100s (modules-final/config-ubuntu-drivers)
      00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
      00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/consume-vendor-data)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo 'Writing networking config: previous-network.out'
+Writing networking config: previous-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@104.209.150.152:.
+PROPOSED_SCRIPT                               100%  196     3.3KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo bash PROPOSED_SCRIPT
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~20.04.1 [416 kB]
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~20.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) over (20.1-10-g71af48df-0ubuntu5) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- dpkg-query --show cloud-init
+cloud-init	20.2-45-g5f7825e2-0ubuntu1~20.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo cloud-init clean --logs --reboot
+Connection to 104.209.150.152 closed by remote host.
++ true
++ sleep 60
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cloud-init status --wait --long
+
+status: done
+time: Wed, 24 Jun 2020 20:11:07 +0000
+detail:
+DataSourceAzure [seed=/var/lib/waagent]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- '!' grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- sudo systemd-analyze blame
+3.333s snapd.service                                              
+3.230s cloud-init.service                                         
+2.994s cloud-config.service                                       
+2.691s snap.lxd.activate.service                                  
+2.388s lvm2-monitor.service                                       
+2.355s accounts-daemon.service                                    
+2.046s dev-sda1.device                                            
+1.882s systemd-logind.service                                     
+1.854s cloud-init-local.service                                   
+1.631s systemd-networkd-wait-online.service                       
+1.628s networkd-dispatcher.service                                
+1.614s apport.service                                             
+1.561s systemd-udev-settle.service                                
+1.469s grub-common.service                                        
+ 860ms chrony.service                                             
+ 833ms systemd-journald.service                                   
+ 754ms cloud-final.service                                        
+ 733ms grub-initrd-fallback.service                               
+ 712ms atd.service                                                
+ 702ms rsyslog.service                                            
+ 616ms e2scrub_reap.service                                       
+ 549ms systemd-udev-trigger.service                               
+ 452ms sys-kernel-tracing.mount                                   
+ 444ms systemd-resolved.service                                   
+ 444ms sys-kernel-debug.mount                                     
+ 440ms keyboard-setup.service                                     
+ 436ms kmod-static-nodes.service                                  
+ 424ms dev-mqueue.mount                                           
+ 423ms ssh.service                                                
+ 414ms dev-hugepages.mount                                        
+ 365ms modprobe@drm.service                                       
+ 356ms systemd-networkd.service                                   
+ 327ms systemd-modules-load.service                               
+ 322ms systemd-remount-fs.service                                 
+ 278ms ufw.service                                                
+ 231ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+ 215ms plymouth-quit.service                                      
+ 206ms snapd.apparmor.service                                     
+ 206ms sys-fs-fuse-connections.mount                              
+ 204ms plymouth-quit-wait.service                                 
+ 186ms systemd-user-sessions.service                              
+ 174ms apparmor.service                                           
+ 169ms console-setup.service                                      
+ 168ms sys-kernel-config.mount                                    
+ 163ms snapd.seeded.service                                       
+ 150ms plymouth-read-write.service                                
+ 135ms systemd-tmpfiles-setup.service                             
+ 134ms user@1000.service                                          
+ 133ms polkit.service                                             
+ 102ms multipathd.service                                         
+  97ms boot-efi.mount                                             
+  93ms systemd-random-seed.service                                
+  93ms snap-core18-1754.mount                                     
+  89ms snap-lxd-15675.mount                                       
+  83ms snap-snapd-8140.mount                                      
+  81ms finalrd.service                                            
+  75ms systemd-journal-flush.service                              
+  71ms systemd-update-utmp.service                                
+  71ms systemd-sysctl.service                                     
+  70ms systemd-udevd.service                                      
+  70ms setvtrgb.service                                           
+  70ms snapd.socket                                               
+  55ms ephemeral-disk-warning.service                             
+  54ms dev-loop1.device                                           
+  54ms dev-loop0.device                                           
+  52ms systemd-sysusers.service                                   
+  49ms dev-loop2.device                                           
+  40ms blk-availability.service                                   
+  24ms systemd-tmpfiles-setup-dev.service                         
+  23ms systemd-update-utmp-runlevel.service                       
+  17ms user-runtime-dir@1000.service                              
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00300s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.03900s +00.01000s
+|`->get_boot_telemetry @00.04900s +00.02600s
+|`->get_system_info @00.07500s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.07600s +00.19600s
+|`->load_azure_ds_dir @00.27200s +00.00100s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.27800s +00.00100s
+|`->_extract_preprovisioned_vm_setting @00.27900s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00600 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.30100s +00.46200s
+|`->_get_metadata_from_imds @00.76400s +00.00800s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.49400 seconds
+
+|`->_get_random_seed @00.79600s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.73000 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.80600s +00.00000s
+|`->write_files @00.80600s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.76900 seconds
+
+Finished stage: (init-local/search-Azure) 00.77200 seconds
+
+|`->network config from imds @00.85600s +00.00000s
+Finished stage: (init-local) 00.96900 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.47400s +00.01700s
+|`->network config from imds @03.53200s +00.00000s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.54100s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.54400s +00.10700s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @03.65200s +00.00000s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @03.66900s +00.01200s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @03.68200s +00.00500s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01300 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @03.69500s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.03200 seconds
+
+|`->_report_ready @03.70100s +00.00500s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.16200 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.16300 seconds
+
+Finished stage: (azure-ds/_negotiate) 00.16600 seconds
+
+Finished stage: (azure-ds/setup) 00.16700 seconds
+
+Finished stage: (init-network/setup-datasource) 00.16800 seconds
+
+|`->reading and applying user-data @03.71300s +00.00700s
+|`->reading and applying vendor-data @03.72000s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @03.74600s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @03.74600s +00.15500s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.15600 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.15600 seconds
+
+Finished stage: (azure-ds/activate) 00.15600 seconds
+
+Finished stage: (init-network/activate-datasource) 00.15700 seconds
+
+|`->config-migrator ran successfully @03.99300s +00.00100s
+|`->config-seed_random ran successfully @03.99400s +00.00100s
+|`->config-bootcmd ran successfully @03.99600s +00.00000s
+|`->config-write-files ran successfully @03.99600s +00.00100s
+|`->config-growpart ran successfully @03.99700s +00.07300s
+|`->config-resizefs ran successfully @04.07000s +00.40800s
+|`->config-disk_setup ran successfully @04.47800s +00.65700s
+|`->config-mounts ran successfully @05.13600s +00.30500s
+|`->config-set_hostname ran successfully @05.44100s +00.00700s
+|`->config-update_hostname ran successfully @05.44900s +00.00100s
+|`->config-update_etc_hosts ran successfully @05.45000s +00.00000s
+|`->config-ca-certs ran successfully @05.45000s +00.00100s
+|`->config-rsyslog ran successfully @05.45100s +00.00100s
+|`->config-users-groups ran successfully @05.45300s +00.17300s
+|`->config-ssh ran successfully @05.62600s +00.53300s
+Finished stage: (init-network) 02.71000 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @11.70600s +00.00100s
+|`->config-snap ran successfully @11.70700s +00.00100s
+|`->config-ssh-import-id ran successfully @11.70800s +01.20900s
+|`->config-locale ran successfully @12.91800s +00.02700s
+|`->config-set-passwords ran successfully @12.94500s +00.00100s
+|`->config-grub-dpkg ran successfully @12.94700s +00.44000s
+|`->config-apt-pipelining ran successfully @13.38800s +00.00100s
+|`->config-apt-configure ran successfully @13.39000s +00.14300s
+|`->config-ubuntu-advantage ran successfully @13.53400s +00.00100s
+|`->config-ntp ran successfully @13.53500s +00.00100s
+|`->config-timezone ran successfully @13.53600s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @13.53700s +00.00000s
+|`->config-runcmd ran successfully @13.53800s +00.00000s
+|`->config-byobu ran successfully @13.53900s +00.00000s
+Finished stage: (modules-config) 01.85000 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @14.14100s +00.00100s
+|`->config-fan ran successfully @14.14200s +00.00100s
+|`->config-landscape ran successfully @14.14300s +00.00100s
+|`->config-lxd ran successfully @14.14400s +00.00100s
+|`->config-ubuntu-drivers ran successfully @14.14500s +00.00100s
+|`->config-puppet ran successfully @14.14600s +00.00100s
+|`->config-chef ran successfully @14.14700s +00.00100s
+|`->config-mcollective ran successfully @14.14800s +00.00100s
+|`->config-salt-minion ran successfully @14.14900s +00.00100s
+|`->config-rightscale_userdata ran successfully @14.15000s +00.00100s
+|`->config-scripts-vendor ran successfully @14.15100s +00.00100s
+|`->config-scripts-per-once ran successfully @14.15200s +00.00100s
+|`->config-scripts-per-boot ran successfully @14.15300s +00.00000s
+|`->config-scripts-per-instance ran successfully @14.15400s +00.00100s
+|`->config-scripts-user ran successfully @14.15500s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @14.15600s +00.01300s
+|`->config-keys-to-console ran successfully @14.20300s +00.13300s
+|`->config-phone-home ran successfully @14.33700s +00.00100s
+|`->config-final-message ran successfully @14.33800s +00.00400s
+|`->config-power-state-change ran successfully @14.34200s +00.00100s
+Finished stage: (modules-final) 00.21900 seconds
+
+Total Time: 10.02900 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cloud-init analyze blame
+-- Boot Record 01 --
+     01.20900s (modules-config/config-ssh-import-id)
+     00.65700s (init-network/config-disk_setup)
+     00.53300s (init-network/config-ssh)
+     00.46200s (azure-ds/obtain-dhcp-lease)
+     00.44000s (modules-config/config-grub-dpkg)
+     00.40800s (init-network/config-resizefs)
+     00.30500s (init-network/config-mounts)
+     00.19600s (azure-ds/list_possible_azure_ds_devs)
+     00.17300s (init-network/config-users-groups)
+     00.15500s (azure-ds/_has_ntfs_filesystem)
+     00.14300s (modules-config/config-apt-configure)
+     00.13300s (modules-final/config-keys-to-console)
+     00.10700s (azure-ds/generate_certificate)
+     00.07300s (init-network/config-growpart)
+     00.02700s (modules-config/config-locale)
+     00.02600s (azure-ds/get_boot_telemetry)
+     00.01700s (init-network/check-cache)
+     00.01300s (modules-final/config-ssh-authkey-fingerprints)
+     00.01200s (azure-ds/_decrypt_certs_from_xml)
+     00.01000s (azure-ds/check-platform-viability)
+     00.00800s (azure-ds/_get_metadata_from_imds)
+     00.00700s (init-network/consume-user-data)
+     00.00700s (init-network/config-set_hostname)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00500s (azure-ds/_report_ready)
+     00.00400s (modules-final/config-final-message)
+     00.00200s (azure-ds/write_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
      00.00100s (modules-final/config-salt-minion)
      00.00100s (modules-final/config-rightscale_userdata)
      00.00100s (modules-final/config-puppet)
@@ -3825,414 +4176,60 @@ Total Time: 35.40500 seconds
      00.00100s (modules-config/config-ubuntu-advantage)
      00.00100s (modules-config/config-timezone)
      00.00100s (modules-config/config-snap)
-     00.00100s (modules-config/config-locale)
-     00.00100s (modules-config/config-emit_upstart)
-     00.00100s (modules-config/config-apt-pipelining)
-     00.00100s (init-network/config-write-files)
-     00.00100s (init-network/config-update_etc_hosts)
-     00.00100s (init-network/config-seed_random)
-     00.00100s (init-network/config-rsyslog)
-     00.00100s (init-network/config-ca-certs)
-     00.00100s (init-network/config-bootcmd)
-     00.00100s (azure-ds/temporary_hostname)
-     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
-     00.00100s (azure-ds/get_system_info)
-     00.00100s (azure-ds/_networkd_get_value_from_leases)
-     00.00000s (modules-final/config-scripts-user)
-     00.00000s (modules-final/config-scripts-per-instance)
-     00.00000s (modules-final/config-scripts-per-boot)
-     00.00000s (modules-config/config-runcmd)
-     00.00000s (modules-config/config-disable-ec2-metadata)
-     00.00000s (modules-config/config-byobu)
-     00.00000s (init-network/consume-vendor-data)
-     00.00000s (init-network/config-migrator)
-     00.00000s (init-local/check-cache)
-     00.00000s (azure-ds/wait-for-ephemeral-disk)
-     00.00000s (azure-ds/parse_network_config)
-     00.00000s (azure-ds/parse_network_config)
-     00.00000s (azure-ds/load_azure_ovf_pubkeys)
-     00.00000s (azure-ds/load_azure_ds_dir)
-     00.00000s (azure-ds/count_files)
-     00.00000s (azure-ds/_get_random_seed)
-     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
-
-1 boot records analyzed
-+ echo Writing networking config: previous-network.out
-Writing networking config: previous-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cat /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- grep DHCP /var/log/syslog
-+ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@52.252.115.168:.
-PROPOSED_SCRIPT                               100%  196     3.3KB/s   00:00    
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo bash PROPOSED_SCRIPT
-+ egrep cloud-init
-  cloud-init
-Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~20.04.1 [416 kB]
-Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~20.04.1_all.deb ...
-Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) over (20.1-10-g71af48df-0ubuntu5) ...
-Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) ...
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- dpkg-query --show cloud-init
-cloud-init	20.2-45-g5f7825e2-0ubuntu1~20.04.1
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo hostname SRU-didnt-work
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo cloud-init clean --logs --reboot
-Connection to 52.252.115.168 closed by remote host.
-+ true
-+ sleep 60
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init status --wait --long
-
-status: done
-time: Thu, 18 Jun 2020 18:50:11 +0000
-detail:
-DataSourceAzure [seed=/var/lib/waagent]
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ! grep Trace /var/log/cloud-init.log
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo cat /run/cloud-init/result.json
-{
- "v1": {
-  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
-  "errors": []
- }
-}
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo systemd-analyze blame
-3.710s cloud-config.service                                       
-3.464s snapd.service                                              
-3.114s snap.lxd.activate.service                                  
-2.963s accounts-daemon.service                                    
-2.857s cloud-init.service                                         
-2.726s lvm2-monitor.service                                       
-2.358s dev-sdb1.device                                            
-2.031s cloud-init-local.service                                   
-1.900s networkd-dispatcher.service                                
-1.889s apport.service                                             
-1.810s systemd-logind.service                                     
-1.753s systemd-networkd-wait-online.service                       
-1.738s grub-common.service                                        
-1.713s systemd-udev-settle.service                                
-1.096s systemd-journald.service                                   
-1.030s chrony.service                                             
- 942ms grub-initrd-fallback.service                               
- 848ms cloud-final.service                                        
- 748ms systemd-udev-trigger.service                               
- 666ms atd.service                                                
- 657ms sys-kernel-debug.mount                                     
- 657ms sys-kernel-tracing.mount                                   
- 637ms keyboard-setup.service                                     
- 623ms kmod-static-nodes.service                                  
- 610ms dev-mqueue.mount                                           
- 567ms systemd-resolved.service                                   
- 563ms ssh.service                                                
- 563ms e2scrub_reap.service                                       
- 552ms dev-hugepages.mount                                        
- 542ms rsyslog.service                                            
- 535ms modprobe@drm.service                                       
- 478ms systemd-modules-load.service                               
- 467ms systemd-remount-fs.service                                 
- 396ms ufw.service                                                
- 356ms systemd-networkd.service                                   
- 314ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
- 253ms sys-fs-fuse-connections.mount                              
- 243ms plymouth-quit-wait.service                                 
- 235ms apparmor.service                                           
- 231ms console-setup.service                                      
- 227ms snapd.apparmor.service                                     
- 221ms plymouth-quit.service                                      
- 211ms sys-kernel-config.mount                                    
- 184ms systemd-user-sessions.service                              
- 158ms systemd-random-seed.service                                
- 145ms systemd-sysctl.service                                     
- 141ms user@1000.service                                          
- 138ms finalrd.service                                            
- 137ms setvtrgb.service                                           
- 135ms systemd-sysusers.service                                   
- 133ms plymouth-read-write.service                                
- 131ms snap-core18-1754.mount                                     
- 126ms snapd.seeded.service                                       
- 121ms snap-lxd-15457.mount                                       
- 118ms systemd-tmpfiles-setup.service                             
- 118ms polkit.service                                             
- 117ms boot-efi.mount                                             
- 112ms snap-snapd-7777.mount                                      
-  86ms systemd-journal-flush.service                              
-  85ms multipathd.service                                         
-  67ms dev-loop0.device                                           
-  67ms dev-loop1.device                                           
-  67ms dev-loop2.device                                           
-  66ms systemd-update-utmp.service                                
-  62ms snapd.socket                                               
-  61ms systemd-tmpfiles-setup-dev.service                         
-  51ms systemd-update-utmp-runlevel.service                       
-  45ms systemd-udevd.service                                      
-  32ms blk-availability.service                                   
-  20ms user-runtime-dir@1000.service                              
-  18ms ephemeral-disk-warning.service                             
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze show
--- Boot Record 01 --
-The total time elapsed since completing an event is printed after the "@" character.
-The time the event takes is printed after the "+" character.
-
-Starting stage: init-local
-|`->no cache found @00.00400s +00.00000s
-Starting stage: init-local/search-Azure
-Starting stage: azure-ds/_get_data
-|`->found azure asset tag @00.10700s +00.01200s
-|`->get_boot_telemetry @00.11900s +00.01800s
-|`->get_system_info @00.13700s +00.00000s
-Starting stage: azure-ds/crawl_metadata
-|`->list_possible_azure_ds_devs @00.13700s +00.21100s
-|`->load_azure_ds_dir @00.34800s +00.00100s
-Starting stage: azure-ds/load_azure_ds_dir
-Starting stage: azure-ds/read_azure_ovf
-|`->load_azure_ovf_pubkeys @00.35300s +00.00000s
-|`->_extract_preprovisioned_vm_setting @00.35400s +00.00000s
-Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
-
-Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
-
-Starting stage: azure-ds/get_metadata_from_imds
-|`->obtain dhcp lease @00.37600s +00.37900s
-|`->_get_metadata_from_imds @00.75600s +00.00800s
-Finished stage: (azure-ds/get_metadata_from_imds) 00.41100 seconds
-
-|`->_get_random_seed @00.78800s +00.00000s
-Finished stage: (azure-ds/crawl_metadata) 00.66400 seconds
-
-|`->maybe_remove_ubuntu_network_config_scripts @00.80100s +00.00000s
-|`->write_files @00.80200s +00.00200s
-Finished stage: (azure-ds/_get_data) 00.69700 seconds
-
-Finished stage: (init-local/search-Azure) 00.70000 seconds
-
-|`->network config from imds @00.85900s +00.00100s
-Finished stage: (init-local) 01.06800 seconds
-
-Starting stage: init-network
-|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.78500s +00.02000s
-|`->network config from imds @03.84800s +00.00100s
-Starting stage: init-network/setup-datasource
-Starting stage: azure-ds/setup
-Starting stage: azure-ds/_negotiate
-Starting stage: azure-ds/bounce_network_with_azure_hostname
-|`->temporary_hostname @03.85800s +00.00000s
-Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
-
-Starting stage: azure-ds/get_metadata_from_fabric
-Starting stage: azure-ds/register_with_azure_and_fetch_data
-|`->generate_certificate @03.86200s +00.02600s
-Starting stage: azure-ds/find_endpoint
-|`->_networkd_get_value_from_leases @03.88800s +00.00100s
-Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
-
-Starting stage: azure-ds/parse_certificates
-|`->_decrypt_certs_from_xml @03.90500s +00.01300s
-Starting stage: azure-ds/_get_ssh_key_from_cert
-|`->_run_x509_action @03.91900s +00.00600s
-Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.03800 seconds
-
-Starting stage: azure-ds/_get_fingerprint_from_cert
-|`->_run_x509_action @03.95600s +00.00600s
-Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
-
-Finished stage: (azure-ds/parse_certificates) 00.05700 seconds
-
-|`->_report_ready @03.96200s +00.00600s
-Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.10800 seconds
-
-Finished stage: (azure-ds/get_metadata_from_fabric) 00.10800 seconds
-
-Finished stage: (azure-ds/_negotiate) 00.11300 seconds
-
-Finished stage: (azure-ds/setup) 00.11300 seconds
-
-Finished stage: (init-network/setup-datasource) 00.11300 seconds
-
-|`->reading and applying user-data @03.97700s +00.00700s
-|`->reading and applying vendor-data @03.98400s +00.00000s
-Starting stage: init-network/activate-datasource
-Starting stage: azure-ds/activate
-Starting stage: azure-ds/address_ephemeral_resize
-|`->wait for ephemeral disk @04.01900s +00.00000s
-Starting stage: azure-ds/can_dev_be_reformatted
-|`->_has_ntfs_filesystem @04.02000s +00.13500s
-Finished stage: (azure-ds/can_dev_be_reformatted) 00.13600 seconds
-
-Finished stage: (azure-ds/address_ephemeral_resize) 00.13600 seconds
-
-Finished stage: (azure-ds/activate) 00.13700 seconds
-
-Finished stage: (init-network/activate-datasource) 00.13900 seconds
-
-|`->config-migrator ran successfully @04.20200s +00.00000s
-|`->config-seed_random ran successfully @04.20300s +00.00100s
-|`->config-bootcmd ran successfully @04.20400s +00.00300s
-|`->config-write-files ran successfully @04.20700s +00.00100s
-|`->config-growpart ran successfully @04.20800s +00.12200s
-|`->config-resizefs ran successfully @04.33100s +00.37400s
-|`->config-disk_setup ran successfully @04.70500s +00.75700s
-|`->config-mounts ran successfully @05.46300s +00.31900s
-|`->config-set_hostname ran successfully @05.78300s +00.00700s
-|`->config-update_hostname ran successfully @05.79000s +00.00100s
-|`->config-update_etc_hosts ran successfully @05.79200s +00.00000s
-|`->config-ca-certs ran successfully @05.79300s +00.00000s
-|`->config-rsyslog ran successfully @05.79400s +00.00100s
-|`->config-users-groups ran successfully @05.79500s +00.05800s
-|`->config-ssh ran successfully @05.85400s +00.20800s
-Finished stage: (init-network) 02.30300 seconds
-
-Starting stage: modules-config
-|`->config-emit_upstart ran successfully @11.92700s +00.01000s
-|`->config-snap ran successfully @11.93800s +00.00500s
-|`->config-ssh-import-id ran successfully @11.94300s +01.62000s
-|`->config-locale ran successfully @13.56300s +00.02700s
-|`->config-set-passwords ran successfully @13.59000s +00.00100s
-|`->config-grub-dpkg ran successfully @13.59200s +00.70600s
-|`->config-apt-pipelining ran successfully @14.29900s +00.00100s
-|`->config-apt-configure ran successfully @14.30000s +00.15100s
-|`->config-ubuntu-advantage ran successfully @14.45200s +00.00000s
-|`->config-ntp ran successfully @14.45500s +00.00100s
-|`->config-timezone ran successfully @14.45600s +00.00100s
-|`->config-disable-ec2-metadata ran successfully @14.45700s +00.00100s
-|`->config-runcmd ran successfully @14.45800s +00.00100s
-|`->config-byobu ran successfully @14.45900s +00.00100s
-Finished stage: (modules-config) 02.64800 seconds
-
-Starting stage: modules-final
-|`->config-package-update-upgrade-install ran successfully @15.16600s +00.00000s
-|`->config-fan ran successfully @15.16700s +00.00100s
-|`->config-landscape ran successfully @15.16800s +00.00100s
-|`->config-lxd ran successfully @15.16900s +00.00100s
-|`->config-ubuntu-drivers ran successfully @15.17000s +00.00100s
-|`->config-puppet ran successfully @15.17100s +00.00100s
-|`->config-chef ran successfully @15.17200s +00.00100s
-|`->config-mcollective ran successfully @15.17400s +00.00000s
-|`->config-salt-minion ran successfully @15.17500s +00.00000s
-|`->config-rightscale_userdata ran successfully @15.17600s +00.00100s
-|`->config-scripts-vendor ran successfully @15.17700s +00.00000s
-|`->config-scripts-per-once ran successfully @15.17800s +00.00100s
-|`->config-scripts-per-boot ran successfully @15.17900s +00.00000s
-|`->config-scripts-per-instance ran successfully @15.18000s +00.00100s
-|`->config-scripts-user ran successfully @15.18100s +00.00100s
-|`->config-ssh-authkey-fingerprints ran successfully @15.18200s +00.10200s
-|`->config-keys-to-console ran successfully @15.28500s +00.05600s
-|`->config-phone-home ran successfully @15.34200s +00.00100s
-|`->config-final-message ran successfully @15.34300s +00.00400s
-|`->config-power-state-change ran successfully @15.34800s +00.00100s
-Finished stage: (modules-final) 00.20000 seconds
-
-Total Time: 9.90800 seconds
-
-1 boot records analyzed
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze blame
--- Boot Record 01 --
-     01.62000s (modules-config/config-ssh-import-id)
-     00.75700s (init-network/config-disk_setup)
-     00.70600s (modules-config/config-grub-dpkg)
-     00.37900s (azure-ds/obtain-dhcp-lease)
-     00.37400s (init-network/config-resizefs)
-     00.31900s (init-network/config-mounts)
-     00.21100s (azure-ds/list_possible_azure_ds_devs)
-     00.20800s (init-network/config-ssh)
-     00.15100s (modules-config/config-apt-configure)
-     00.13500s (azure-ds/_has_ntfs_filesystem)
-     00.12200s (init-network/config-growpart)
-     00.10200s (modules-final/config-ssh-authkey-fingerprints)
-     00.05800s (init-network/config-users-groups)
-     00.05600s (modules-final/config-keys-to-console)
-     00.02700s (modules-config/config-locale)
-     00.02600s (azure-ds/generate_certificate)
-     00.02000s (init-network/check-cache)
-     00.01800s (azure-ds/get_boot_telemetry)
-     00.01300s (azure-ds/_decrypt_certs_from_xml)
-     00.01200s (azure-ds/check-platform-viability)
-     00.01000s (modules-config/config-emit_upstart)
-     00.00800s (azure-ds/_get_metadata_from_imds)
-     00.00700s (init-network/consume-user-data)
-     00.00700s (init-network/config-set_hostname)
-     00.00600s (azure-ds/_run_x509_action)
-     00.00600s (azure-ds/_run_x509_action)
-     00.00600s (azure-ds/_report_ready)
-     00.00500s (modules-config/config-snap)
-     00.00400s (modules-final/config-final-message)
-     00.00300s (init-network/config-bootcmd)
-     00.00200s (azure-ds/write_files)
-     00.00100s (modules-final/config-ubuntu-drivers)
-     00.00100s (modules-final/config-scripts-user)
-     00.00100s (modules-final/config-scripts-per-once)
-     00.00100s (modules-final/config-scripts-per-instance)
-     00.00100s (modules-final/config-rightscale_userdata)
-     00.00100s (modules-final/config-puppet)
-     00.00100s (modules-final/config-power-state-change)
-     00.00100s (modules-final/config-phone-home)
-     00.00100s (modules-final/config-lxd)
-     00.00100s (modules-final/config-landscape)
-     00.00100s (modules-final/config-fan)
-     00.00100s (modules-final/config-chef)
-     00.00100s (modules-config/config-timezone)
      00.00100s (modules-config/config-set-passwords)
-     00.00100s (modules-config/config-runcmd)
      00.00100s (modules-config/config-ntp)
-     00.00100s (modules-config/config-disable-ec2-metadata)
-     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-emit_upstart)
      00.00100s (modules-config/config-apt-pipelining)
      00.00100s (init-network/config-write-files)
      00.00100s (init-network/config-update_hostname)
      00.00100s (init-network/config-seed_random)
      00.00100s (init-network/config-rsyslog)
-     00.00100s (azure-ds/parse_network_config)
-     00.00100s (azure-ds/parse_network_config)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (azure-ds/load_azure_ovf_pubkeys)
      00.00100s (azure-ds/load_azure_ds_dir)
-     00.00100s (azure-ds/_networkd_get_value_from_leases)
-     00.00000s (modules-final/config-scripts-vendor)
      00.00000s (modules-final/config-scripts-per-boot)
-     00.00000s (modules-final/config-salt-minion)
-     00.00000s (modules-final/config-package-update-upgrade-install)
-     00.00000s (modules-final/config-mcollective)
-     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
      00.00000s (init-network/consume-vendor-data)
      00.00000s (init-network/config-update_etc_hosts)
-     00.00000s (init-network/config-migrator)
-     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
      00.00000s (init-local/check-cache)
      00.00000s (azure-ds/wait-for-ephemeral-disk)
      00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/parse_network_config)
      00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
-     00.00000s (azure-ds/load_azure_ovf_pubkeys)
      00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_networkd_get_value_from_leases)
      00.00000s (azure-ds/_get_random_seed)
      00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
 
 1 boot records analyzed
-+ echo After upgrade write network config: upgrade-network.out
++ echo 'After upgrade write network config: upgrade-network.out'
 After upgrade write network config: upgrade-network.out
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cat /etc/netplan/50-cloud-init.yaml
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 route
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 addr
-+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- grep DHCP /var/log/syslog
-+ echo ------- Diff previous-network to post-upgrade-network ------
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@104.209.150.152 -- grep DHCP /var/log/syslog
++ echo '------- Diff previous-network to post-upgrade-network ------'
 ------- Diff previous-network to post-upgrade-network ------
 + diff -urN previous-network.out upgrade-network.out
---- previous-network.out	2020-06-18 18:48:58.904705001 +0000
-+++ upgrade-network.out	2020-06-18 18:50:49.518381051 +0000
+--- previous-network.out	2020-06-24 20:09:59.172984686 +0000
++++ upgrade-network.out	2020-06-24 20:11:42.486608309 +0000
 @@ -38,3 +38,9 @@
- Jun 18 18:48:14 SRU-worked-azure dhclient[503]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x282147ed)
- Jun 18 18:48:14 SRU-worked-azure dhclient[503]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0xed472128)
- Jun 18 18:48:14 SRU-worked-azure systemd-networkd[531]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
-+Jun 18 18:50:03 SRU-worked-azure dhclient[528]: Internet Systems Consortium DHCP Client 4.4.1
-+Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xc711112b)
-+Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPOFFER of 10.0.0.6 from 168.63.129.16
-+Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x2b1111c7)
-+Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0xc711112b)
-+Jun 18 18:50:03 SRU-worked-azure systemd-networkd[556]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
-2020-06-18 18:49:59,943 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
-2020-06-18 18:49:59,943 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
-2020-06-18 18:49:59,944 - azure.py[DEBUG]: Generating certificate for communication with fabric...
-2020-06-18 18:50:00,044 - azure.py[DEBUG]: Reporting ready to Azure fabric.
-2020-06-18 18:50:00,050 - azure.py[INFO]: Reported ready to Azure fabric.
-2020-06-18 18:50:00,051 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
+ Jun 24 20:09:15 SRU-worked-azure dhclient[503]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x35462789)
+ Jun 24 20:09:15 SRU-worked-azure dhclient[503]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0x89274635)
+ Jun 24 20:09:15 SRU-worked-azure systemd-networkd[531]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
++Jun 24 20:11:00 SRU-worked-azure dhclient[526]: Internet Systems Consortium DHCP Client 4.4.1
++Jun 24 20:11:00 SRU-worked-azure dhclient[526]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x318f9102)
++Jun 24 20:11:00 SRU-worked-azure dhclient[526]: DHCPOFFER of 10.0.0.6 from 168.63.129.16
++Jun 24 20:11:00 SRU-worked-azure dhclient[526]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x2918f31)
++Jun 24 20:11:00 SRU-worked-azure dhclient[526]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0x318f9102)
++Jun 24 20:11:00 SRU-worked-azure systemd-networkd[554]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
+
 
 === END verification output ===
-

--- a/manual/azure-sru-20.2.45.txt
+++ b/manual/azure-sru-20.2.45.txt
@@ -1,0 +1,4195 @@
+=== Verification script ===
+#!/bin/sh
+set -ex
+# Manually deploy on Azure using Azure CLI client.
+# Validate upgrade to proposed version of cloud-init
+# Check Tracebacks or error conditions on clean boot
+
+SRU_VARS=./sru-scripts/sru-vars.template
+
+if [ ! -f $SRU_VARS ]; then
+   echo "Missing config environment file $SRU_VARS."
+   exit 1
+fi
+
+. $SRU_VARS
+
+parse_args $0 $@
+assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME \
+  AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP \
+  AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
+create_samplecloudconfig
+create_setup_proposed_script
+
+AZURE_VNET_NAME=$AZURE_VNET_NAME-$UBUNTU_RELEASE
+
+
+IPV6_NET_REGISTERED=$(az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network | jq -r '.properties.state')
+IPV6_CA_LB_REGISTERED=$(az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network | jq -r '.properties.state')
+
+if [ "$IPV6_NET_REGISTERED" != "Registered" -o "$IPV6_CA_LB_REGISTERED" != "Registered" ]; then
+    echo "Account is not yet registered for AllowIPv6VirtualNetwork or AllowIPv6CAOnStandardLB. Can take 30 mins. Activate feature now (y/n)?"
+    read RESP
+    if [ "$RESP" = "y" ]; then
+        az feature register --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
+        az feature register --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
+    else
+        echo "Skipping any advanced network tests because you opted to avoid registering IPv6 feature"
+        echo -n "Proceed without any advanced networking tests (y/n)? "
+        read OK
+        if [ "$OK" = "y" ]; then
+            AZURE_ADVANCED_NIC_TESTS=false
+        else
+            echo "quit the test run"
+            exit 1
+        fi
+    fi
+    echo "Waiting for AllowIPv6VirtualNetwork feature registration"
+    while [ "$IPV6_NET_REGISTERED" != "Registered" -o "$IPV6_CA_LB_REGISTERED" != "Registered" ]; do
+        echo -n "."
+        sleep 5
+        IPV6_NET_REGISTERED=$(az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network | jq -r '.properties.state')
+        IPV6_CA_LB_REGISTERED=$(az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network | jq -r '.properties.state')
+    done
+fi
+
+IPV6_REGISTRATION_COMPLETE=$(az provider show -n Microsoft.Network | jq -r ".registrationState")
+echo "Waiting for Microsoft.Network IPv6 feature registration"
+while [ "$IPV6_REGISTRATION_COMPLETE"  != "Registered" ]; do
+    echo -n "."
+    sleep 5
+    IPV6_REGISTRATION_COMPLETE=$(az provider show -n Microsoft.Network | jq -r ".registrationState")
+done
+
+
+echo "### BEGIN $UBUNTU_RELEASE"
+
+az group show -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 || az group create --name $AZURE_RESOURCE_GROUP --location $AZURE_REGION
+
+if [ -n "${AZURE_BOOT_DIAG}" ]; then
+     az storage account show --name $AZURE_BOOT_DIAG > /dev/null 2>&1 ||
+         az storage account create \
+             --name $AZURE_BOOT_DIAG \
+             --resource-group $AZURE_RESOURCE_GROUP \
+             --location $AZURE_REGION \
+             --sku Standard_RAGRS \
+             --kind StorageV2
+    AZURE_BOOT_DIAG_ARG="--boot-diagnostics-storage ${AZURE_BOOT_DIAG}"
+else
+    AZURE_BOOT_DIAG_ARG=""
+fi
+
+az network nsg show --name $AZURE_NETWORK_SECURITY_GROUP -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 || az network nsg create \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --location $AZURE_REGION \
+    --name $AZURE_NETWORK_SECURITY_GROUP
+
+az network nsg rule show --name allowSSHIn --nsg-name $AZURE_NETWORK_SECURITY_GROUP -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 || az network nsg rule create \
+    --name allowSSHIn  \
+    --nsg-name $AZURE_NETWORK_SECURITY_GROUP  \
+    --resource-group $AZURE_RESOURCE_GROUP  \
+    --priority 100  \
+    --description "Allow SSH In"  \
+    --access Allow  \
+    --protocol "*"  \
+    --direction Inbound  \
+    --source-address-prefixes "*"  \
+    --source-port-ranges "*"  \
+    --destination-address-prefixes "*"  \
+    --destination-port-ranges 22
+
+az network nsg rule show --name allowAllOut --nsg-name $AZURE_NETWORK_SECURITY_GROUP -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 || az network nsg rule create \
+    --name allowAllOut  \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --nsg-name $AZURE_NETWORK_SECURITY_GROUP \
+    --priority 200  \
+    --description "Allow All Out"  \
+    --access Allow  \
+    --protocol "*"  \
+    --direction Outbound  \
+    --source-address-prefixes "*"  \
+    --source-port-ranges "*"  \
+    --destination-address-prefixes "*"  \
+    --destination-port-ranges "*"
+
+az network vnet show --name $AZURE_VNET_NAME -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 || az network vnet create \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --location $AZURE_REGION \
+    --name $AZURE_VNET_NAME \
+    --address-prefixes "10.0.0.0/16" "ace:cab:deca::/48"
+
+az network vnet subnet show --name sruSubnet --vnet-name $AZURE_VNET_NAME -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 || az network vnet subnet create \
+    --name sruSubnet \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --vnet-name $AZURE_VNET_NAME \
+    --address-prefixes "10.0.0.0/24" "ace:cab:deca:deed::/64" \
+    --network-security-group $AZURE_NETWORK_SECURITY_GROUP
+
+
+sshopts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+netcfg="/etc/netplan/50-cloud-init.yaml"
+case $UBUNTU_RELEASE in
+    xenial) image_version=Canonical:UbuntuServer:16.04-DAILY-LTS
+            netcfg="/etc/network/interfaces.d/50-cloud-init.cfg";;
+    bionic) image_version=Canonical:UbuntuServer:18.04-DAILY-LTS;;
+    eoan) image_version=Canonical:UbuntuServer:19.10-DAILY;;
+    focal) image_version=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts;;
+    *) echo "!! UPDATE FAMILY CASE STATEMENT !!"; exit 1;;
+esac
+# Note: accelerated network requires bigger size than our default DS1
+for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELEASE --size Standard_DS2_v2"; do
+    if [ "" = "$nics" ]; then
+        echo "Creating standard network vm"
+        name=test-sru-$UBUNTU_RELEASE
+    else
+        if [ $AZURE_ADVANCED_NIC_TESTS = false ]; then
+            echo "Skipping advanced nic tests because ipv6 feature is disabled"
+            continue
+        fi
+        echo "Creating advanced network vm"
+        name=test-sru-$UBUNTU_RELEASE-advanced
+        # Dual stack load balancer setup with only 1 dualstack/dual nic vm
+        # Create VM IP address
+        az network public-ip create \
+            --name vmPublicIP-IPv4-$UBUNTU_RELEASE \
+            --resource-group $AZURE_RESOURCE_GROUP \
+            --location $AZURE_REGION \
+            --sku BASIC \
+            --allocation-method dynamic \
+            --version IPv4
+        # Create an IPV4 IP address for LB
+        az network public-ip create \
+            --name lbPublicIP_v4_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP  \
+            --location $AZURE_REGION  \
+            --sku BASIC  \
+            --allocation-method dynamic  \
+            --version IPv4
+
+        # Create an IPV6 IP address for LB
+        az network public-ip create \
+            --name lbPublicIP_v6_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP  \
+            --location $AZURE_REGION \
+            --sku BASIC  \
+            --allocation-method dynamic  \
+            --version IPv6
+
+        # Create LB
+        az network lb create \
+            --name dsLB_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP \
+            --sku Basic \
+            --location $AZURE_REGION \
+            --frontend-ip-name dsLbFrontEnd_v4_$UBUNTU_RELEASE  \
+            --public-ip-address lbPublicIP_v4_$UBUNTU_RELEASE  \
+            --backend-pool-name dsLbBackEndPool_v4_$UBUNTU_RELEASE
+
+        # Create LB ipv6 frontend
+        az network lb frontend-ip create \
+            --lb-name dsLB_$UBUNTU_RELEASE  \
+            --name dsLbFrontEnd_v6_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP  \
+            --public-ip-address lbPublicIP_v6_$UBUNTU_RELEASE
+
+        # Create LB ipv6 backend
+        az network lb address-pool create \
+            --lb-name dsLB_$UBUNTU_RELEASE  \
+            --name dsLbBackEndPool_v6_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP
+
+        # Create LB health probe for ssh port
+        az network lb probe create -g $AZURE_RESOURCE_GROUP  \
+            --lb-name dsLB_$UBUNTU_RELEASE -n dsProbe_$UBUNTU_RELEASE --protocol tcp \
+            --port 22
+
+        az network lb rule create \
+            --lb-name dsLB_$UBUNTU_RELEASE  \
+            --name dsLBrule_v4_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP  \
+            --frontend-ip-name dsLbFrontEnd_v4_$UBUNTU_RELEASE  \
+            --protocol Tcp  \
+            --frontend-port 22  \
+            --backend-port 22  \
+            --probe-name dsProbe_$UBUNTU_RELEASE \
+            --backend-pool-name dsLbBackEndPool_v4_$UBUNTU_RELEASE
+
+        az network lb rule create \
+            --lb-name dsLB_$UBUNTU_RELEASE  \
+            --name dsLBrule_v6_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP  \
+            --frontend-ip-name dsLbFrontEnd_v6_$UBUNTU_RELEASE  \
+            --protocol Tcp  \
+            --frontend-port 22  \
+            --backend-port 22  \
+            --probe-name dsProbe_$UBUNTU_RELEASE \
+            --backend-pool-name dsLbBackEndPool_v6_$UBUNTU_RELEASE
+
+        az vm availability-set create \
+            --name dsAVset_$UBUNTU_RELEASE  \
+            --resource-group $AZURE_RESOURCE_GROUP \
+            --location $AZURE_REGION \
+            --platform-fault-domain-count 2  \
+            --platform-update-domain-count 2
+
+        az network nic create \
+            --name $AZURE_NIC_NAME-$UBUNTU_RELEASE \
+            --resource-group $AZURE_RESOURCE_GROUP \
+            --network-security-group $AZURE_NETWORK_SECURITY_GROUP \
+            --vnet-name $AZURE_VNET_NAME \
+             --accelerated-networking true \
+            --subnet sruSubnet \
+            --private-ip-address-version IPv4 \
+            --lb-address-pools dsLbBackEndPool_v4_$UBUNTU_RELEASE  \
+            --lb-name dsLB_$UBUNTU_RELEASE  \
+            --public-ip-address vmPublicIP-IPv4-$UBUNTU_RELEASE
+
+        az network nic create \
+            --name ${AZURE_NIC_NAME}2-$UBUNTU_RELEASE \
+            --resource-group $AZURE_RESOURCE_GROUP \
+            --network-security-group $AZURE_NETWORK_SECURITY_GROUP \
+            --vnet-name $AZURE_VNET_NAME \
+            --accelerated-networking true \
+            --subnet sruSubnet \
+            --private-ip-address-version IPv4
+
+        # Add IPv6 on primary nic
+        az network nic ip-config create \
+            --name $AZURE_NIC_NAME-$UBUNTU_RELEASE-v6 \
+            --nic-name $AZURE_NIC_NAME-$UBUNTU_RELEASE \
+            --resource-group $AZURE_RESOURCE_GROUP \
+            --vnet-name $AZURE_VNET_NAME \
+            --subnet sruSubnet \
+            --lb-address-pools dsLbBackEndPool_v6_$UBUNTU_RELEASE  \
+            --lb-name dsLB_$UBUNTU_RELEASE \
+            --private-ip-address-version IPv6
+
+    fi
+    az vm show --name $name -g $AZURE_RESOURCE_GROUP > /dev/null 2>&1 ||
+        az vm create --name=$name \
+            --image=$image_version:latest \
+            --admin-username=root --admin-username=ubuntu \
+            -g $AZURE_RESOURCE_GROUP --ssh-key-value $SSH_KEY \
+            $AZURE_BOOT_DIAG_ARG \
+            --custom-data $SAMPLE_CLOUDCONFIG $nics
+    IP=$(az vm list-ip-addresses --name $name | jq -r '.[] | .virtualMachine.network.publicIpAddresses[].ipAddress'| awk '{printf "ubuntu@%s", $1}')
+
+    echo "Created $name: ubuntu@$IP"
+
+    ssh $sshopts $IP -- cloud-init status --wait --long
+    ssh $sshopts $IP -- dpkg-query --show cloud-init
+    ssh $sshopts $IP -- sudo cat /run/cloud-init/result.json
+    ssh $sshopts $IP -- ! grep Trace /var/log/cloud-init.log
+    ssh $sshopts $IP -- systemd-analyze
+    ssh $sshopts $IP -- systemd-analyze blame
+    ssh $sshopts $IP -- cloud-init analyze show
+    ssh $sshopts $IP -- cloud-init analyze blame
+    echo 'Writing networking config: previous-network.out'
+    ssh $sshopts $IP -- cat $netcfg > previous-network.out
+    ssh $sshopts $IP -- ip -4 route >> previous-network.out
+    ssh $sshopts $IP -- ip -4 addr >> previous-network.out
+    ssh $sshopts $IP -- ip -6 route >> previous-network.out
+    ssh $sshopts $IP -- ip -6 addr >> previous-network.out
+    ssh $sshopts $IP -- grep DHCP /var/log/syslog >> previous-network.out
+
+    scp $sshopts PROPOSED_SCRIPT $IP:.
+    ssh $sshopts $IP -- sudo bash PROPOSED_SCRIPT 2>&1 | egrep 'cloud-init'
+    ssh $sshopts $IP -- dpkg-query --show cloud-init
+    ssh $sshopts $IP -- sudo hostname SRU-didnt-work
+    ssh $sshopts $IP -- sudo rm -f $netcfg
+    ssh $sshopts $IP -- sudo cloud-init clean --logs --reboot || true
+    sleep 60
+
+    ssh $sshopts $IP -- cloud-init status --wait --long
+    ssh $sshopts $IP -- ! grep Trace /var/log/cloud-init.log
+    ssh $sshopts $IP -- sudo cat /run/cloud-init/result.json
+    ssh $sshopts $IP -- sudo systemd-analyze blame
+    ssh $sshopts $IP -- cloud-init analyze show
+    ssh $sshopts $IP -- cloud-init analyze blame
+    echo 'After upgrade write network config: upgrade-network.out'
+    ssh $sshopts $IP -- cat $netcfg > upgrade-network.out
+    ssh $sshopts $IP -- ip -4 route >> upgrade-network.out
+    ssh $sshopts $IP -- ip -4 addr >> upgrade-network.out
+    ssh $sshopts $IP -- ip -6 route >> upgrade-network.out
+    ssh $sshopts $IP -- ip -6 addr >> upgrade-network.out
+    ssh $sshopts $IP -- grep DHCP /var/log/syslog >> upgrade-network.out
+    echo '------- Diff previous-network to post-upgrade-network ------'
+    diff -urN previous-network.out upgrade-network.out
+    echo '------- Diff previous-network to post-upgrade-network ------'
+    ssh $sshopts $IP -- cloud-init query --format "'cloud-region: {{cloud_name}}-{{region}}'"
+    echo 'Get cloud-id'
+    ssh $sshopts $IP -- cloud-id
+    ssh $sshopts $IP -- cloud-init query --format "'cloud-region: {{cloud_name}}-{{ds.meta_data.imds.compute.location}}'"
+    echo 'Validating whether metadata is being updated per boot LP:1819913. Expect last log to be Sytem Boot'
+    ssh $sshopts $IP -- sudo reboot || true
+    sleep 30
+    ssh $sshopts $IP -- cloud-init status --wait --long
+    echo 'After reboot'
+    ssh $sshopts $IP -- "grep 'Update datasource' /var/log/cloud-init.log"
+done
+echo "### END $UBUNTU_RELEASE"
+
+
+=== BEGIN verification output ===
++ SRU_VARS=./sru-scripts/sru-vars.template
++ [ ! -f ./sru-scripts/sru-vars.template ]
++ . ./sru-scripts/sru-vars.template
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=UNSET
++ PROPOSED_SCRIPT=setup_proposed.sh
++ USE_DEV_PPA=0
++ SAMPLE_CLOUDCONFIG=sethostname.yaml
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=UNSET
++ AZURE_VNET_NAME=UNSET
++ AZURE_NETWORK_SECURITY_GROUP=UNSET
++ AZURE_NIC_NAME=UNSET
++ AZURE_RESOURCE_GROUP=UNSET
++ AZURE_BOOT_DIAG=UNSET
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ SRU_VARS_RC=.sru-vars.rc
++ [ -f .sru-vars.rc ]
++ [ -f /root/.sru-vars.rc ]
++ . /root/.sru-vars.rc
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=chad.smith
++ USE_DEV_PPA=0
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=eastus2
++ AZURE_VNET_NAME=sruVnet
++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++ AZURE_NIC_NAME=sruNic
++ AZURE_RESOURCE_GROUP=srugroupIPV6
++ AZURE_BOOT_DIAG=storeitsru
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ parse_args ./sru-scripts/manual/azure-sru xenial
++ script=./sru-scripts/manual/azure-sru
++ shift
++ [ 1 = 0 ]
++ [ 1 -ne 0 ]
++ UBUNTU_RELEASE=xenial
++ shift
++ [ 0 -ne 0 ]
++ [ -z xenial ]
++ assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
++ local value=
++ eval value=$PROPOSED_SCRIPT > /dev/null
++ value=setup_proposed.sh
++ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
++ eval value=$AZURE_REGION > /dev/null
++ value=eastus2
++ [ -z eastus2 -o eastus2 = UNSET ]
++ eval value=$AZURE_VNET_NAME > /dev/null
++ value=sruVnet
++ [ -z sruVnet -o sruVnet = UNSET ]
++ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
++ value=sruNetSecGroup
++ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
++ eval value=$AZURE_NIC_NAME > /dev/null
++ value=sruNic
++ [ -z sruNic -o sruNic = UNSET ]
++ eval value=$AZURE_RESOURCE_GROUP > /dev/null
++ value=srugroupIPV6
++ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
++ eval value=$AZURE_BOOT_DIAG > /dev/null
++ value=storeitsru
++ [ -z storeitsru -o storeitsru = UNSET ]
++ eval value=$SSH_KEY > /dev/null
++ value=/root/.ssh/id_rsa.pub
++ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
++ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
++ value=sethostname.yaml
++ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
++ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
++ value=true
++ [ -z true -o true = UNSET ]
++ create_samplecloudconfig
++ filename=sethostname.yaml
++ cat
++ create_setup_proposed_script
++ [ 0 -eq 0 ]
++ cat
++ AZURE_VNET_NAME=sruVnet-xenial
++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_NET_REGISTERED=Registered
++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_CA_LB_REGISTERED=Registered
++ [ Registered != Registered -o Registered != Registered ]
++ + az provider showjq -n -r Microsoft.Network .registrationState
+
++ IPV6_REGISTRATION_COMPLETE=Registered
++ echo Waiting for Microsoft.Network IPv6 feature registration
+Waiting for Microsoft.Network IPv6 feature registration
++ [ Registered != Registered ]
++ echo ### BEGIN xenial
+### BEGIN xenial
++ az group show -g srugroupIPV6
++ [ -n storeitsru ]
++ az storage account show --name storeitsru
++ az storage account create --name storeitsru --resource-group srugroupIPV6 --location eastus2 --sku Standard_RAGRS --kind StorageV2
+The default kind for created storage account will change to 'StorageV2' from 'Storage' in future
+{
+  "accessTier": "Hot",
+  "azureFilesIdentityBasedAuthentication": null,
+  "creationTime": "2020-06-18T18:32:15.827025+00:00",
+  "customDomain": null,
+  "enableHttpsTrafficOnly": true,
+  "encryption": {
+    "keySource": "Microsoft.Storage",
+    "keyVaultProperties": null,
+    "services": {
+      "blob": {
+        "enabled": true,
+        "lastEnabledTime": "2020-06-18T18:32:15.920777+00:00"
+      },
+      "file": {
+        "enabled": true,
+        "lastEnabledTime": "2020-06-18T18:32:15.920777+00:00"
+      },
+      "queue": null,
+      "table": null
+    }
+  },
+  "failoverInProgress": null,
+  "geoReplicationStats": null,
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Storage/storageAccounts/storeitsru",
+  "identity": null,
+  "isHnsEnabled": null,
+  "kind": "StorageV2",
+  "largeFileSharesState": null,
+  "lastGeoFailoverTime": null,
+  "location": "eastus2",
+  "name": "storeitsru",
+  "networkRuleSet": {
+    "bypass": "AzureServices",
+    "defaultAction": "Allow",
+    "ipRules": [],
+    "virtualNetworkRules": []
+  },
+  "primaryEndpoints": {
+    "blob": "https://storeitsru.blob.core.windows.net/",
+    "dfs": "https://storeitsru.dfs.core.windows.net/",
+    "file": "https://storeitsru.file.core.windows.net/",
+    "queue": "https://storeitsru.queue.core.windows.net/",
+    "table": "https://storeitsru.table.core.windows.net/",
+    "web": "https://storeitsru.z20.web.core.windows.net/"
+  },
+  "primaryLocation": "eastus2",
+  "provisioningState": "Succeeded",
+  "resourceGroup": "srugroupIPV6",
+  "secondaryEndpoints": {
+    "blob": "https://storeitsru-secondary.blob.core.windows.net/",
+    "dfs": "https://storeitsru-secondary.dfs.core.windows.net/",
+    "file": null,
+    "queue": "https://storeitsru-secondary.queue.core.windows.net/",
+    "table": "https://storeitsru-secondary.table.core.windows.net/",
+    "web": "https://storeitsru-secondary.z20.web.core.windows.net/"
+  },
+  "secondaryLocation": "centralus",
+  "sku": {
+    "capabilities": null,
+    "kind": null,
+    "locations": null,
+    "name": "Standard_RAGRS",
+    "resourceType": null,
+    "restrictions": null,
+    "tier": "Standard"
+  },
+  "statusOfPrimary": "available",
+  "statusOfSecondary": "available",
+  "tags": {},
+  "type": "Microsoft.Storage/storageAccounts"
+}
++ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ az network nsg show --name sruNetSecGroup -g srugroupIPV6
++ az network nsg create --resource-group srugroupIPV6 --location eastus2 --name sruNetSecGroup
+{
+  "NewNSG": {
+    "defaultSecurityRules": [
+      {
+        "access": "Allow",
+        "description": "Allow inbound traffic from all VMs in VNET",
+        "destinationAddressPrefix": "VirtualNetwork",
+        "destinationAddressPrefixes": [],
+        "destinationApplicationSecurityGroups": null,
+        "destinationPortRange": "*",
+        "destinationPortRanges": [],
+        "direction": "Inbound",
+        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowVnetInBound",
+        "name": "AllowVnetInBound",
+        "priority": 65000,
+        "protocol": "*",
+        "provisioningState": "Succeeded",
+        "resourceGroup": "srugroupIPV6",
+        "sourceAddressPrefix": "VirtualNetwork",
+        "sourceAddressPrefixes": [],
+        "sourceApplicationSecurityGroups": null,
+        "sourcePortRange": "*",
+        "sourcePortRanges": [],
+        "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
+      },
+      {
+        "access": "Allow",
+        "description": "Allow inbound traffic from azure load balancer",
+        "destinationAddressPrefix": "*",
+        "destinationAddressPrefixes": [],
+        "destinationApplicationSecurityGroups": null,
+        "destinationPortRange": "*",
+        "destinationPortRanges": [],
+        "direction": "Inbound",
+        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+        "name": "AllowAzureLoadBalancerInBound",
+        "priority": 65001,
+        "protocol": "*",
+        "provisioningState": "Succeeded",
+        "resourceGroup": "srugroupIPV6",
+        "sourceAddressPrefix": "AzureLoadBalancer",
+        "sourceAddressPrefixes": [],
+        "sourceApplicationSecurityGroups": null,
+        "sourcePortRange": "*",
+        "sourcePortRanges": [],
+        "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
+      },
+      {
+        "access": "Deny",
+        "description": "Deny all inbound traffic",
+        "destinationAddressPrefix": "*",
+        "destinationAddressPrefixes": [],
+        "destinationApplicationSecurityGroups": null,
+        "destinationPortRange": "*",
+        "destinationPortRanges": [],
+        "direction": "Inbound",
+        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/DenyAllInBound",
+        "name": "DenyAllInBound",
+        "priority": 65500,
+        "protocol": "*",
+        "provisioningState": "Succeeded",
+        "resourceGroup": "srugroupIPV6",
+        "sourceAddressPrefix": "*",
+        "sourceAddressPrefixes": [],
+        "sourceApplicationSecurityGroups": null,
+        "sourcePortRange": "*",
+        "sourcePortRanges": [],
+        "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
+      },
+      {
+        "access": "Allow",
+        "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+        "destinationAddressPrefix": "VirtualNetwork",
+        "destinationAddressPrefixes": [],
+        "destinationApplicationSecurityGroups": null,
+        "destinationPortRange": "*",
+        "destinationPortRanges": [],
+        "direction": "Outbound",
+        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowVnetOutBound",
+        "name": "AllowVnetOutBound",
+        "priority": 65000,
+        "protocol": "*",
+        "provisioningState": "Succeeded",
+        "resourceGroup": "srugroupIPV6",
+        "sourceAddressPrefix": "VirtualNetwork",
+        "sourceAddressPrefixes": [],
+        "sourceApplicationSecurityGroups": null,
+        "sourcePortRange": "*",
+        "sourcePortRanges": [],
+        "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
+      },
+      {
+        "access": "Allow",
+        "description": "Allow outbound traffic from all VMs to Internet",
+        "destinationAddressPrefix": "Internet",
+        "destinationAddressPrefixes": [],
+        "destinationApplicationSecurityGroups": null,
+        "destinationPortRange": "*",
+        "destinationPortRanges": [],
+        "direction": "Outbound",
+        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/AllowInternetOutBound",
+        "name": "AllowInternetOutBound",
+        "priority": 65001,
+        "protocol": "*",
+        "provisioningState": "Succeeded",
+        "resourceGroup": "srugroupIPV6",
+        "sourceAddressPrefix": "*",
+        "sourceAddressPrefixes": [],
+        "sourceApplicationSecurityGroups": null,
+        "sourcePortRange": "*",
+        "sourcePortRanges": [],
+        "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
+      },
+      {
+        "access": "Deny",
+        "description": "Deny all outbound traffic",
+        "destinationAddressPrefix": "*",
+        "destinationAddressPrefixes": [],
+        "destinationApplicationSecurityGroups": null,
+        "destinationPortRange": "*",
+        "destinationPortRanges": [],
+        "direction": "Outbound",
+        "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+        "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/defaultSecurityRules/DenyAllOutBound",
+        "name": "DenyAllOutBound",
+        "priority": 65500,
+        "protocol": "*",
+        "provisioningState": "Succeeded",
+        "resourceGroup": "srugroupIPV6",
+        "sourceAddressPrefix": "*",
+        "sourceAddressPrefixes": [],
+        "sourceApplicationSecurityGroups": null,
+        "sourcePortRange": "*",
+        "sourcePortRanges": [],
+        "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules"
+      }
+    ],
+    "etag": "W/\"bce16190-7342-4072-8a30-f501c5d32ea5\"",
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
+    "location": "eastus2",
+    "name": "sruNetSecGroup",
+    "networkInterfaces": null,
+    "provisioningState": "Succeeded",
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": "05112927-8422-43ab-802d-aa64aca51b4b",
+    "securityRules": [],
+    "subnets": null,
+    "tags": null,
+    "type": "Microsoft.Network/networkSecurityGroups"
+  }
+}
++ az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule create --name allowSSHIn --nsg-name sruNetSecGroup --resource-group srugroupIPV6 --priority 100 --description Allow SSH In --access Allow --protocol * --direction Inbound --source-address-prefixes * --source-port-ranges * --destination-address-prefixes * --destination-port-ranges 22
+{
+  "access": "Allow",
+  "description": "Allow SSH In",
+  "destinationAddressPrefix": "*",
+  "destinationAddressPrefixes": [],
+  "destinationApplicationSecurityGroups": null,
+  "destinationPortRange": "22",
+  "destinationPortRanges": [],
+  "direction": "Inbound",
+  "etag": "W/\"90ed4ab5-74f9-41a6-bbe2-2fa99a366f32\"",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/securityRules/allowSSHIn",
+  "name": "allowSSHIn",
+  "priority": 100,
+  "protocol": "*",
+  "provisioningState": "Succeeded",
+  "resourceGroup": "srugroupIPV6",
+  "sourceAddressPrefix": "*",
+  "sourceAddressPrefixes": [],
+  "sourceApplicationSecurityGroups": null,
+  "sourcePortRange": "*",
+  "sourcePortRanges": [],
+  "type": "Microsoft.Network/networkSecurityGroups/securityRules"
+}
++ az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule create --name allowAllOut --resource-group srugroupIPV6 --nsg-name sruNetSecGroup --priority 200 --description Allow All Out --access Allow --protocol * --direction Outbound --source-address-prefixes * --source-port-ranges * --destination-address-prefixes * --destination-port-ranges *
+{
+  "access": "Allow",
+  "description": "Allow All Out",
+  "destinationAddressPrefix": "*",
+  "destinationAddressPrefixes": [],
+  "destinationApplicationSecurityGroups": null,
+  "destinationPortRange": "*",
+  "destinationPortRanges": [],
+  "direction": "Outbound",
+  "etag": "W/\"851362de-277d-4855-b8d3-67456650aa34\"",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup/securityRules/allowAllOut",
+  "name": "allowAllOut",
+  "priority": 200,
+  "protocol": "*",
+  "provisioningState": "Succeeded",
+  "resourceGroup": "srugroupIPV6",
+  "sourceAddressPrefix": "*",
+  "sourceAddressPrefixes": [],
+  "sourceApplicationSecurityGroups": null,
+  "sourcePortRange": "*",
+  "sourcePortRanges": [],
+  "type": "Microsoft.Network/networkSecurityGroups/securityRules"
+}
++ az network vnet show --name sruVnet-xenial -g srugroupIPV6
++ az network vnet create --resource-group srugroupIPV6 --location eastus2 --name sruVnet-xenial --address-prefixes 10.0.0.0/16 ace:cab:deca::/48
+{
+  "newVNet": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16",
+        "ace:cab:deca::/48"
+      ]
+    },
+    "ddosProtectionPlan": null,
+    "dhcpOptions": {
+      "dnsServers": []
+    },
+    "enableDdosProtection": false,
+    "enableVmProtection": false,
+    "etag": "W/\"3355d29f-09a9-47b6-a32c-0d3371f124da\"",
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-xenial",
+    "location": "eastus2",
+    "name": "sruVnet-xenial",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": "5b48766f-4c15-4579-aebb-7dd9da916ffa",
+    "subnets": [],
+    "tags": {},
+    "type": "Microsoft.Network/virtualNetworks",
+    "virtualNetworkPeerings": []
+  }
+}
++ az network vnet subnet show --name sruSubnet --vnet-name sruVnet-xenial -g srugroupIPV6
++ az network vnet subnet create --name sruSubnet --resource-group srugroupIPV6 --vnet-name sruVnet-xenial --address-prefixes 10.0.0.0/24 ace:cab:deca:deed::/64 --network-security-group sruNetSecGroup
+{
+  "addressPrefix": null,
+  "addressPrefixes": [
+    "10.0.0.0/24",
+    "ace:cab:deca:deed::/64"
+  ],
+  "delegations": [],
+  "etag": "W/\"7f7f041b-698d-4db5-b783-a0bcc046d2fb\"",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-xenial/subnets/sruSubnet",
+  "ipConfigurationProfiles": null,
+  "ipConfigurations": null,
+  "name": "sruSubnet",
+  "natGateway": null,
+  "networkSecurityGroup": {
+    "defaultSecurityRules": null,
+    "etag": null,
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
+    "location": null,
+    "name": null,
+    "networkInterfaces": null,
+    "provisioningState": null,
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": null,
+    "securityRules": null,
+    "subnets": null,
+    "tags": null,
+    "type": null
+  },
+  "privateEndpointNetworkPolicies": "Enabled",
+  "privateEndpoints": null,
+  "privateLinkServiceNetworkPolicies": "Enabled",
+  "provisioningState": "Succeeded",
+  "purpose": null,
+  "resourceGroup": "srugroupIPV6",
+  "resourceNavigationLinks": null,
+  "routeTable": null,
+  "serviceAssociationLinks": null,
+  "serviceEndpointPolicies": null,
+  "serviceEndpoints": null,
+  "type": "Microsoft.Network/virtualNetworks/subnets"
+}
++ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ netcfg=/etc/netplan/50-cloud-init.yaml
++ image_version=Canonical:UbuntuServer:16.04-DAILY-LTS
++ netcfg=/etc/network/interfaces.d/50-cloud-init.cfg
++ [  =  ]
++ echo Creating standard network vm
+Creating standard network vm
++ name=test-sru-xenial
++ az vm show --name test-sru-xenial -g srugroupIPV6
++ az vm create --name=test-sru-xenial --image=Canonical:UbuntuServer:16.04-DAILY-LTS:latest --admin-username=root --admin-username=ubuntu -g srugroupIPV6 --ssh-key-value /root/.ssh/id_rsa.pub --boot-diagnostics-storage storeitsru --custom-data sethostname.yaml
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-xenial",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-7E-7A-14",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.4",
+  "publicIpAddress": "20.36.167.25",
+  "resourceGroup": "srugroupIPV6",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-xenial
++ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
++ awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@20.36.167.25
++ echo Created test-sru-xenial: ubuntu@ubuntu@20.36.167.25
+Created test-sru-xenial: ubuntu@ubuntu@20.36.167.25
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init status --wait --long
+
+status: done
+time: Thu, 18 Jun 2020 18:35:23 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~16.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo cat /run/cloud-init/result.json
+sudo: unable to resolve host SRU-worked-azure
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/dev/sr0]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- systemd-analyze
+Startup finished in 5.646s (kernel) + 24.900s (userspace) = 30.546s
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- systemd-analyze blame
+          8.012s cloud-init.service
+          4.461s cloud-config.service
+          3.763s cloud-init-local.service
+          2.510s snapd.service
+          2.162s pollinate.service
+          2.093s lxd-containers.service
+          1.849s dev-sda1.device
+          1.659s snapd.seeded.service
+          1.427s apparmor.service
+           923ms accounts-daemon.service
+           739ms networking.service
+           654ms cloud-final.service
+           594ms iscsid.service
+           526ms systemd-logind.service
+           522ms rsyslog.service
+           472ms grub-common.service
+           453ms mdadm.service
+           450ms lvm2-monitor.service
+           412ms open-iscsi.service
+           388ms systemd-timesyncd.service
+           281ms ssh.service
+           258ms systemd-modules-load.service
+           256ms resolvconf.service
+           250ms apport.service
+           216ms kmod-static-nodes.service
+           210ms keyboard-setup.service
+           209ms console-setup.service
+           209ms systemd-update-utmp.service
+           208ms ufw.service
+           208ms dev-mqueue.mount
+           208ms systemd-remount-fs.service
+           193ms lxd.socket
+           189ms irqbalance.service
+           175ms sys-kernel-debug.mount
+           162ms systemd-udev-trigger.service
+           160ms systemd-tmpfiles-setup-dev.service
+           157ms dev-hugepages.mount
+           133ms systemd-journald.service
+           102ms snapd.socket
+            99ms systemd-journal-flush.service
+            98ms systemd-udevd.service
+            87ms polkitd.service
+            74ms systemd-user-sessions.service
+            70ms systemd-machine-id-commit.service
+            62ms ondemand.service
+            56ms systemd-sysctl.service
+            55ms plymouth-read-write.service
+            53ms systemd-tmpfiles-setup.service
+            49ms setvtrgb.service
+            48ms rc-local.service
+            37ms systemd-random-seed.service
+            30ms ephemeral-disk-warning.service
+            30ms boot-efi.mount
+            29ms plymouth-quit-wait.service
+            29ms sys-fs-fuse-connections.mount
+            26ms plymouth-quit.service
+            25ms sys-kernel-config.mount
+            20ms user@1000.service
+             9ms systemd-update-utmp-runlevel.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.10300s +00.00600s
+|`->get_boot_telemetry @00.10900s +00.00900s
+|`->get_system_info @00.11800s +00.00100s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.11900s +00.05700s
+|`->load_azure_ds_dir @00.17600s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.29700s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.29700s +00.00100s
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00800 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.33200s +00.27400s
+|`->_get_metadata_from_imds @00.60600s +00.10200s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.40100 seconds
+
+|`->_get_random_seed @00.73300s +00.00100s
+Finished stage: (azure-ds/crawl_metadata) 00.62100 seconds
+
+|`->write_files @00.74100s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.64000 seconds
+
+Finished stage: (init-local/search-Azure) 00.64300 seconds
+
+|`->network config from fallback @00.80800s +00.02000s
+Finished stage: (init-local) 00.84100 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @01.98000s +00.02200s
+|`->network config from fallback @02.05600s +00.02000s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/get_metadata_from_agent
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @02.08400s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+
+|`->invoke_agent @02.08700s +00.17700s
+|`->wait for agents to retrieve SSH keys @02.26400s +01.00200s
+Starting stage: azure-ds/pubkeys_from_crt_files
+|`->crtfile_to_pubkey @03.26700s +00.03100s
+Finished stage: (azure-ds/pubkeys_from_crt_files) 00.03200 seconds
+
+Finished stage: (azure-ds/get_metadata_from_agent) 01.21500 seconds
+
+Finished stage: (azure-ds/_negotiate) 01.21600 seconds
+
+Finished stage: (azure-ds/setup) 01.21600 seconds
+
+Finished stage: (init-network/setup-datasource) 01.21600 seconds
+
+|`->reading and applying user-data @03.30500s +00.00800s
+|`->reading and applying vendor-data @03.31300s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @03.34300s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @03.34300s +00.05200s
+Starting stage: azure-ds/mount-ntfs-and-count
+|`->count_files @03.45300s +00.00200s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.06700 seconds
+
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.11900 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.11900 seconds
+
+Finished stage: (azure-ds/activate) 00.12000 seconds
+
+Finished stage: (init-network/activate-datasource) 00.12200 seconds
+
+|`->config-migrator ran successfully @03.51000s +00.00100s
+|`->config-seed_random ran successfully @03.51100s +00.00100s
+|`->config-bootcmd ran successfully @03.51300s +00.00000s
+|`->config-write-files ran successfully @03.51400s +00.00000s
+|`->config-growpart ran successfully @03.51500s +00.37900s
+|`->config-resizefs ran successfully @03.89400s +00.24700s
+|`->config-disk_setup ran successfully @04.14100s +04.38700s
+|`->config-mounts ran successfully @08.52800s +00.12200s
+|`->config-set_hostname ran successfully @08.65000s +00.00600s
+|`->config-update_hostname ran successfully @08.65600s +00.00200s
+|`->config-update_etc_hosts ran successfully @08.65800s +00.00000s
+|`->config-ca-certs ran successfully @08.65900s +00.00100s
+|`->config-rsyslog ran successfully @08.66000s +00.00100s
+|`->config-users-groups ran successfully @08.66100s +00.72900s
+|`->config-ssh ran successfully @09.39100s +00.19500s
+Finished stage: (init-network) 07.62000 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @15.00800s +00.00200s
+|`->config-snap ran successfully @15.01300s +00.00400s
+|`->config-ssh-import-id ran successfully @15.02400s +00.94800s
+|`->config-locale ran successfully @15.97300s +01.27600s
+|`->config-set-passwords ran successfully @17.25000s +00.00100s
+|`->config-grub-dpkg ran successfully @17.25200s +01.08300s
+|`->config-apt-pipelining ran successfully @18.33600s +00.00100s
+|`->config-apt-configure ran successfully @18.33700s +00.29800s
+|`->config-ubuntu-advantage ran successfully @18.63500s +00.00200s
+|`->config-ntp ran successfully @18.63700s +00.00100s
+|`->config-timezone ran successfully @18.63800s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @18.64000s +00.00000s
+|`->config-runcmd ran successfully @18.64000s +00.00100s
+|`->config-byobu ran successfully @18.64100s +00.00100s
+Finished stage: (modules-config) 03.68400 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @19.10700s +00.00100s
+|`->config-fan ran successfully @19.10900s +00.00100s
+|`->config-landscape ran successfully @19.11000s +00.00100s
+|`->config-lxd ran successfully @19.11100s +00.00100s
+|`->config-ubuntu-drivers ran successfully @19.11200s +00.00100s
+|`->config-puppet ran successfully @19.11300s +00.00100s
+|`->config-chef ran successfully @19.11400s +00.00100s
+|`->config-mcollective ran successfully @19.11500s +00.00100s
+|`->config-salt-minion ran successfully @19.11700s +00.00000s
+|`->config-rightscale_userdata ran successfully @19.11800s +00.00000s
+|`->config-scripts-vendor ran successfully @19.11900s +00.00100s
+|`->config-scripts-per-once ran successfully @19.12000s +00.00100s
+|`->config-scripts-per-boot ran successfully @19.12100s +00.00100s
+|`->config-scripts-per-instance ran successfully @19.12200s +00.00100s
+|`->config-scripts-user ran successfully @19.12300s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @19.12400s +00.06000s
+|`->config-keys-to-console ran successfully @19.18400s +00.10500s
+|`->config-phone-home ran successfully @19.29000s +00.00100s
+|`->config-final-message ran successfully @19.29200s +00.00400s
+|`->config-power-state-change ran successfully @19.29700s +00.00000s
+Finished stage: (modules-final) 00.21400 seconds
+
+Total Time: 20.12200 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze blame
+-- Boot Record 01 --
+     04.38700s (init-network/config-disk_setup)
+     01.27600s (modules-config/config-locale)
+     01.08300s (modules-config/config-grub-dpkg)
+     01.00200s (azure-ds/waiting-for-ssh-public-key)
+     00.94800s (modules-config/config-ssh-import-id)
+     00.72900s (init-network/config-users-groups)
+     00.37900s (init-network/config-growpart)
+     00.29800s (modules-config/config-apt-configure)
+     00.27400s (azure-ds/obtain-dhcp-lease)
+     00.24700s (init-network/config-resizefs)
+     00.19500s (init-network/config-ssh)
+     00.17700s (azure-ds/invoke_agent)
+     00.12200s (init-network/config-mounts)
+     00.10500s (modules-final/config-keys-to-console)
+     00.10200s (azure-ds/_get_metadata_from_imds)
+     00.06000s (modules-final/config-ssh-authkey-fingerprints)
+     00.05700s (azure-ds/list_possible_azure_ds_devs)
+     00.05200s (azure-ds/_has_ntfs_filesystem)
+     00.03100s (azure-ds/crtfile_to_pubkey)
+     00.02200s (init-network/check-cache)
+     00.02000s (azure-ds/parse_network_config)
+     00.02000s (azure-ds/parse_network_config)
+     00.00900s (azure-ds/get_boot_telemetry)
+     00.00800s (init-network/consume-user-data)
+     00.00600s (init-network/config-set_hostname)
+     00.00600s (azure-ds/check-platform-viability)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (modules-config/config-snap)
+     00.00200s (modules-config/config-ubuntu-advantage)
+     00.00200s (modules-config/config-emit_upstart)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (azure-ds/write_files)
+     00.00200s (azure-ds/count_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (azure-ds/get_system_info)
+     00.00100s (azure-ds/_get_random_seed)
+     00.00100s (azure-ds/_extract_preprovisioned_vm_setting)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/load_azure_ds_dir)
+
+1 boot records analyzed
++ echo Writing networking config: previous-network.out
+Writing networking config: previous-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cat /etc/network/interfaces.d/50-cloud-init.cfg
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@20.36.167.25:.
+PROPOSED_SCRIPT                               100%  196     3.3KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo bash PROPOSED_SCRIPT
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu xenial-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~16.04.1 [425 kB]
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~16.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) over (19.4-33-gbb4131a2-0ubuntu1~16.04.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~16.04.1) ...
+Leaving 'diversion of /etc/init/ureadahead.conf to /etc/init/ureadahead.conf.disabled by cloud-init'
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- dpkg-query --show cloud-init
+cloud-init	20.2-45-g5f7825e2-0ubuntu1~16.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo hostname SRU-didnt-work
+sudo: unable to resolve host SRU-worked-azure
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo rm -f /etc/network/interfaces.d/50-cloud-init.cfg
+sudo: unable to resolve host SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo cloud-init clean --logs --reboot
+sudo: unable to resolve host SRU-didnt-work
+Connection to 20.36.167.25 closed by remote host.
++ true
++ sleep 60
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init status --wait --long
+
+status: done
+time: Thu, 18 Jun 2020 18:36:58 +0000
+detail:
+DataSourceAzure [seed=/var/lib/waagent]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo cat /run/cloud-init/result.json
+sudo: unable to resolve host SRU-worked-azure
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- sudo systemd-analyze blame
+sudo: unable to resolve host SRU-worked-azure
+          2.580s cloud-config.service
+          1.700s cloud-init-local.service
+          1.622s cloud-init.service
+          1.414s snapd.service
+          1.356s dev-sda1.device
+           907ms iscsid.service
+           829ms accounts-daemon.service
+           778ms grub-common.service
+           733ms systemd-logind.service
+           723ms mdadm.service
+           690ms cloud-final.service
+           589ms apparmor.service
+           549ms ssh.service
+           546ms networking.service
+           538ms rsyslog.service
+           535ms lxd-containers.service
+           496ms rc-local.service
+           453ms lvm2-monitor.service
+           410ms systemd-timesyncd.service
+           296ms apport.service
+           223ms polkitd.service
+           218ms ondemand.service
+           210ms systemd-modules-load.service
+           202ms console-setup.service
+           193ms open-iscsi.service
+           145ms lxd.socket
+           145ms keyboard-setup.service
+           144ms dev-mqueue.mount
+           142ms resolvconf.service
+           134ms systemd-update-utmp.service
+           128ms irqbalance.service
+           126ms ufw.service
+           124ms systemd-udev-trigger.service
+           120ms systemd-journald.service
+           119ms sys-kernel-debug.mount
+           100ms kmod-static-nodes.service
+            99ms systemd-remount-fs.service
+            88ms dev-hugepages.mount
+            77ms systemd-journal-flush.service
+            76ms sys-kernel-config.mount
+            75ms systemd-tmpfiles-setup.service
+            63ms systemd-sysctl.service
+            63ms systemd-tmpfiles-setup-dev.service
+            60ms systemd-random-seed.service
+            59ms setvtrgb.service
+            56ms sys-fs-fuse-connections.mount
+            53ms snapd.socket
+            49ms snapd.seeded.service
+            43ms systemd-udevd.service
+            36ms systemd-user-sessions.service
+            35ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+            28ms plymouth-quit-wait.service
+            27ms plymouth-quit.service
+            24ms plymouth-read-write.service
+            20ms user@1000.service
+            16ms systemd-update-utmp-runlevel.service
+            15ms boot-efi.mount
+            15ms ephemeral-disk-warning.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00100s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.03600s +00.00600s
+|`->get_boot_telemetry @00.04200s +00.00900s
+|`->get_system_info @00.05100s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.05100s +00.17500s
+|`->load_azure_ds_dir @00.22600s +00.00100s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.23100s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.23100s +00.00100s
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.25200s +00.18400s
+|`->_get_metadata_from_imds @00.43600s +00.01100s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.21400 seconds
+
+|`->_get_random_seed @00.46500s +00.00100s
+Finished stage: (azure-ds/crawl_metadata) 00.42100 seconds
+
+|`->write_files @00.47300s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.44100 seconds
+
+Finished stage: (init-local/search-Azure) 00.44400 seconds
+
+|`->network config from fallback @00.53700s +00.01800s
+Finished stage: (init-local) 00.56900 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @01.52200s +00.01900s
+|`->network config from fallback @01.59300s +00.01800s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @01.62000s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @01.62400s +00.03000s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @01.65400s +00.00000s
+|`->_load_dhclient_json @01.65400s +00.02400s
+|`->_get_value_from_dhcpoptions @01.67800s +00.00000s
+|`->_get_value_from_leases_file @01.67900s +00.00000s
+Finished stage: (azure-ds/find_endpoint) 00.02500 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @01.70000s +00.01700s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @01.71700s +00.00600s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01100 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @01.72800s +00.00500s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.03500 seconds
+
+|`->_report_ready @01.73400s +00.00600s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.11600 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.11700 seconds
+
+Finished stage: (azure-ds/_negotiate) 00.12100 seconds
+
+Finished stage: (azure-ds/setup) 00.12100 seconds
+
+Finished stage: (init-network/setup-datasource) 00.12100 seconds
+
+|`->reading and applying user-data @01.74800s +00.00600s
+|`->reading and applying vendor-data @01.75500s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @01.78200s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @01.78200s +00.08800s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.08800 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.08900 seconds
+
+Finished stage: (azure-ds/activate) 00.08900 seconds
+
+Finished stage: (init-network/activate-datasource) 00.09100 seconds
+
+|`->config-migrator ran successfully @01.89100s +00.00100s
+|`->config-seed_random ran successfully @01.89200s +00.00100s
+|`->config-bootcmd ran successfully @01.89400s +00.00000s
+|`->config-write-files ran successfully @01.89500s +00.00000s
+|`->config-growpart ran successfully @01.89600s +00.04200s
+|`->config-resizefs ran successfully @01.93800s +00.01500s
+|`->config-disk_setup ran successfully @01.95300s +00.18600s
+|`->config-mounts ran successfully @02.14000s +00.12400s
+|`->config-set_hostname ran successfully @02.26400s +00.00600s
+|`->config-update_hostname ran successfully @02.27000s +00.00200s
+|`->config-update_etc_hosts ran successfully @02.27200s +00.00100s
+|`->config-ca-certs ran successfully @02.27300s +00.00100s
+|`->config-rsyslog ran successfully @02.27400s +00.00100s
+|`->config-users-groups ran successfully @02.27500s +00.06500s
+|`->config-ssh ran successfully @02.34100s +00.38300s
+Finished stage: (init-network) 01.22000 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @05.50400s +00.00000s
+|`->config-snap ran successfully @05.50600s +00.00100s
+|`->config-ssh-import-id ran successfully @05.50700s +00.90000s
+|`->config-locale ran successfully @06.41100s +00.00100s
+|`->config-set-passwords ran successfully @06.41200s +00.00200s
+|`->config-grub-dpkg ran successfully @06.42000s +00.49500s
+|`->config-apt-pipelining ran successfully @06.91600s +00.00100s
+|`->config-apt-configure ran successfully @06.91700s +00.22400s
+|`->config-ubuntu-advantage ran successfully @07.14200s +00.00100s
+|`->config-ntp ran successfully @07.14300s +00.00100s
+|`->config-timezone ran successfully @07.14500s +00.00000s
+|`->config-disable-ec2-metadata ran successfully @07.14600s +00.00000s
+|`->config-runcmd ran successfully @07.14700s +00.00000s
+|`->config-byobu ran successfully @07.14800s +00.00000s
+Finished stage: (modules-config) 01.67500 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @07.65500s +00.00100s
+|`->config-fan ran successfully @07.65700s +00.00000s
+|`->config-landscape ran successfully @07.65800s +00.00100s
+|`->config-lxd ran successfully @07.65900s +00.00100s
+|`->config-ubuntu-drivers ran successfully @07.66000s +00.00100s
+|`->config-puppet ran successfully @07.66200s +00.00000s
+|`->config-chef ran successfully @07.66300s +00.00100s
+|`->config-mcollective ran successfully @07.66400s +00.00100s
+|`->config-salt-minion ran successfully @07.66500s +00.00100s
+|`->config-rightscale_userdata ran successfully @07.66600s +00.00100s
+|`->config-scripts-vendor ran successfully @07.66800s +00.00000s
+|`->config-scripts-per-once ran successfully @07.66900s +00.00100s
+|`->config-scripts-per-boot ran successfully @07.67000s +00.00000s
+|`->config-scripts-per-instance ran successfully @07.67100s +00.00100s
+|`->config-scripts-user ran successfully @07.67200s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @07.67300s +00.08900s
+|`->config-keys-to-console ran successfully @07.76300s +00.10200s
+|`->config-phone-home ran successfully @07.86600s +00.00100s
+|`->config-final-message ran successfully @07.86800s +00.00400s
+|`->config-power-state-change ran successfully @07.87300s +00.00100s
+Finished stage: (modules-final) 00.23800 seconds
+
+Total Time: 6.26400 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cloud-init analyze blame
+-- Boot Record 01 --
+     00.90000s (modules-config/config-ssh-import-id)
+     00.49500s (modules-config/config-grub-dpkg)
+     00.38300s (init-network/config-ssh)
+     00.22400s (modules-config/config-apt-configure)
+     00.18600s (init-network/config-disk_setup)
+     00.18400s (azure-ds/obtain-dhcp-lease)
+     00.17500s (azure-ds/list_possible_azure_ds_devs)
+     00.12400s (init-network/config-mounts)
+     00.10200s (modules-final/config-keys-to-console)
+     00.08900s (modules-final/config-ssh-authkey-fingerprints)
+     00.08800s (azure-ds/_has_ntfs_filesystem)
+     00.06500s (init-network/config-users-groups)
+     00.04200s (init-network/config-growpart)
+     00.03000s (azure-ds/generate_certificate)
+     00.02400s (azure-ds/_load_dhclient_json)
+     00.01900s (init-network/check-cache)
+     00.01800s (azure-ds/parse_network_config)
+     00.01800s (azure-ds/parse_network_config)
+     00.01700s (azure-ds/_decrypt_certs_from_xml)
+     00.01500s (init-network/config-resizefs)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.00900s (azure-ds/get_boot_telemetry)
+     00.00600s (init-network/consume-user-data)
+     00.00600s (init-network/config-set_hostname)
+     00.00600s (azure-ds/check-platform-viability)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_report_ready)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00200s (modules-config/config-set-passwords)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (azure-ds/write_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-locale)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/_get_random_seed)
+     00.00100s (azure-ds/_extract_preprovisioned_vm_setting)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-fan)
+     00.00000s (modules-config/config-timezone)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (azure-ds/_get_value_from_leases_file)
+     00.00000s (azure-ds/_get_value_from_dhcpoptions)
+
+1 boot records analyzed
++ echo After upgrade write network config: upgrade-network.out
+After upgrade write network config: upgrade-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- cat /etc/network/interfaces.d/50-cloud-init.cfg
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.36.167.25 -- grep DHCP /var/log/syslog
++ echo ------- Diff previous-network to post-upgrade-network ------
+------- Diff previous-network to post-upgrade-network ------
++ diff -urN previous-network.out upgrade-network.out
+--- previous-network.out	2020-06-18 18:36:01.824734350 +0000
++++ upgrade-network.out	2020-06-18 18:37:40.862284064 +0000
+@@ -40,3 +40,14 @@
+ Jun 18 18:35:15 SRU-worked-azure ifup[910]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
+ Jun 18 18:35:15 SRU-worked-azure dhclient[1006]: DHCPACK of 10.0.0.4 from 168.63.129.16
+ Jun 18 18:35:15 SRU-worked-azure ifup[910]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 18 18:36:54 SRU-worked-azure dhclient[895]: Internet Systems Consortium DHCP Client 4.3.3
++Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x38ad7c27)
++Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x277cad38)
++Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
++Jun 18 18:36:54 SRU-worked-azure dhclient[895]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: Internet Systems Consortium DHCP Client 4.3.3
++Jun 18 18:36:54 SRU-worked-azure ifup[942]: Internet Systems Consortium DHCP Client 4.3.3
++Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x701d9f8)
++Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x701d9f8)
++Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPACK of 10.0.0.4 from 168.63.129.16
++ SRU_VARS=./sru-scripts/sru-vars.template
++ [ ! -f ./sru-scripts/sru-vars.template ]
++ . ./sru-scripts/sru-vars.template
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=UNSET
++ PROPOSED_SCRIPT=setup_proposed.sh
++ USE_DEV_PPA=0
++ SAMPLE_CLOUDCONFIG=sethostname.yaml
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=UNSET
++ AZURE_VNET_NAME=UNSET
++ AZURE_NETWORK_SECURITY_GROUP=UNSET
++ AZURE_NIC_NAME=UNSET
++ AZURE_RESOURCE_GROUP=UNSET
++ AZURE_BOOT_DIAG=UNSET
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ SRU_VARS_RC=.sru-vars.rc
++ [ -f .sru-vars.rc ]
++ [ -f /root/.sru-vars.rc ]
++ . /root/.sru-vars.rc
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=chad.smith
++ USE_DEV_PPA=0
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=eastus2
++ AZURE_VNET_NAME=sruVnet
++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++ AZURE_NIC_NAME=sruNic
++ AZURE_RESOURCE_GROUP=srugroupIPV6
++ AZURE_BOOT_DIAG=storeitsru
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ parse_args ./sru-scripts/manual/azure-sru bionic
++ script=./sru-scripts/manual/azure-sru
++ shift
++ [ 1 = 0 ]
++ [ 1 -ne 0 ]
++ UBUNTU_RELEASE=bionic
++ shift
++ [ 0 -ne 0 ]
++ [ -z bionic ]
++ assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
++ local value=
++ eval value=$PROPOSED_SCRIPT > /dev/null
++ value=setup_proposed.sh
++ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
++ eval value=$AZURE_REGION > /dev/null
++ value=eastus2
++ [ -z eastus2 -o eastus2 = UNSET ]
++ eval value=$AZURE_VNET_NAME > /dev/null
++ value=sruVnet
++ [ -z sruVnet -o sruVnet = UNSET ]
++ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
++ value=sruNetSecGroup
++ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
++ eval value=$AZURE_NIC_NAME > /dev/null
++ value=sruNic
++ [ -z sruNic -o sruNic = UNSET ]
++ eval value=$AZURE_RESOURCE_GROUP > /dev/null
++ value=srugroupIPV6
++ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
++ eval value=$AZURE_BOOT_DIAG > /dev/null
++ value=storeitsru
++ [ -z storeitsru -o storeitsru = UNSET ]
++ eval value=$SSH_KEY > /dev/null
++ value=/root/.ssh/id_rsa.pub
++ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
++ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
++ value=sethostname.yaml
++ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
++ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
++ value=true
++ [ -z true -o true = UNSET ]
++ create_samplecloudconfig
++ filename=sethostname.yaml
++ cat
++ create_setup_proposed_script
++ [ 0 -eq 0 ]
++ cat
++ AZURE_VNET_NAME=sruVnet-bionic
++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_NET_REGISTERED=Registered
++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_CA_LB_REGISTERED=Registered
++ [ Registered != Registered -o Registered != Registered ]
++ az provider show -n Microsoft.Network
++ jq -r .registrationState
++ IPV6_REGISTRATION_COMPLETE=Registered
++ echo Waiting for Microsoft.Network IPv6 feature registration
+Waiting for Microsoft.Network IPv6 feature registration
++ [ Registered != Registered ]
++ echo ### BEGIN bionic
+### BEGIN bionic
++ az group show -g srugroupIPV6
++ [ -n storeitsru ]
++ az storage account show --name storeitsru
++ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ az network nsg show --name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network vnet show --name sruVnet-bionic -g srugroupIPV6
++ az network vnet create --resource-group srugroupIPV6 --location eastus2 --name sruVnet-bionic --address-prefixes 10.0.0.0/16 ace:cab:deca::/48
+{
+  "newVNet": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16",
+        "ace:cab:deca::/48"
+      ]
+    },
+    "ddosProtectionPlan": null,
+    "dhcpOptions": {
+      "dnsServers": []
+    },
+    "enableDdosProtection": false,
+    "enableVmProtection": false,
+    "etag": "W/\"d22a4b86-116c-46f8-8c55-3d80b205b2bd\"",
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-bionic",
+    "location": "eastus2",
+    "name": "sruVnet-bionic",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": "ed2059fb-2027-4c24-9fe6-4cd46c86e9db",
+    "subnets": [],
+    "tags": {},
+    "type": "Microsoft.Network/virtualNetworks",
+    "virtualNetworkPeerings": []
+  }
+}
++ az network vnet subnet show --name sruSubnet --vnet-name sruVnet-bionic -g srugroupIPV6
++ az network vnet subnet create --name sruSubnet --resource-group srugroupIPV6 --vnet-name sruVnet-bionic --address-prefixes 10.0.0.0/24 ace:cab:deca:deed::/64 --network-security-group sruNetSecGroup
+{
+  "addressPrefix": null,
+  "addressPrefixes": [
+    "10.0.0.0/24",
+    "ace:cab:deca:deed::/64"
+  ],
+  "delegations": [],
+  "etag": "W/\"9d3479ad-eef6-4e82-b793-7e2a39aa4667\"",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-bionic/subnets/sruSubnet",
+  "ipConfigurationProfiles": null,
+  "ipConfigurations": null,
+  "name": "sruSubnet",
+  "natGateway": null,
+  "networkSecurityGroup": {
+    "defaultSecurityRules": null,
+    "etag": null,
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
+    "location": null,
+    "name": null,
+    "networkInterfaces": null,
+    "provisioningState": null,
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": null,
+    "securityRules": null,
+    "subnets": null,
+    "tags": null,
+    "type": null
+  },
+  "privateEndpointNetworkPolicies": "Enabled",
+  "privateEndpoints": null,
+  "privateLinkServiceNetworkPolicies": "Enabled",
+  "provisioningState": "Succeeded",
+  "purpose": null,
+  "resourceGroup": "srugroupIPV6",
+  "resourceNavigationLinks": null,
+  "routeTable": null,
+  "serviceAssociationLinks": null,
+  "serviceEndpointPolicies": null,
+  "serviceEndpoints": null,
+  "type": "Microsoft.Network/virtualNetworks/subnets"
+}
++ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ netcfg=/etc/netplan/50-cloud-init.yaml
++ image_version=Canonical:UbuntuServer:18.04-DAILY-LTS
++ [  =  ]
++ echo Creating standard network vm
+Creating standard network vm
++ name=test-sru-bionic
++ az vm show --name test-sru-bionic -g srugroupIPV6
++ az vm create --name=test-sru-bionic --image=Canonical:UbuntuServer:18.04-DAILY-LTS:latest --admin-username=root --admin-username=ubuntu -g srugroupIPV6 --ssh-key-value /root/.ssh/id_rsa.pub --boot-diagnostics-storage storeitsru --custom-data sethostname.yaml
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-bionic",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-7A-71-1B",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.4",
+  "publicIpAddress": "20.186.104.66",
+  "resourceGroup": "srugroupIPV6",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-bionic
++ jq -r+  .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
+awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@20.186.104.66
++ echo Created test-sru-bionic: ubuntu@ubuntu@20.186.104.66
+Created test-sru-bionic: ubuntu@ubuntu@20.186.104.66
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init status --wait --long
+
+status: done
+time: Thu, 18 Jun 2020 18:40:11 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~18.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/dev/sr0]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- systemd-analyze
+Startup finished in 7.664s (kernel) + 32.061s (userspace) = 39.726s
+graphical.target reached after 31.144s in userspace
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- systemd-analyze blame
+          9.773s cloud-init.service
+          5.598s cloud-init-local.service
+          4.236s cloud-config.service
+          2.135s dev-sda1.device
+          1.957s pollinate.service
+          1.821s lxd-containers.service
+          1.792s systemd-networkd-wait-online.service
+          1.776s snapd.seeded.service
+          1.689s snapd.service
+          1.444s apparmor.service
+           918ms cloud-final.service
+           824ms networkd-dispatcher.service
+           822ms accounts-daemon.service
+           722ms grub-common.service
+           671ms apport.service
+           458ms systemd-timesyncd.service
+           440ms systemd-modules-load.service
+           366ms keyboard-setup.service
+           361ms lvm2-monitor.service
+           348ms systemd-udev-trigger.service
+           317ms polkit.service
+           302ms rsyslog.service
+           282ms systemd-logind.service
+           260ms dev-mqueue.mount
+           254ms kmod-static-nodes.service
+           249ms ufw.service
+           230ms ebtables.service
+           228ms dev-hugepages.mount
+           228ms systemd-remount-fs.service
+           226ms systemd-journald.service
+           193ms systemd-journal-flush.service
+           182ms systemd-tmpfiles-setup-dev.service
+           180ms sys-kernel-debug.mount
+           173ms systemd-networkd.service
+           149ms systemd-sysctl.service
+           137ms snapd.socket
+           128ms setvtrgb.service
+           124ms systemd-udevd.service
+           123ms lxd.socket
+           113ms systemd-machine-id-commit.service
+           111ms console-setup.service
+           102ms systemd-tmpfiles-setup.service
+           101ms ssh.service
+           101ms systemd-user-sessions.service
+            90ms systemd-resolved.service
+            83ms plymouth-read-write.service
+            72ms blk-availability.service
+            46ms plymouth-quit.service
+            43ms user@1000.service
+            38ms sys-fs-fuse-connections.mount
+            37ms systemd-random-seed.service
+            37ms ephemeral-disk-warning.service
+            36ms sys-kernel-config.mount
+            33ms systemd-update-utmp.service
+            29ms boot-efi.mount
+            21ms systemd-update-utmp-runlevel.service
+            16ms plymouth-quit-wait.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00100s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.15000s +00.01000s
+|`->get_boot_telemetry @00.16000s +00.01500s
+|`->get_system_info @00.17500s +00.00100s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.17600s +00.04500s
+|`->load_azure_ds_dir @00.22200s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.34800s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.34900s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00800 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01300 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.39100s +00.42100s
+|`->_get_metadata_from_imds @00.81200s +00.02000s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.46500 seconds
+
+|`->_get_random_seed @00.85600s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.69000 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.86700s +00.00000s
+|`->write_files @00.86800s +00.01000s
+Finished stage: (azure-ds/_get_data) 00.72800 seconds
+
+Finished stage: (init-local/search-Azure) 00.73100 seconds
+
+|`->network config from imds @00.94200s +00.00100s
+Finished stage: (init-local) 01.16900 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.71700s +00.03400s
+|`->network config from imds @03.79800s +00.00000s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.80800s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.81300s +00.15700s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @03.97100s +00.00000s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @04.00300s +00.01400s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @04.01800s +00.00600s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.13200 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @04.15100s +00.00700s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00900 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.15600 seconds
+
+|`->_report_ready @04.15900s +02.75500s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 03.10200 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 03.10200 seconds
+
+Finished stage: (azure-ds/_negotiate) 03.10700 seconds
+
+Finished stage: (azure-ds/setup) 03.10700 seconds
+
+Finished stage: (init-network/setup-datasource) 03.10800 seconds
+
+|`->reading and applying user-data @06.93100s +00.00800s
+|`->reading and applying vendor-data @06.93900s +00.00100s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @06.97800s +00.00100s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @06.97900s +00.16200s
+Starting stage: azure-ds/mount-ntfs-and-count
+|`->count_files @07.25400s +00.00500s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.13200 seconds
+
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.29400 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.29600 seconds
+
+Finished stage: (azure-ds/activate) 00.29600 seconds
+
+Finished stage: (init-network/activate-datasource) 00.30200 seconds
+
+|`->config-migrator ran successfully @07.32800s +00.00100s
+|`->config-seed_random ran successfully @07.33000s +00.00100s
+|`->config-bootcmd ran successfully @07.33100s +00.00100s
+|`->config-write-files ran successfully @07.33200s +00.00100s
+|`->config-growpart ran successfully @07.33300s +00.59900s
+|`->config-resizefs ran successfully @07.93300s +01.69600s
+|`->config-disk_setup ran successfully @09.63000s +02.49900s
+|`->config-mounts ran successfully @12.13000s +00.19700s
+|`->config-set_hostname ran successfully @12.32800s +00.00800s
+|`->config-update_hostname ran successfully @12.33700s +00.00100s
+|`->config-update_etc_hosts ran successfully @12.33800s +00.00100s
+|`->config-ca-certs ran successfully @12.33900s +00.00100s
+|`->config-rsyslog ran successfully @12.34000s +00.00100s
+|`->config-users-groups ran successfully @12.34200s +00.29000s
+|`->config-ssh ran successfully @12.63200s +00.25300s
+Finished stage: (init-network) 09.18700 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @18.16800s +00.00000s
+|`->config-snap ran successfully @18.16900s +00.00100s
+|`->config-ssh-import-id ran successfully @18.17000s +01.12000s
+|`->config-locale ran successfully @19.29700s +00.00200s
+|`->config-set-passwords ran successfully @19.30000s +00.00100s
+|`->config-grub-dpkg ran successfully @19.30100s +01.95100s
+|`->config-apt-pipelining ran successfully @21.25300s +00.00100s
+|`->config-apt-configure ran successfully @21.25500s +00.25100s
+|`->config-ubuntu-advantage ran successfully @21.50700s +00.00100s
+|`->config-ntp ran successfully @21.50900s +00.00000s
+|`->config-timezone ran successfully @21.51000s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @21.51100s +00.00100s
+|`->config-runcmd ran successfully @21.51200s +00.00100s
+|`->config-byobu ran successfully @21.51400s +00.00100s
+Finished stage: (modules-config) 03.40300 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @22.26600s +00.00100s
+|`->config-fan ran successfully @22.26700s +00.00100s
+|`->config-landscape ran successfully @22.26900s +00.00000s
+|`->config-lxd ran successfully @22.27000s +00.00100s
+|`->config-ubuntu-drivers ran successfully @22.27100s +00.00100s
+|`->config-puppet ran successfully @22.27200s +00.00100s
+|`->config-chef ran successfully @22.27300s +00.00100s
+|`->config-mcollective ran successfully @22.27400s +00.00100s
+|`->config-salt-minion ran successfully @22.27500s +00.00100s
+|`->config-rightscale_userdata ran successfully @22.27700s +00.00000s
+|`->config-scripts-vendor ran successfully @22.27800s +00.00000s
+|`->config-scripts-per-once ran successfully @22.27900s +00.00100s
+|`->config-scripts-per-boot ran successfully @22.28000s +00.00000s
+|`->config-scripts-per-instance ran successfully @22.28100s +00.00100s
+|`->config-scripts-user ran successfully @22.28200s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @22.28300s +00.02700s
+|`->config-keys-to-console ran successfully @22.31500s +00.11400s
+|`->config-phone-home ran successfully @22.43100s +00.00500s
+|`->config-final-message ran successfully @22.47500s +00.00500s
+|`->config-power-state-change ran successfully @22.48000s +00.00100s
+Finished stage: (modules-final) 00.23500 seconds
+
+Total Time: 33.77700 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze blame
+-- Boot Record 01 --
+     02.75500s (azure-ds/_report_ready)
+     02.49900s (init-network/config-disk_setup)
+     01.95100s (modules-config/config-grub-dpkg)
+     01.69600s (init-network/config-resizefs)
+     01.12000s (modules-config/config-ssh-import-id)
+     00.59900s (init-network/config-growpart)
+     00.42100s (azure-ds/obtain-dhcp-lease)
+     00.29000s (init-network/config-users-groups)
+     00.25300s (init-network/config-ssh)
+     00.25100s (modules-config/config-apt-configure)
+     00.19700s (init-network/config-mounts)
+     00.16200s (azure-ds/_has_ntfs_filesystem)
+     00.15700s (azure-ds/generate_certificate)
+     00.11400s (modules-final/config-keys-to-console)
+     00.04500s (azure-ds/list_possible_azure_ds_devs)
+     00.03400s (init-network/check-cache)
+     00.02700s (modules-final/config-ssh-authkey-fingerprints)
+     00.02000s (azure-ds/_get_metadata_from_imds)
+     00.01500s (azure-ds/get_boot_telemetry)
+     00.01400s (azure-ds/_decrypt_certs_from_xml)
+     00.01000s (azure-ds/write_files)
+     00.01000s (azure-ds/check-platform-viability)
+     00.00800s (init-network/consume-user-data)
+     00.00800s (init-network/config-set_hostname)
+     00.00700s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00500s (modules-final/config-phone-home)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (azure-ds/count_files)
+     00.00200s (modules-config/config-locale)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/consume-vendor-data)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/wait-for-ephemeral-disk)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/get_system_info)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo Writing networking config: previous-network.out
+Writing networking config: previous-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@20.186.104.66:.
+PROPOSED_SCRIPT                               100%  196     3.5KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo bash PROPOSED_SCRIPT
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu bionic-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~18.04.1 [422 kB]
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~18.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) over (19.4-33-gbb4131a2-0ubuntu1~18.04.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- dpkg-query --show cloud-init
+cloud-init	20.2-45-g5f7825e2-0ubuntu1~18.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo cloud-init clean --logs --reboot
+Connection to 20.186.104.66 closed by remote host.
++ true
++ sleep 60
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init status --wait --long
+
+status: done
+time: Thu, 18 Jun 2020 18:41:53 +0000
+detail:
+DataSourceAzure [seed=/var/lib/waagent]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- sudo systemd-analyze blame
+          2.888s cloud-config.service
+          2.303s cloud-init.service
+          1.803s dev-sda1.device
+          1.737s cloud-init-local.service
+          1.539s systemd-networkd-wait-online.service
+          1.182s snapd.service
+          1.051s networkd-dispatcher.service
+          1.000s lxd-containers.service
+           876ms cloud-final.service
+           632ms apparmor.service
+           600ms systemd-udev-trigger.service
+           510ms accounts-daemon.service
+           461ms systemd-timesyncd.service
+           426ms systemd-modules-load.service
+           424ms keyboard-setup.service
+           424ms grub-common.service
+           418ms apport.service
+           385ms systemd-journald.service
+           342ms systemd-logind.service
+           297ms ssh.service
+           276ms rsyslog.service
+           275ms lxd.socket
+           274ms snapd.socket
+           265ms polkit.service
+           254ms lvm2-monitor.service
+           157ms systemd-journal-flush.service
+           153ms systemd-remount-fs.service
+           153ms kmod-static-nodes.service
+           152ms dev-mqueue.mount
+           147ms ufw.service
+           143ms sys-kernel-debug.mount
+           123ms ebtables.service
+           113ms dev-hugepages.mount
+            99ms systemd-udevd.service
+            97ms systemd-sysctl.service
+            94ms systemd-tmpfiles-setup.service
+            82ms ephemeral-disk-warning.service
+            76ms systemd-resolved.service
+            73ms blk-availability.service
+            68ms sys-fs-fuse-connections.mount
+            68ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+            66ms snapd.seeded.service
+            56ms systemd-user-sessions.service
+            52ms systemd-tmpfiles-setup-dev.service
+            46ms setvtrgb.service
+            46ms systemd-networkd.service
+            45ms systemd-update-utmp.service
+            44ms user@1000.service
+            40ms sys-kernel-config.mount
+            39ms plymouth-quit.service
+            34ms systemd-update-utmp-runlevel.service
+            34ms plymouth-quit-wait.service
+            28ms systemd-random-seed.service
+            24ms plymouth-read-write.service
+            19ms boot-efi.mount
+            18ms console-setup.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00100s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.03300s +00.00900s
+|`->get_boot_telemetry @00.04200s +00.01600s
+|`->get_system_info @00.05800s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.05800s +00.18200s
+|`->load_azure_ds_dir @00.24100s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.24500s +00.00100s
+|`->_extract_preprovisioned_vm_setting @00.24600s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00500 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.26600s +00.29000s
+|`->_get_metadata_from_imds @00.55700s +00.01100s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.32600 seconds
+
+|`->_get_random_seed @00.59200s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.54300 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.60200s +00.00000s
+|`->write_files @00.60200s +00.00300s
+Finished stage: (azure-ds/_get_data) 00.57200 seconds
+
+Finished stage: (init-local/search-Azure) 00.57500 seconds
+
+|`->network config from imds @00.66200s +00.00000s
+Finished stage: (init-local) 00.87800 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.10200s +00.01800s
+|`->network config from imds @03.16800s +00.00000s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.17900s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.18300s +00.08100s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @03.26500s +00.00000s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @03.28900s +00.01400s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @03.30400s +00.00700s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04100 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @03.34500s +00.00800s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00800 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.06500 seconds
+
+|`->_report_ready @03.35400s +00.01900s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.19000 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.19100 seconds
+
+Finished stage: (azure-ds/_negotiate) 00.19500 seconds
+
+Finished stage: (azure-ds/setup) 00.19600 seconds
+
+Finished stage: (init-network/setup-datasource) 00.19700 seconds
+
+|`->reading and applying user-data @03.38300s +00.01000s
+|`->reading and applying vendor-data @03.39300s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @03.44500s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @03.44600s +00.16600s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.16700 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.16800 seconds
+
+Finished stage: (azure-ds/activate) 00.16900 seconds
+
+Finished stage: (init-network/activate-datasource) 00.17100 seconds
+
+|`->config-migrator ran successfully @03.66900s +00.00100s
+|`->config-seed_random ran successfully @03.67100s +00.02900s
+|`->config-bootcmd ran successfully @03.70100s +00.00400s
+|`->config-write-files ran successfully @03.70500s +00.00100s
+|`->config-growpart ran successfully @03.70600s +00.24700s
+|`->config-resizefs ran successfully @03.95400s +00.02900s
+|`->config-disk_setup ran successfully @03.98300s +00.19000s
+|`->config-mounts ran successfully @04.17400s +00.19600s
+|`->config-set_hostname ran successfully @04.37100s +00.00800s
+|`->config-update_hostname ran successfully @04.37900s +00.00200s
+|`->config-update_etc_hosts ran successfully @04.38100s +00.00000s
+|`->config-ca-certs ran successfully @04.38200s +00.00100s
+|`->config-rsyslog ran successfully @04.38300s +00.00100s
+|`->config-users-groups ran successfully @04.38400s +00.19600s
+|`->config-ssh ran successfully @04.58100s +00.18400s
+Finished stage: (init-network) 01.68000 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @08.05400s +00.00400s
+|`->config-snap ran successfully @08.05900s +00.00100s
+|`->config-ssh-import-id ran successfully @08.06000s +00.98900s
+|`->config-locale ran successfully @09.05000s +00.01900s
+|`->config-set-passwords ran successfully @09.06900s +00.00100s
+|`->config-grub-dpkg ran successfully @09.08500s +00.45300s
+|`->config-apt-pipelining ran successfully @09.53900s +00.00200s
+|`->config-apt-configure ran successfully @09.54100s +00.13900s
+|`->config-ubuntu-advantage ran successfully @09.68100s +00.00100s
+|`->config-ntp ran successfully @09.68200s +00.00100s
+|`->config-timezone ran successfully @09.68300s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @09.68400s +00.00100s
+|`->config-runcmd ran successfully @09.68500s +00.00100s
+|`->config-byobu ran successfully @09.68600s +00.00100s
+Finished stage: (modules-config) 01.66500 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @10.46100s +00.00100s
+|`->config-fan ran successfully @10.46200s +00.00100s
+|`->config-landscape ran successfully @10.46300s +00.00100s
+|`->config-lxd ran successfully @10.46500s +00.00000s
+|`->config-ubuntu-drivers ran successfully @10.46600s +00.00100s
+|`->config-puppet ran successfully @10.46700s +00.00100s
+|`->config-chef ran successfully @10.46800s +00.00100s
+|`->config-mcollective ran successfully @10.46900s +00.00100s
+|`->config-salt-minion ran successfully @10.47000s +00.00100s
+|`->config-rightscale_userdata ran successfully @10.47200s +00.00000s
+|`->config-scripts-vendor ran successfully @10.47300s +00.00100s
+|`->config-scripts-per-once ran successfully @10.47400s +00.00100s
+|`->config-scripts-per-boot ran successfully @10.47500s +00.00100s
+|`->config-scripts-per-instance ran successfully @10.47600s +00.00100s
+|`->config-scripts-user ran successfully @10.47800s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @10.47900s +00.08800s
+|`->config-keys-to-console ran successfully @10.56700s +00.10900s
+|`->config-phone-home ran successfully @10.67700s +00.00100s
+|`->config-final-message ran successfully @10.67900s +00.00500s
+|`->config-power-state-change ran successfully @10.68400s +00.00200s
+Finished stage: (modules-final) 00.24900 seconds
+
+Total Time: 8.26000 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cloud-init analyze blame
+-- Boot Record 01 --
+     00.98900s (modules-config/config-ssh-import-id)
+     00.45300s (modules-config/config-grub-dpkg)
+     00.29000s (azure-ds/obtain-dhcp-lease)
+     00.24700s (init-network/config-growpart)
+     00.19600s (init-network/config-users-groups)
+     00.19600s (init-network/config-mounts)
+     00.19000s (init-network/config-disk_setup)
+     00.18400s (init-network/config-ssh)
+     00.18200s (azure-ds/list_possible_azure_ds_devs)
+     00.16600s (azure-ds/_has_ntfs_filesystem)
+     00.13900s (modules-config/config-apt-configure)
+     00.10900s (modules-final/config-keys-to-console)
+     00.08800s (modules-final/config-ssh-authkey-fingerprints)
+     00.08100s (azure-ds/generate_certificate)
+     00.02900s (init-network/config-seed_random)
+     00.02900s (init-network/config-resizefs)
+     00.01900s (modules-config/config-locale)
+     00.01900s (azure-ds/_report_ready)
+     00.01800s (init-network/check-cache)
+     00.01600s (azure-ds/get_boot_telemetry)
+     00.01400s (azure-ds/_decrypt_certs_from_xml)
+     00.01100s (azure-ds/_get_metadata_from_imds)
+     00.01000s (init-network/consume-user-data)
+     00.00900s (azure-ds/check-platform-viability)
+     00.00800s (init-network/config-set_hostname)
+     00.00800s (azure-ds/_run_x509_action)
+     00.00700s (azure-ds/_run_x509_action)
+     00.00500s (modules-final/config-final-message)
+     00.00400s (modules-config/config-emit_upstart)
+     00.00400s (init-network/config-bootcmd)
+     00.00300s (azure-ds/write_files)
+     00.00200s (modules-final/config-power-state-change)
+     00.00200s (modules-config/config-apt-pipelining)
+     00.00200s (init-network/config-update_hostname)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-local/check-cache)
+     00.00100s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo After upgrade write network config: upgrade-network.out
+After upgrade write network config: upgrade-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@20.186.104.66 -- grep DHCP /var/log/syslog
++ echo ------- Diff previous-network to post-upgrade-network ------
+------- Diff previous-network to post-upgrade-network ------
++ diff -urN previous-network.out upgrade-network.out
+--- previous-network.out	2020-06-18 18:40:47.485188739 +0000
++++ upgrade-network.out	2020-06-18 18:42:33.870829153 +0000
+@@ -38,3 +38,9 @@
+ Jun 18 18:40:03 SRU-worked-azure dhclient[810]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
+ Jun 18 18:40:03 SRU-worked-azure dhclient[810]: DHCPACK of 10.0.0.4 from 168.63.129.16
+ Jun 18 18:40:03 SRU-worked-azure systemd-networkd[846]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
++Jun 18 18:41:48 SRU-worked-azure dhclient[821]: Internet Systems Consortium DHCP Client 4.3.5
++Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0x8f23af27)
++Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x27af238f)
++Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
++Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPACK of 10.0.0.4 from 168.63.129.16
++Jun 18 18:41:48 SRU-worked-azure systemd-networkd[856]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
++ SRU_VARS=./sru-scripts/sru-vars.template
++ [ ! -f ./sru-scripts/sru-vars.template ]
++ . ./sru-scripts/sru-vars.template
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=UNSET
++ PROPOSED_SCRIPT=setup_proposed.sh
++ USE_DEV_PPA=0
++ SAMPLE_CLOUDCONFIG=sethostname.yaml
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=UNSET
++ AZURE_VNET_NAME=UNSET
++ AZURE_NETWORK_SECURITY_GROUP=UNSET
++ AZURE_NIC_NAME=UNSET
++ AZURE_RESOURCE_GROUP=UNSET
++ AZURE_BOOT_DIAG=UNSET
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ SRU_VARS_RC=.sru-vars.rc
++ [ -f .sru-vars.rc ]
++ [ -f /root/.sru-vars.rc ]
++ . /root/.sru-vars.rc
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=chad.smith
++ USE_DEV_PPA=0
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=eastus2
++ AZURE_VNET_NAME=sruVnet
++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++ AZURE_NIC_NAME=sruNic
++ AZURE_RESOURCE_GROUP=srugroupIPV6
++ AZURE_BOOT_DIAG=storeitsru
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ parse_args ./sru-scripts/manual/azure-sru eoan
++ script=./sru-scripts/manual/azure-sru
++ shift
++ [ 1 = 0 ]
++ [ 1 -ne 0 ]
++ UBUNTU_RELEASE=eoan
++ shift
++ [ 0 -ne 0 ]
++ [ -z eoan ]
++ assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
++ local value=
++ eval value=$PROPOSED_SCRIPT > /dev/null
++ value=setup_proposed.sh
++ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
++ eval value=$AZURE_REGION > /dev/null
++ value=eastus2
++ [ -z eastus2 -o eastus2 = UNSET ]
++ eval value=$AZURE_VNET_NAME > /dev/null
++ value=sruVnet
++ [ -z sruVnet -o sruVnet = UNSET ]
++ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
++ value=sruNetSecGroup
++ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
++ eval value=$AZURE_NIC_NAME > /dev/null
++ value=sruNic
++ [ -z sruNic -o sruNic = UNSET ]
++ eval value=$AZURE_RESOURCE_GROUP > /dev/null
++ value=srugroupIPV6
++ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
++ eval value=$AZURE_BOOT_DIAG > /dev/null
++ value=storeitsru
++ [ -z storeitsru -o storeitsru = UNSET ]
++ eval value=$SSH_KEY > /dev/null
++ value=/root/.ssh/id_rsa.pub
++ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
++ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
++ value=sethostname.yaml
++ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
++ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
++ value=true
++ [ -z true -o true = UNSET ]
++ create_samplecloudconfig
++ filename=sethostname.yaml
++ cat
++ create_setup_proposed_script
++ [ 0 -eq 0 ]
++ cat
++ AZURE_VNET_NAME=sruVnet-eoan
++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_NET_REGISTERED=Registered
++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_CA_LB_REGISTERED=Registered
++ [ Registered != Registered -o Registered != Registered ]
++ az provider show -n Microsoft.Network
++ jq -r .registrationState
++ IPV6_REGISTRATION_COMPLETE=Registered
++ echo Waiting for Microsoft.Network IPv6 feature registration
+Waiting for Microsoft.Network IPv6 feature registration
++ [ Registered != Registered ]
++ echo ### BEGIN eoan
+### BEGIN eoan
++ az group show -g srugroupIPV6
++ [ -n storeitsru ]
++ az storage account show --name storeitsru
++ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ az network nsg show --name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network vnet show --name sruVnet-eoan -g srugroupIPV6
++ az network vnet create --resource-group srugroupIPV6 --location eastus2 --name sruVnet-eoan --address-prefixes 10.0.0.0/16 ace:cab:deca::/48
+{
+  "newVNet": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16",
+        "ace:cab:deca::/48"
+      ]
+    },
+    "ddosProtectionPlan": null,
+    "dhcpOptions": {
+      "dnsServers": []
+    },
+    "enableDdosProtection": false,
+    "enableVmProtection": false,
+    "etag": "W/\"be5cca5e-5e74-4a28-9cce-8123226baa7b\"",
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-eoan",
+    "location": "eastus2",
+    "name": "sruVnet-eoan",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": "a34e9b15-469c-49aa-805a-4334611ae2fa",
+    "subnets": [],
+    "tags": {},
+    "type": "Microsoft.Network/virtualNetworks",
+    "virtualNetworkPeerings": []
+  }
+}
++ az network vnet subnet show --name sruSubnet --vnet-name sruVnet-eoan -g srugroupIPV6
++ az network vnet subnet create --name sruSubnet --resource-group srugroupIPV6 --vnet-name sruVnet-eoan --address-prefixes 10.0.0.0/24 ace:cab:deca:deed::/64 --network-security-group sruNetSecGroup
+{
+  "addressPrefix": null,
+  "addressPrefixes": [
+    "10.0.0.0/24",
+    "ace:cab:deca:deed::/64"
+  ],
+  "delegations": [],
+  "etag": "W/\"2fca82f3-c951-4958-80fd-867bf44132c7\"",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-eoan/subnets/sruSubnet",
+  "ipConfigurationProfiles": null,
+  "ipConfigurations": null,
+  "name": "sruSubnet",
+  "natGateway": null,
+  "networkSecurityGroup": {
+    "defaultSecurityRules": null,
+    "etag": null,
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
+    "location": null,
+    "name": null,
+    "networkInterfaces": null,
+    "provisioningState": null,
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": null,
+    "securityRules": null,
+    "subnets": null,
+    "tags": null,
+    "type": null
+  },
+  "privateEndpointNetworkPolicies": "Enabled",
+  "privateEndpoints": null,
+  "privateLinkServiceNetworkPolicies": "Enabled",
+  "provisioningState": "Succeeded",
+  "purpose": null,
+  "resourceGroup": "srugroupIPV6",
+  "resourceNavigationLinks": null,
+  "routeTable": null,
+  "serviceAssociationLinks": null,
+  "serviceEndpointPolicies": null,
+  "serviceEndpoints": null,
+  "type": "Microsoft.Network/virtualNetworks/subnets"
+}
++ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ netcfg=/etc/netplan/50-cloud-init.yaml
++ image_version=Canonical:UbuntuServer:19.10-DAILY
++ [  =  ]
++ echo Creating standard network vm
+Creating standard network vm
++ name=test-sru-eoan
++ az vm show --name test-sru-eoan -g srugroupIPV6
++ az vm create --name=test-sru-eoan --image=Canonical:UbuntuServer:19.10-DAILY:latest --admin-username=root --admin-username=ubuntu -g srugroupIPV6 --ssh-key-value /root/.ssh/id_rsa.pub --boot-diagnostics-storage storeitsru --custom-data sethostname.yaml
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-eoan",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-00-25-59",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.5",
+  "publicIpAddress": "52.254.87.225",
+  "resourceGroup": "srugroupIPV6",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-eoan
++ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
++ awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@52.254.87.225
++ echo Created test-sru-eoan: ubuntu@ubuntu@52.254.87.225
+Created test-sru-eoan: ubuntu@ubuntu@52.254.87.225
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init status --wait --long
+..........................................................................
+status: done
+time: Thu, 18 Jun 2020 18:44:38 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- dpkg-query --show cloud-init
+cloud-init	19.4-33-gbb4131a2-0ubuntu1~19.10.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/dev/sr0]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- systemd-analyze
+Startup finished in 3.543s (kernel) + 57.231s (userspace) = 1min 775ms 
+graphical.target reached after 56.462s in userspace
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- systemd-analyze blame
+         26.851s snapd.seeded.service
+         11.450s cloud-init.service
+          4.846s cloud-init-local.service
+          2.897s lvm2-monitor.service
+          2.639s dev-sda1.device
+          2.490s cloud-config.service
+          2.414s systemd-udev-settle.service
+          2.374s pollinate.service
+          1.543s systemd-networkd-wait-online.service
+          1.214s snapd.service
+          1.189s systemd-logind.service
+          1.091s accounts-daemon.service
+           872ms rsyslog.service
+           781ms networkd-dispatcher.service
+           775ms apparmor.service
+           772ms cloud-final.service
+           709ms apport.service
+           704ms grub-common.service
+           516ms systemd-journald.service
+           515ms systemd-networkd.service
+           503ms systemd-resolved.service
+           434ms user@1000.service
+           430ms snap.lxd.activate.service
+           411ms systemd-udev-trigger.service
+           356ms systemd-udevd.service
+           342ms chrony.service
+           337ms atd.service
+           274ms keyboard-setup.service
+           238ms sys-kernel-debug.mount
+           238ms systemd-modules-load.service
+           235ms blk-availability.service
+           230ms systemd-remount-fs.service
+           223ms dev-hugepages.mount
+           221ms ufw.service
+           209ms grub-initrd-fallback.service
+           204ms multipathd.service
+           195ms systemd-user-sessions.service
+           176ms kmod-static-nodes.service
+           174ms systemd-sysusers.service
+           169ms dev-mqueue.mount
+           166ms plymouth-quit-wait.service
+           161ms systemd-journal-flush.service
+           153ms polkit.service
+           147ms plymouth-quit.service
+           116ms sys-fs-fuse-connections.mount
+           112ms plymouth-read-write.service
+           110ms sys-kernel-config.mount
+           110ms systemd-tmpfiles-setup.service
+           108ms finalrd.service
+           102ms systemd-machine-id-commit.service
+           102ms ssh.service
+            99ms systemd-sysctl.service
+            97ms console-setup.service
+            93ms setvtrgb.service
+            81ms snapd.socket
+            71ms systemd-random-seed.service
+            52ms systemd-tmpfiles-setup-dev.service
+            47ms snap-snapd-7777.mount
+            42ms snap-core18-1754.mount
+            40ms user-runtime-dir@1000.service
+            37ms snap-lxd-15457.mount
+            37ms systemd-update-utmp-runlevel.service
+            35ms dev-loop2.device
+            31ms dev-loop0.device
+            30ms ephemeral-disk-warning.service
+            30ms systemd-update-utmp.service
+            30ms boot-efi.mount
+            23ms dev-loop1.device
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00300s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.14100s +00.00900s
+|`->get_boot_telemetry @00.15000s +00.06800s
+|`->get_system_info @00.21800s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.21800s +00.05600s
+|`->load_azure_ds_dir @00.27400s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.38700s +00.00100s
+|`->_extract_preprovisioned_vm_setting @00.38800s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00300 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01100 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.42200s +00.38900s
+|`->_get_metadata_from_imds @00.81100s +00.08800s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.50200 seconds
+
+|`->_get_random_seed @00.92300s +00.00100s
+Finished stage: (azure-ds/crawl_metadata) 00.71400 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.93200s +00.00100s
+|`->write_files @00.93300s +00.01000s
+Finished stage: (azure-ds/_get_data) 00.80200 seconds
+
+Finished stage: (init-local/search-Azure) 00.80400 seconds
+
+|`->network config from imds @01.00700s +00.00000s
+Finished stage: (init-local) 01.26100 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.84200s +00.02100s
+|`->network config from imds @03.91900s +00.00000s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.92800s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.93200s +00.28500s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @04.21700s +00.00100s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @04.24000s +00.01300s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @04.25300s +00.00600s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.04700 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @04.30000s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00700 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.06700 seconds
+
+|`->_report_ready @04.30700s +02.55600s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 02.93300 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 02.93300 seconds
+
+Finished stage: (azure-ds/_negotiate) 02.93700 seconds
+
+Finished stage: (azure-ds/setup) 02.93800 seconds
+
+Finished stage: (init-network/setup-datasource) 02.93800 seconds
+
+|`->reading and applying user-data @06.87700s +00.00700s
+|`->reading and applying vendor-data @06.88400s +00.00100s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @06.91900s +00.00100s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @06.92000s +00.13700s
+Starting stage: azure-ds/mount-ntfs-and-count
+|`->count_files @07.14000s +00.00100s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.09600 seconds
+
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.23300 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.23500 seconds
+
+Finished stage: (azure-ds/activate) 00.23500 seconds
+
+Finished stage: (init-network/activate-datasource) 00.23600 seconds
+
+|`->config-migrator ran successfully @07.23500s +00.00100s
+|`->config-seed_random ran successfully @07.23600s +00.00100s
+|`->config-bootcmd ran successfully @07.23800s +00.00000s
+|`->config-write-files ran successfully @07.23800s +00.00100s
+|`->config-growpart ran successfully @07.23900s +00.72300s
+|`->config-resizefs ran successfully @07.96200s +02.69800s
+|`->config-disk_setup ran successfully @10.66000s +02.51800s
+|`->config-mounts ran successfully @13.18100s +00.26300s
+|`->config-set_hostname ran successfully @13.44400s +00.00700s
+|`->config-update_hostname ran successfully @13.45100s +00.00100s
+|`->config-update_etc_hosts ran successfully @13.45300s +00.00000s
+|`->config-ca-certs ran successfully @13.45400s +00.00000s
+|`->config-rsyslog ran successfully @13.45500s +00.00000s
+|`->config-users-groups ran successfully @13.45600s +00.84800s
+|`->config-ssh ran successfully @14.30500s +00.49000s
+Finished stage: (init-network) 10.96700 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @44.99700s +00.00000s
+|`->config-snap ran successfully @44.99800s +00.00000s
+|`->config-ssh-import-id ran successfully @44.99900s +00.83700s
+|`->config-locale ran successfully @45.83600s +00.00200s
+|`->config-set-passwords ran successfully @45.83800s +00.00100s
+|`->config-grub-dpkg ran successfully @45.83900s +00.97200s
+|`->config-apt-pipelining ran successfully @46.81200s +00.00100s
+|`->config-apt-configure ran successfully @46.81300s +00.12700s
+|`->config-ubuntu-advantage ran successfully @46.94100s +00.00100s
+|`->config-ntp ran successfully @46.94200s +00.00100s
+|`->config-timezone ran successfully @46.94300s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @46.94400s +00.00100s
+|`->config-runcmd ran successfully @46.94500s +00.00100s
+|`->config-byobu ran successfully @46.94600s +00.00100s
+Finished stage: (modules-config) 01.99800 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @47.59600s +00.00100s
+|`->config-fan ran successfully @47.59700s +00.00100s
+|`->config-landscape ran successfully @47.59800s +00.00100s
+|`->config-lxd ran successfully @47.59900s +00.00100s
+|`->config-ubuntu-drivers ran successfully @47.60100s +00.00000s
+|`->config-puppet ran successfully @47.60200s +00.00000s
+|`->config-chef ran successfully @47.60300s +00.00000s
+|`->config-mcollective ran successfully @47.60400s +00.00000s
+|`->config-salt-minion ran successfully @47.60500s +00.00000s
+|`->config-rightscale_userdata ran successfully @47.60600s +00.00100s
+|`->config-scripts-vendor ran successfully @47.60700s +00.00100s
+|`->config-scripts-per-once ran successfully @47.60800s +00.00100s
+|`->config-scripts-per-boot ran successfully @47.60900s +00.00000s
+|`->config-scripts-per-instance ran successfully @47.61000s +00.00000s
+|`->config-scripts-user ran successfully @47.61100s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @47.61200s +00.05500s
+|`->config-keys-to-console ran successfully @47.66700s +00.11000s
+|`->config-phone-home ran successfully @47.77700s +00.00100s
+|`->config-final-message ran successfully @47.77900s +00.00400s
+|`->config-power-state-change ran successfully @47.78300s +00.00100s
+Finished stage: (modules-final) 00.21600 seconds
+
+Total Time: 33.11700 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze blame
+-- Boot Record 01 --
+     02.69800s (init-network/config-resizefs)
+     02.55600s (azure-ds/_report_ready)
+     02.51800s (init-network/config-disk_setup)
+     00.97200s (modules-config/config-grub-dpkg)
+     00.84800s (init-network/config-users-groups)
+     00.83700s (modules-config/config-ssh-import-id)
+     00.72300s (init-network/config-growpart)
+     00.49000s (init-network/config-ssh)
+     00.38900s (azure-ds/obtain-dhcp-lease)
+     00.28500s (azure-ds/generate_certificate)
+     00.26300s (init-network/config-mounts)
+     00.13700s (azure-ds/_has_ntfs_filesystem)
+     00.12700s (modules-config/config-apt-configure)
+     00.11000s (modules-final/config-keys-to-console)
+     00.08800s (azure-ds/_get_metadata_from_imds)
+     00.06800s (azure-ds/get_boot_telemetry)
+     00.05600s (azure-ds/list_possible_azure_ds_devs)
+     00.05500s (modules-final/config-ssh-authkey-fingerprints)
+     00.02100s (init-network/check-cache)
+     00.01300s (azure-ds/_decrypt_certs_from_xml)
+     00.01000s (azure-ds/write_files)
+     00.00900s (azure-ds/check-platform-viability)
+     00.00700s (init-network/consume-user-data)
+     00.00700s (init-network/config-set_hostname)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00200s (modules-config/config-locale)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/consume-vendor-data)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-migrator)
+     00.00100s (azure-ds/wait-for-ephemeral-disk)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00100s (azure-ds/load_azure_ovf_pubkeys)
+     00.00100s (azure-ds/count_files)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00100s (azure-ds/_get_random_seed)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-instance)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-snap)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo Writing networking config: previous-network.out
+Writing networking config: previous-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@52.254.87.225:.
+PROPOSED_SCRIPT                               100%  196     2.9KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo bash PROPOSED_SCRIPT
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu eoan-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~19.10.1 [420 kB]
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~19.10.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) over (19.4-33-gbb4131a2-0ubuntu1~19.10.1) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~19.10.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- dpkg-query --show cloud-init
+cloud-init	20.2-45-g5f7825e2-0ubuntu1~19.10.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo cloud-init clean --logs --reboot
+Connection to 52.254.87.225 closed by remote host.
++ true
++ sleep 60
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init status --wait --long
+
+status: done
+time: Thu, 18 Jun 2020 18:45:55 +0000
+detail:
+DataSourceAzure [seed=/var/lib/waagent]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- sudo systemd-analyze blame
+          3.178s snapd.service
+          2.743s snap.lxd.activate.service
+          2.625s cloud-init.service
+          2.171s lvm2-monitor.service
+          2.049s dev-sda1.device
+          1.943s systemd-logind.service
+          1.870s systemd-networkd-wait-online.service
+          1.754s cloud-config.service
+          1.677s systemd-udev-settle.service
+          1.640s accounts-daemon.service
+          1.553s cloud-init-local.service
+          1.439s rsyslog.service
+          1.416s grub-common.service
+          1.300s apport.service
+          1.020s systemd-user-sessions.service
+           971ms grub-initrd-fallback.service
+           838ms networkd-dispatcher.service
+           815ms cloud-final.service
+           768ms atd.service
+           649ms systemd-journald.service
+           377ms systemd-networkd.service
+           365ms ssh.service
+           359ms systemd-resolved.service
+           349ms chrony.service
+           335ms systemd-udev-trigger.service
+           334ms systemd-remount-fs.service
+           329ms dev-mqueue.mount
+           329ms ufw.service
+           325ms keyboard-setup.service
+           322ms kmod-static-nodes.service
+           316ms sys-kernel-debug.mount
+           304ms dev-hugepages.mount
+           300ms systemd-modules-load.service
+           217ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+           216ms polkit.service
+           199ms apparmor.service
+           194ms systemd-journal-flush.service
+           161ms snapd.socket
+           132ms systemd-tmpfiles-setup.service
+           121ms console-setup.service
+           120ms sys-kernel-config.mount
+           120ms systemd-sysctl.service
+           119ms sys-fs-fuse-connections.mount
+           118ms plymouth-read-write.service
+           116ms finalrd.service
+           106ms systemd-random-seed.service
+           103ms boot-efi.mount
+           102ms snap-core18-1754.mount
+           101ms user@1000.service
+            98ms systemd-sysusers.service
+            94ms snap-lxd-15457.mount
+            88ms plymouth-quit-wait.service
+            87ms ephemeral-disk-warning.service
+            84ms setvtrgb.service
+            81ms snap-snapd-7777.mount
+            78ms snapd.seeded.service
+            69ms plymouth-quit.service
+            67ms multipathd.service
+            55ms dev-loop0.device
+            54ms systemd-udevd.service
+            54ms dev-loop1.device
+            52ms dev-loop2.device
+            47ms systemd-update-utmp.service
+            34ms blk-availability.service
+            34ms systemd-tmpfiles-setup-dev.service
+            19ms user-runtime-dir@1000.service
+            16ms systemd-update-utmp-runlevel.service
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.04600s +00.00800s
+|`->get_boot_telemetry @00.05400s +00.01600s
+|`->get_system_info @00.07100s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.07100s +00.20000s
+|`->load_azure_ds_dir @00.27100s +00.00100s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.27500s +00.00100s
+|`->_extract_preprovisioned_vm_setting @00.27600s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00300 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00400 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.29600s +00.34500s
+|`->_get_metadata_from_imds @00.64100s +00.00900s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.37300 seconds
+
+|`->_get_random_seed @00.67000s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.60800 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.67900s +00.00100s
+|`->write_files @00.68000s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.63700 seconds
+
+Finished stage: (init-local/search-Azure) 00.64000 seconds
+
+|`->network config from imds @00.73300s +00.00100s
+Finished stage: (init-local) 00.84100 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.61200s +00.03200s
+|`->network config from imds @03.68500s +00.00100s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.69500s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.69900s +00.13800s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @03.83700s +00.00100s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @03.86000s +00.01200s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @03.87300s +00.00500s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.01200 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @03.88500s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.03100 seconds
+
+|`->_report_ready @03.89100s +00.00600s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.19800 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.19900 seconds
+
+Finished stage: (azure-ds/_negotiate) 00.20300 seconds
+
+Finished stage: (azure-ds/setup) 00.20400 seconds
+
+Finished stage: (init-network/setup-datasource) 00.20400 seconds
+
+|`->reading and applying user-data @03.90400s +00.00700s
+|`->reading and applying vendor-data @03.91100s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @03.94600s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @03.94700s +00.15100s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.15300 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.15300 seconds
+
+Finished stage: (azure-ds/activate) 00.15300 seconds
+
+Finished stage: (init-network/activate-datasource) 00.15500 seconds
+
+|`->config-migrator ran successfully @04.13900s +00.00100s
+|`->config-seed_random ran successfully @04.14000s +00.00400s
+|`->config-bootcmd ran successfully @04.14400s +00.00100s
+|`->config-write-files ran successfully @04.14500s +00.00700s
+|`->config-growpart ran successfully @04.15200s +00.11200s
+|`->config-resizefs ran successfully @04.26500s +00.15100s
+|`->config-disk_setup ran successfully @04.41700s +00.71000s
+|`->config-mounts ran successfully @05.12800s +00.25000s
+|`->config-set_hostname ran successfully @05.37800s +00.00700s
+|`->config-update_hostname ran successfully @05.38500s +00.00200s
+|`->config-update_etc_hosts ran successfully @05.38700s +00.00000s
+|`->config-ca-certs ran successfully @05.38800s +00.00000s
+|`->config-rsyslog ran successfully @05.38900s +00.00000s
+|`->config-users-groups ran successfully @05.39000s +00.06600s
+|`->config-ssh ran successfully @05.45700s +00.26400s
+Finished stage: (init-network) 02.12800 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @11.11300s +00.00000s
+|`->config-snap ran successfully @11.11400s +00.00000s
+|`->config-ssh-import-id ran successfully @11.11500s +00.75500s
+|`->config-locale ran successfully @11.87100s +00.00600s
+|`->config-set-passwords ran successfully @11.87700s +00.00100s
+|`->config-grub-dpkg ran successfully @11.87900s +00.30800s
+|`->config-apt-pipelining ran successfully @12.18800s +00.00100s
+|`->config-apt-configure ran successfully @12.18900s +00.12000s
+|`->config-ubuntu-advantage ran successfully @12.31000s +00.00100s
+|`->config-ntp ran successfully @12.31100s +00.00100s
+|`->config-timezone ran successfully @12.31200s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @12.31300s +00.00100s
+|`->config-runcmd ran successfully @12.31400s +00.00100s
+|`->config-byobu ran successfully @12.31500s +00.00100s
+Finished stage: (modules-config) 01.21900 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @12.98100s +00.00100s
+|`->config-fan ran successfully @12.98200s +00.00100s
+|`->config-landscape ran successfully @12.98300s +00.00100s
+|`->config-lxd ran successfully @12.98400s +00.00100s
+|`->config-ubuntu-drivers ran successfully @12.98500s +00.00100s
+|`->config-puppet ran successfully @12.98600s +00.00100s
+|`->config-chef ran successfully @12.98700s +00.00100s
+|`->config-mcollective ran successfully @12.98800s +00.00100s
+|`->config-salt-minion ran successfully @12.98900s +00.00100s
+|`->config-rightscale_userdata ran successfully @12.99000s +00.00100s
+|`->config-scripts-vendor ran successfully @12.99100s +00.00100s
+|`->config-scripts-per-once ran successfully @12.99200s +00.00100s
+|`->config-scripts-per-boot ran successfully @12.99300s +00.00100s
+|`->config-scripts-per-instance ran successfully @12.99400s +00.00100s
+|`->config-scripts-user ran successfully @12.99500s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @12.99600s +00.08600s
+|`->config-keys-to-console ran successfully @13.08200s +00.11400s
+|`->config-phone-home ran successfully @13.19700s +00.00100s
+|`->config-final-message ran successfully @13.19900s +00.00400s
+|`->config-power-state-change ran successfully @13.20300s +00.00100s
+Finished stage: (modules-final) 00.23900 seconds
+
+Total Time: 8.36800 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cloud-init analyze blame
+-- Boot Record 01 --
+     00.75500s (modules-config/config-ssh-import-id)
+     00.71000s (init-network/config-disk_setup)
+     00.34500s (azure-ds/obtain-dhcp-lease)
+     00.30800s (modules-config/config-grub-dpkg)
+     00.26400s (init-network/config-ssh)
+     00.25000s (init-network/config-mounts)
+     00.20000s (azure-ds/list_possible_azure_ds_devs)
+     00.15100s (init-network/config-resizefs)
+     00.15100s (azure-ds/_has_ntfs_filesystem)
+     00.13800s (azure-ds/generate_certificate)
+     00.12000s (modules-config/config-apt-configure)
+     00.11400s (modules-final/config-keys-to-console)
+     00.11200s (init-network/config-growpart)
+     00.08600s (modules-final/config-ssh-authkey-fingerprints)
+     00.06600s (init-network/config-users-groups)
+     00.03200s (init-network/check-cache)
+     00.01600s (azure-ds/get_boot_telemetry)
+     00.01200s (azure-ds/_decrypt_certs_from_xml)
+     00.00900s (azure-ds/_get_metadata_from_imds)
+     00.00800s (azure-ds/check-platform-viability)
+     00.00700s (init-network/consume-user-data)
+     00.00700s (init-network/config-write-files)
+     00.00700s (init-network/config-set_hostname)
+     00.00600s (modules-config/config-locale)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_report_ready)
+     00.00500s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (init-network/config-seed_random)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (azure-ds/write_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00100s (azure-ds/load_azure_ovf_pubkeys)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (modules-config/config-snap)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo After upgrade write network config: upgrade-network.out
+After upgrade write network config: upgrade-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.254.87.225 -- grep DHCP /var/log/syslog
++ echo ------- Diff previous-network to post-upgrade-network ------
+------- Diff previous-network to post-upgrade-network ------
++ diff -urN previous-network.out upgrade-network.out
+--- previous-network.out	2020-06-18 18:44:52.444953133 +0000
++++ upgrade-network.out	2020-06-18 18:46:32.902485798 +0000
+@@ -38,3 +38,9 @@
+ Jun 18 18:44:07 SRU-worked-azure dhclient[496]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x5d57032b)
+ Jun 18 18:44:07 SRU-worked-azure dhclient[496]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0x2b03575d)
+ Jun 18 18:44:07 SRU-worked-azure systemd-networkd[521]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
++Jun 18 18:45:50 SRU-worked-azure dhclient[518]: Internet Systems Consortium DHCP Client 4.4.1
++Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xe60a9272)
++Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPOFFER of 10.0.0.5 from 168.63.129.16
++Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x72920ae6)
++Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0xe60a9272)
++Jun 18 18:45:50 SRU-worked-azure systemd-networkd[543]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
++ SRU_VARS=./sru-scripts/sru-vars.template
++ [ ! -f ./sru-scripts/sru-vars.template ]
++ . ./sru-scripts/sru-vars.template
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=UNSET
++ PROPOSED_SCRIPT=setup_proposed.sh
++ USE_DEV_PPA=0
++ SAMPLE_CLOUDCONFIG=sethostname.yaml
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=UNSET
++ AZURE_VNET_NAME=UNSET
++ AZURE_NETWORK_SECURITY_GROUP=UNSET
++ AZURE_NIC_NAME=UNSET
++ AZURE_RESOURCE_GROUP=UNSET
++ AZURE_BOOT_DIAG=UNSET
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ SRU_VARS_RC=.sru-vars.rc
++ [ -f .sru-vars.rc ]
++ [ -f /root/.sru-vars.rc ]
++ . /root/.sru-vars.rc
++ PRESERVE_INSTANCE=false
++ UBUNTU_RELEASE=
++ LP_USER=chad.smith
++ USE_DEV_PPA=0
++ SSH_KEY=/root/.ssh/id_rsa.pub
++ AZURE_REGION=eastus2
++ AZURE_VNET_NAME=sruVnet
++ AZURE_NETWORK_SECURITY_GROUP=sruNetSecGroup
++ AZURE_NIC_NAME=sruNic
++ AZURE_RESOURCE_GROUP=srugroupIPV6
++ AZURE_BOOT_DIAG=storeitsru
++ AZURE_ADVANCED_NIC_TESTS=true
++ GCE_ZONE=UNSET
++ OPENSTACK_ADMIN_NET_ID=UNSET
++ OPENSTACK_SSH_KEY_NAME=UNSET
++ VMWARE_PASSWORD=UNSET
++ parse_args ./sru-scripts/manual/azure-sru focal
++ script=./sru-scripts/manual/azure-sru
++ shift
++ [ 1 = 0 ]
++ [ 1 -ne 0 ]
++ UBUNTU_RELEASE=focal
++ shift
++ [ 0 -ne 0 ]
++ [ -z focal ]
++ assert_expected_vars PROPOSED_SCRIPT AZURE_REGION AZURE_VNET_NAME AZURE_NETWORK_SECURITY_GROUP AZURE_NIC_NAME AZURE_RESOURCE_GROUP AZURE_BOOT_DIAG SSH_KEY SAMPLE_CLOUDCONFIG AZURE_ADVANCED_NIC_TESTS
++ local value=
++ eval value=$PROPOSED_SCRIPT > /dev/null
++ value=setup_proposed.sh
++ [ -z setup_proposed.sh -o setup_proposed.sh = UNSET ]
++ eval value=$AZURE_REGION > /dev/null
++ value=eastus2
++ [ -z eastus2 -o eastus2 = UNSET ]
++ eval value=$AZURE_VNET_NAME > /dev/null
++ value=sruVnet
++ [ -z sruVnet -o sruVnet = UNSET ]
++ eval value=$AZURE_NETWORK_SECURITY_GROUP > /dev/null
++ value=sruNetSecGroup
++ [ -z sruNetSecGroup -o sruNetSecGroup = UNSET ]
++ eval value=$AZURE_NIC_NAME > /dev/null
++ value=sruNic
++ [ -z sruNic -o sruNic = UNSET ]
++ eval value=$AZURE_RESOURCE_GROUP > /dev/null
++ value=srugroupIPV6
++ [ -z srugroupIPV6 -o srugroupIPV6 = UNSET ]
++ eval value=$AZURE_BOOT_DIAG > /dev/null
++ value=storeitsru
++ [ -z storeitsru -o storeitsru = UNSET ]
++ eval value=$SSH_KEY > /dev/null
++ value=/root/.ssh/id_rsa.pub
++ [ -z /root/.ssh/id_rsa.pub -o /root/.ssh/id_rsa.pub = UNSET ]
++ eval value=$SAMPLE_CLOUDCONFIG > /dev/null
++ value=sethostname.yaml
++ [ -z sethostname.yaml -o sethostname.yaml = UNSET ]
++ eval value=$AZURE_ADVANCED_NIC_TESTS > /dev/null
++ value=true
++ [ -z true -o true = UNSET ]
++ create_samplecloudconfig
++ filename=sethostname.yaml
++ cat
++ create_setup_proposed_script
++ [ 0 -eq 0 ]
++ cat
++ AZURE_VNET_NAME=sruVnet-focal
++ az feature show --name AllowIPv6VirtualNetwork --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_NET_REGISTERED=Registered
++ az feature show --name AllowIPv6CAOnStandardLB --namespace Microsoft.Network
++ jq -r .properties.state
++ IPV6_CA_LB_REGISTERED=Registered
++ [ Registered != Registered -o Registered != Registered ]
++ az provider show -n Microsoft.Network
++ jq -r .registrationState
++ IPV6_REGISTRATION_COMPLETE=Registered
++ echo Waiting for Microsoft.Network IPv6 feature registration
+Waiting for Microsoft.Network IPv6 feature registration
++ [ Registered != Registered ]
++ echo ### BEGIN focal
+### BEGIN focal
++ az group show -g srugroupIPV6
++ [ -n storeitsru ]
++ az storage account show --name storeitsru
++ AZURE_BOOT_DIAG_ARG=--boot-diagnostics-storage storeitsru
++ az network nsg show --name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowSSHIn --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network nsg rule show --name allowAllOut --nsg-name sruNetSecGroup -g srugroupIPV6
++ az network vnet show --name sruVnet-focal -g srugroupIPV6
++ az network vnet create --resource-group srugroupIPV6 --location eastus2 --name sruVnet-focal --address-prefixes 10.0.0.0/16 ace:cab:deca::/48
+{
+  "newVNet": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16",
+        "ace:cab:deca::/48"
+      ]
+    },
+    "ddosProtectionPlan": null,
+    "dhcpOptions": {
+      "dnsServers": []
+    },
+    "enableDdosProtection": false,
+    "enableVmProtection": false,
+    "etag": "W/\"ac7ca4c7-c905-4d56-9081-751583dc13e5\"",
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-focal",
+    "location": "eastus2",
+    "name": "sruVnet-focal",
+    "provisioningState": "Succeeded",
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": "f5a27459-e965-40c7-b86d-9c2575c21fd6",
+    "subnets": [],
+    "tags": {},
+    "type": "Microsoft.Network/virtualNetworks",
+    "virtualNetworkPeerings": []
+  }
+}
++ az network vnet subnet show --name sruSubnet --vnet-name sruVnet-focal -g srugroupIPV6
++ az network vnet subnet create --name sruSubnet --resource-group srugroupIPV6 --vnet-name sruVnet-focal --address-prefixes 10.0.0.0/24 ace:cab:deca:deed::/64 --network-security-group sruNetSecGroup
+{
+  "addressPrefix": null,
+  "addressPrefixes": [
+    "10.0.0.0/24",
+    "ace:cab:deca:deed::/64"
+  ],
+  "delegations": [],
+  "etag": "W/\"a2439f1e-f303-4b45-aae8-19d9ae0ce1c0\"",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/virtualNetworks/sruVnet-focal/subnets/sruSubnet",
+  "ipConfigurationProfiles": null,
+  "ipConfigurations": null,
+  "name": "sruSubnet",
+  "natGateway": null,
+  "networkSecurityGroup": {
+    "defaultSecurityRules": null,
+    "etag": null,
+    "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Network/networkSecurityGroups/sruNetSecGroup",
+    "location": null,
+    "name": null,
+    "networkInterfaces": null,
+    "provisioningState": null,
+    "resourceGroup": "srugroupIPV6",
+    "resourceGuid": null,
+    "securityRules": null,
+    "subnets": null,
+    "tags": null,
+    "type": null
+  },
+  "privateEndpointNetworkPolicies": "Enabled",
+  "privateEndpoints": null,
+  "privateLinkServiceNetworkPolicies": "Enabled",
+  "provisioningState": "Succeeded",
+  "purpose": null,
+  "resourceGroup": "srugroupIPV6",
+  "resourceNavigationLinks": null,
+  "routeTable": null,
+  "serviceAssociationLinks": null,
+  "serviceEndpointPolicies": null,
+  "serviceEndpoints": null,
+  "type": "Microsoft.Network/virtualNetworks/subnets"
+}
++ sshopts=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
++ netcfg=/etc/netplan/50-cloud-init.yaml
++ image_version=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts
++ [  =  ]
++ echo Creating standard network vm
+Creating standard network vm
++ name=test-sru-focal
++ az vm show --name test-sru-focal -g srugroupIPV6
++ az vm create --name=test-sru-focal --image=Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts:latest --admin-username=root --admin-username=ubuntu -g srugroupIPV6 --ssh-key-value /root/.ssh/id_rsa.pub --boot-diagnostics-storage storeitsru --custom-data sethostname.yaml
+{
+  "fqdns": "",
+  "id": "/subscriptions/12aad61c-6de4-4e53-a6c6-5aff52a83777/resourceGroups/srugroupIPV6/providers/Microsoft.Compute/virtualMachines/test-sru-focal",
+  "location": "eastus2",
+  "macAddress": "00-0D-3A-00-2A-A9",
+  "powerState": "VM running",
+  "privateIpAddress": "10.0.0.6",
+  "publicIpAddress": "52.252.115.168",
+  "resourceGroup": "srugroupIPV6",
+  "zones": ""
+}
++ az vm list-ip-addresses --name test-sru-focal
++ jq -r .[] | .virtualMachine.network.publicIpAddresses[].ipAddress
++ awk {printf "ubuntu@%s", $1}
++ IP=ubuntu@52.252.115.168
++ echo Created test-sru-focal: ubuntu@ubuntu@52.252.115.168
+Created test-sru-focal: ubuntu@ubuntu@52.252.115.168
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init status --wait --long
+..........................................................................................
+status: done
+time: Thu, 18 Jun 2020 18:48:44 +0000
+detail:
+DataSourceAzure [seed=/dev/sr0]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- dpkg-query --show cloud-init
+cloud-init	20.1-10-g71af48df-0ubuntu5
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/dev/sr0]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- systemd-analyze
+Startup finished in 4.490s (kernel) + 59.785s (userspace) = 1min 4.275s 
+graphical.target reached after 58.788s in userspace
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- systemd-analyze blame
+24.803s snapd.seeded.service                
+10.534s cloud-init.service                  
+ 7.675s cloud-init-local.service            
+ 3.785s lvm2-monitor.service                
+ 3.263s dev-sda1.device                     
+ 2.788s systemd-udev-settle.service         
+ 2.732s cloud-config.service                
+ 2.197s accounts-daemon.service             
+ 1.836s pollinate.service                   
+ 1.268s systemd-logind.service              
+ 1.160s networkd-dispatcher.service         
+ 1.128s grub-common.service                 
+ 1.105s apparmor.service                    
+ 1.063s systemd-networkd-wait-online.service
+ 1.001s apport.service                      
+  938ms systemd-journald.service            
+  936ms snapd.service                       
+  872ms cloud-final.service                 
+  801ms chrony.service                      
+  772ms sys-kernel-tracing.mount            
+  766ms sys-kernel-debug.mount              
+  753ms dev-mqueue.mount                    
+  748ms dev-hugepages.mount                 
+  681ms atd.service                         
+  645ms systemd-resolved.service            
+  642ms kmod-static-nodes.service           
+  639ms keyboard-setup.service              
+  622ms grub-initrd-fallback.service        
+  615ms systemd-udev-trigger.service        
+  568ms systemd-udevd.service               
+  539ms modprobe@drm.service                
+  517ms snap.lxd.activate.service           
+  513ms e2scrub_reap.service                
+  484ms systemd-modules-load.service        
+  484ms user@1000.service                   
+  464ms systemd-remount-fs.service          
+  456ms rsyslog.service                     
+  455ms systemd-networkd.service            
+  390ms ufw.service                         
+  257ms console-setup.service               
+  253ms plymouth-read-write.service         
+  249ms finalrd.service                     
+  243ms systemd-sysusers.service            
+  240ms multipathd.service                  
+  238ms systemd-machine-id-commit.service   
+  222ms polkit.service                      
+  212ms systemd-user-sessions.service       
+  201ms sys-kernel-config.mount             
+  191ms systemd-journal-flush.service       
+  189ms systemd-random-seed.service         
+  159ms systemd-sysctl.service              
+  158ms ssh.service                         
+  130ms systemd-tmpfiles-setup.service      
+  121ms sys-fs-fuse-connections.mount       
+   99ms snapd.socket                        
+   96ms plymouth-quit-wait.service          
+   92ms plymouth-quit.service               
+   58ms snapd.apparmor.service              
+   58ms dev-loop2.device                    
+   58ms systemd-tmpfiles-setup-dev.service  
+   50ms dev-loop0.device                    
+   47ms systemd-update-utmp-runlevel.service
+   43ms snap-snapd-7777.mount               
+   42ms ephemeral-disk-warning.service      
+   37ms blk-availability.service            
+   32ms snap-lxd-15457.mount                
+   31ms systemd-update-utmp.service         
+   31ms snap-core18-1754.mount              
+   30ms user-runtime-dir@1000.service       
+   29ms boot-efi.mount                      
+   25ms setvtrgb.service                    
+   22ms dev-loop1.device                    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.29100s +00.01200s
+|`->get_boot_telemetry @00.30300s +00.12600s
+|`->get_system_info @00.42900s +00.00100s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.43000s +00.08700s
+|`->load_azure_ds_dir @00.51800s +00.00000s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.68700s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.68800s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.01300 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.01800 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.72100s +00.47100s
+|`->_get_metadata_from_imds @01.19200s +00.01600s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.51600 seconds
+
+|`->_get_random_seed @01.23800s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.82200 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @01.25200s +00.00100s
+|`->write_files @01.25400s +00.00800s
+Finished stage: (azure-ds/_get_data) 00.97100 seconds
+
+Finished stage: (init-local/search-Azure) 00.97500 seconds
+
+|`->network config from imds @01.32600s +00.00000s
+Finished stage: (init-local) 01.87400 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/dev/sr0] @03.91900s +00.03600s
+|`->network config from imds @04.01000s +00.00000s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @04.01900s +00.00100s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00400 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @04.02400s +00.14600s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @04.17000s +00.00100s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @04.20200s +00.01400s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @04.21700s +00.00700s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.08200 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @04.30000s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00700 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.10400 seconds
+
+|`->_report_ready @04.30700s +02.96700s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 03.25000 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 03.25100 seconds
+
+Finished stage: (azure-ds/_negotiate) 03.25600 seconds
+
+Finished stage: (azure-ds/setup) 03.25600 seconds
+
+Finished stage: (init-network/setup-datasource) 03.25700 seconds
+
+|`->reading and applying user-data @07.28800s +00.00700s
+|`->reading and applying vendor-data @07.29500s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @07.33000s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @07.33000s +00.15800s
+Starting stage: azure-ds/mount-ntfs-and-count
+|`->count_files @07.60400s +00.00000s
+Finished stage: (azure-ds/mount-ntfs-and-count) 00.13300 seconds
+
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.29200 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.29200 seconds
+
+Finished stage: (azure-ds/activate) 00.29200 seconds
+
+Finished stage: (init-network/activate-datasource) 00.29400 seconds
+
+|`->config-migrator ran successfully @07.73000s +00.00000s
+|`->config-seed_random ran successfully @07.73100s +00.00100s
+|`->config-bootcmd ran successfully @07.73200s +00.00100s
+|`->config-write-files ran successfully @07.73300s +00.00100s
+|`->config-growpart ran successfully @07.73400s +00.78700s
+|`->config-resizefs ran successfully @08.52200s +01.39100s
+|`->config-disk_setup ran successfully @09.91300s +02.59400s
+|`->config-mounts ran successfully @12.51000s +00.33200s
+|`->config-set_hostname ran successfully @12.84200s +00.00900s
+|`->config-update_hostname ran successfully @12.85100s +00.00200s
+|`->config-update_etc_hosts ran successfully @12.85300s +00.00100s
+|`->config-ca-certs ran successfully @12.85400s +00.00100s
+|`->config-rsyslog ran successfully @12.85500s +00.00100s
+|`->config-users-groups ran successfully @12.85600s +00.24900s
+|`->config-ssh ran successfully @13.10600s +00.78900s
+Finished stage: (init-network) 09.99300 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @42.29700s +00.00100s
+|`->config-snap ran successfully @42.29900s +00.00100s
+|`->config-ssh-import-id ran successfully @42.30100s +01.05100s
+|`->config-locale ran successfully @43.35300s +00.00100s
+|`->config-set-passwords ran successfully @43.35400s +00.00200s
+|`->config-grub-dpkg ran successfully @43.35600s +00.86000s
+|`->config-apt-pipelining ran successfully @44.21700s +00.00100s
+|`->config-apt-configure ran successfully @44.21800s +00.17900s
+|`->config-ubuntu-advantage ran successfully @44.39800s +00.00100s
+|`->config-ntp ran successfully @44.39900s +00.00200s
+|`->config-timezone ran successfully @44.40100s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @44.40200s +00.00000s
+|`->config-runcmd ran successfully @44.40300s +00.00000s
+|`->config-byobu ran successfully @44.40400s +00.00000s
+Finished stage: (modules-config) 02.17600 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @45.13100s +00.00100s
+|`->config-fan ran successfully @45.13300s +00.00100s
+|`->config-landscape ran successfully @45.13400s +00.00100s
+|`->config-lxd ran successfully @45.13500s +00.00100s
+|`->config-ubuntu-drivers ran successfully @45.13600s +00.00100s
+|`->config-puppet ran successfully @45.13700s +00.00100s
+|`->config-chef ran successfully @45.13800s +00.00100s
+|`->config-mcollective ran successfully @45.13900s +00.00100s
+|`->config-salt-minion ran successfully @45.14000s +00.00100s
+|`->config-rightscale_userdata ran successfully @45.14100s +00.00100s
+|`->config-scripts-vendor ran successfully @45.14200s +00.00100s
+|`->config-scripts-per-once ran successfully @45.14300s +00.00100s
+|`->config-scripts-per-boot ran successfully @45.14400s +00.00000s
+|`->config-scripts-per-instance ran successfully @45.14500s +00.00000s
+|`->config-scripts-user ran successfully @45.14600s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @45.14700s +00.00900s
+|`->config-keys-to-console ran successfully @45.15700s +00.15000s
+|`->config-phone-home ran successfully @45.36000s +00.00100s
+|`->config-final-message ran successfully @45.36200s +00.00400s
+|`->config-power-state-change ran successfully @45.36600s +00.00100s
+Finished stage: (modules-final) 00.27600 seconds
+
+Total Time: 35.40500 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze blame
+-- Boot Record 01 --
+     02.96700s (azure-ds/_report_ready)
+     02.59400s (init-network/config-disk_setup)
+     01.39100s (init-network/config-resizefs)
+     01.05100s (modules-config/config-ssh-import-id)
+     00.86000s (modules-config/config-grub-dpkg)
+     00.78900s (init-network/config-ssh)
+     00.78700s (init-network/config-growpart)
+     00.47100s (azure-ds/obtain-dhcp-lease)
+     00.33200s (init-network/config-mounts)
+     00.24900s (init-network/config-users-groups)
+     00.17900s (modules-config/config-apt-configure)
+     00.15800s (azure-ds/_has_ntfs_filesystem)
+     00.15000s (modules-final/config-keys-to-console)
+     00.14600s (azure-ds/generate_certificate)
+     00.12600s (azure-ds/get_boot_telemetry)
+     00.08700s (azure-ds/list_possible_azure_ds_devs)
+     00.03600s (init-network/check-cache)
+     00.01600s (azure-ds/_get_metadata_from_imds)
+     00.01400s (azure-ds/_decrypt_certs_from_xml)
+     00.01200s (azure-ds/check-platform-viability)
+     00.00900s (modules-final/config-ssh-authkey-fingerprints)
+     00.00900s (init-network/config-set_hostname)
+     00.00800s (azure-ds/write_files)
+     00.00700s (init-network/consume-user-data)
+     00.00700s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00400s (modules-final/config-final-message)
+     00.00200s (modules-config/config-set-passwords)
+     00.00200s (modules-config/config-ntp)
+     00.00200s (init-network/config-update_hostname)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-locale)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (azure-ds/temporary_hostname)
+     00.00100s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00100s (azure-ds/get_system_info)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-instance)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/parse_network_config)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/load_azure_ds_dir)
+     00.00000s (azure-ds/count_files)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo Writing networking config: previous-network.out
+Writing networking config: previous-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- grep DHCP /var/log/syslog
++ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR PROPOSED_SCRIPT ubuntu@52.252.115.168:.
+PROPOSED_SCRIPT                               100%  196     3.3KB/s   00:00    
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo bash PROPOSED_SCRIPT
++ egrep cloud-init
+  cloud-init
+Get:1 http://archive.ubuntu.com/ubuntu focal-proposed/main amd64 cloud-init all 20.2-45-g5f7825e2-0ubuntu1~20.04.1 [416 kB]
+Preparing to unpack .../cloud-init_20.2-45-g5f7825e2-0ubuntu1~20.04.1_all.deb ...
+Unpacking cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) over (20.1-10-g71af48df-0ubuntu5) ...
+Setting up cloud-init (20.2-45-g5f7825e2-0ubuntu1~20.04.1) ...
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- dpkg-query --show cloud-init
+cloud-init	20.2-45-g5f7825e2-0ubuntu1~20.04.1
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo hostname SRU-didnt-work
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo rm -f /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo cloud-init clean --logs --reboot
+Connection to 52.252.115.168 closed by remote host.
++ true
++ sleep 60
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init status --wait --long
+
+status: done
+time: Thu, 18 Jun 2020 18:50:11 +0000
+detail:
+DataSourceAzure [seed=/var/lib/waagent]
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ! grep Trace /var/log/cloud-init.log
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo cat /run/cloud-init/result.json
+{
+ "v1": {
+  "datasource": "DataSourceAzure [seed=/var/lib/waagent]",
+  "errors": []
+ }
+}
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- sudo systemd-analyze blame
+3.710s cloud-config.service                                       
+3.464s snapd.service                                              
+3.114s snap.lxd.activate.service                                  
+2.963s accounts-daemon.service                                    
+2.857s cloud-init.service                                         
+2.726s lvm2-monitor.service                                       
+2.358s dev-sdb1.device                                            
+2.031s cloud-init-local.service                                   
+1.900s networkd-dispatcher.service                                
+1.889s apport.service                                             
+1.810s systemd-logind.service                                     
+1.753s systemd-networkd-wait-online.service                       
+1.738s grub-common.service                                        
+1.713s systemd-udev-settle.service                                
+1.096s systemd-journald.service                                   
+1.030s chrony.service                                             
+ 942ms grub-initrd-fallback.service                               
+ 848ms cloud-final.service                                        
+ 748ms systemd-udev-trigger.service                               
+ 666ms atd.service                                                
+ 657ms sys-kernel-debug.mount                                     
+ 657ms sys-kernel-tracing.mount                                   
+ 637ms keyboard-setup.service                                     
+ 623ms kmod-static-nodes.service                                  
+ 610ms dev-mqueue.mount                                           
+ 567ms systemd-resolved.service                                   
+ 563ms ssh.service                                                
+ 563ms e2scrub_reap.service                                       
+ 552ms dev-hugepages.mount                                        
+ 542ms rsyslog.service                                            
+ 535ms modprobe@drm.service                                       
+ 478ms systemd-modules-load.service                               
+ 467ms systemd-remount-fs.service                                 
+ 396ms ufw.service                                                
+ 356ms systemd-networkd.service                                   
+ 314ms systemd-fsck@dev-disk-cloud-azure_resource\x2dpart1.service
+ 253ms sys-fs-fuse-connections.mount                              
+ 243ms plymouth-quit-wait.service                                 
+ 235ms apparmor.service                                           
+ 231ms console-setup.service                                      
+ 227ms snapd.apparmor.service                                     
+ 221ms plymouth-quit.service                                      
+ 211ms sys-kernel-config.mount                                    
+ 184ms systemd-user-sessions.service                              
+ 158ms systemd-random-seed.service                                
+ 145ms systemd-sysctl.service                                     
+ 141ms user@1000.service                                          
+ 138ms finalrd.service                                            
+ 137ms setvtrgb.service                                           
+ 135ms systemd-sysusers.service                                   
+ 133ms plymouth-read-write.service                                
+ 131ms snap-core18-1754.mount                                     
+ 126ms snapd.seeded.service                                       
+ 121ms snap-lxd-15457.mount                                       
+ 118ms systemd-tmpfiles-setup.service                             
+ 118ms polkit.service                                             
+ 117ms boot-efi.mount                                             
+ 112ms snap-snapd-7777.mount                                      
+  86ms systemd-journal-flush.service                              
+  85ms multipathd.service                                         
+  67ms dev-loop0.device                                           
+  67ms dev-loop1.device                                           
+  67ms dev-loop2.device                                           
+  66ms systemd-update-utmp.service                                
+  62ms snapd.socket                                               
+  61ms systemd-tmpfiles-setup-dev.service                         
+  51ms systemd-update-utmp-runlevel.service                       
+  45ms systemd-udevd.service                                      
+  32ms blk-availability.service                                   
+  20ms user-runtime-dir@1000.service                              
+  18ms ephemeral-disk-warning.service                             
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze show
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->found azure asset tag @00.10700s +00.01200s
+|`->get_boot_telemetry @00.11900s +00.01800s
+|`->get_system_info @00.13700s +00.00000s
+Starting stage: azure-ds/crawl_metadata
+|`->list_possible_azure_ds_devs @00.13700s +00.21100s
+|`->load_azure_ds_dir @00.34800s +00.00100s
+Starting stage: azure-ds/load_azure_ds_dir
+Starting stage: azure-ds/read_azure_ovf
+|`->load_azure_ovf_pubkeys @00.35300s +00.00000s
+|`->_extract_preprovisioned_vm_setting @00.35400s +00.00000s
+Finished stage: (azure-ds/read_azure_ovf) 00.00400 seconds
+
+Finished stage: (azure-ds/load_azure_ds_dir) 00.00500 seconds
+
+Starting stage: azure-ds/get_metadata_from_imds
+|`->obtain dhcp lease @00.37600s +00.37900s
+|`->_get_metadata_from_imds @00.75600s +00.00800s
+Finished stage: (azure-ds/get_metadata_from_imds) 00.41100 seconds
+
+|`->_get_random_seed @00.78800s +00.00000s
+Finished stage: (azure-ds/crawl_metadata) 00.66400 seconds
+
+|`->maybe_remove_ubuntu_network_config_scripts @00.80100s +00.00000s
+|`->write_files @00.80200s +00.00200s
+Finished stage: (azure-ds/_get_data) 00.69700 seconds
+
+Finished stage: (init-local/search-Azure) 00.70000 seconds
+
+|`->network config from imds @00.85900s +00.00100s
+Finished stage: (init-local) 01.06800 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceAzure [seed=/var/lib/waagent] @03.78500s +00.02000s
+|`->network config from imds @03.84800s +00.00100s
+Starting stage: init-network/setup-datasource
+Starting stage: azure-ds/setup
+Starting stage: azure-ds/_negotiate
+Starting stage: azure-ds/bounce_network_with_azure_hostname
+|`->temporary_hostname @03.85800s +00.00000s
+Finished stage: (azure-ds/bounce_network_with_azure_hostname) 00.00300 seconds
+
+Starting stage: azure-ds/get_metadata_from_fabric
+Starting stage: azure-ds/register_with_azure_and_fetch_data
+|`->generate_certificate @03.86200s +00.02600s
+Starting stage: azure-ds/find_endpoint
+|`->_networkd_get_value_from_leases @03.88800s +00.00100s
+Finished stage: (azure-ds/find_endpoint) 00.00100 seconds
+
+Starting stage: azure-ds/parse_certificates
+|`->_decrypt_certs_from_xml @03.90500s +00.01300s
+Starting stage: azure-ds/_get_ssh_key_from_cert
+|`->_run_x509_action @03.91900s +00.00600s
+Finished stage: (azure-ds/_get_ssh_key_from_cert) 00.03800 seconds
+
+Starting stage: azure-ds/_get_fingerprint_from_cert
+|`->_run_x509_action @03.95600s +00.00600s
+Finished stage: (azure-ds/_get_fingerprint_from_cert) 00.00600 seconds
+
+Finished stage: (azure-ds/parse_certificates) 00.05700 seconds
+
+|`->_report_ready @03.96200s +00.00600s
+Finished stage: (azure-ds/register_with_azure_and_fetch_data) 00.10800 seconds
+
+Finished stage: (azure-ds/get_metadata_from_fabric) 00.10800 seconds
+
+Finished stage: (azure-ds/_negotiate) 00.11300 seconds
+
+Finished stage: (azure-ds/setup) 00.11300 seconds
+
+Finished stage: (init-network/setup-datasource) 00.11300 seconds
+
+|`->reading and applying user-data @03.97700s +00.00700s
+|`->reading and applying vendor-data @03.98400s +00.00000s
+Starting stage: init-network/activate-datasource
+Starting stage: azure-ds/activate
+Starting stage: azure-ds/address_ephemeral_resize
+|`->wait for ephemeral disk @04.01900s +00.00000s
+Starting stage: azure-ds/can_dev_be_reformatted
+|`->_has_ntfs_filesystem @04.02000s +00.13500s
+Finished stage: (azure-ds/can_dev_be_reformatted) 00.13600 seconds
+
+Finished stage: (azure-ds/address_ephemeral_resize) 00.13600 seconds
+
+Finished stage: (azure-ds/activate) 00.13700 seconds
+
+Finished stage: (init-network/activate-datasource) 00.13900 seconds
+
+|`->config-migrator ran successfully @04.20200s +00.00000s
+|`->config-seed_random ran successfully @04.20300s +00.00100s
+|`->config-bootcmd ran successfully @04.20400s +00.00300s
+|`->config-write-files ran successfully @04.20700s +00.00100s
+|`->config-growpart ran successfully @04.20800s +00.12200s
+|`->config-resizefs ran successfully @04.33100s +00.37400s
+|`->config-disk_setup ran successfully @04.70500s +00.75700s
+|`->config-mounts ran successfully @05.46300s +00.31900s
+|`->config-set_hostname ran successfully @05.78300s +00.00700s
+|`->config-update_hostname ran successfully @05.79000s +00.00100s
+|`->config-update_etc_hosts ran successfully @05.79200s +00.00000s
+|`->config-ca-certs ran successfully @05.79300s +00.00000s
+|`->config-rsyslog ran successfully @05.79400s +00.00100s
+|`->config-users-groups ran successfully @05.79500s +00.05800s
+|`->config-ssh ran successfully @05.85400s +00.20800s
+Finished stage: (init-network) 02.30300 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @11.92700s +00.01000s
+|`->config-snap ran successfully @11.93800s +00.00500s
+|`->config-ssh-import-id ran successfully @11.94300s +01.62000s
+|`->config-locale ran successfully @13.56300s +00.02700s
+|`->config-set-passwords ran successfully @13.59000s +00.00100s
+|`->config-grub-dpkg ran successfully @13.59200s +00.70600s
+|`->config-apt-pipelining ran successfully @14.29900s +00.00100s
+|`->config-apt-configure ran successfully @14.30000s +00.15100s
+|`->config-ubuntu-advantage ran successfully @14.45200s +00.00000s
+|`->config-ntp ran successfully @14.45500s +00.00100s
+|`->config-timezone ran successfully @14.45600s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @14.45700s +00.00100s
+|`->config-runcmd ran successfully @14.45800s +00.00100s
+|`->config-byobu ran successfully @14.45900s +00.00100s
+Finished stage: (modules-config) 02.64800 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @15.16600s +00.00000s
+|`->config-fan ran successfully @15.16700s +00.00100s
+|`->config-landscape ran successfully @15.16800s +00.00100s
+|`->config-lxd ran successfully @15.16900s +00.00100s
+|`->config-ubuntu-drivers ran successfully @15.17000s +00.00100s
+|`->config-puppet ran successfully @15.17100s +00.00100s
+|`->config-chef ran successfully @15.17200s +00.00100s
+|`->config-mcollective ran successfully @15.17400s +00.00000s
+|`->config-salt-minion ran successfully @15.17500s +00.00000s
+|`->config-rightscale_userdata ran successfully @15.17600s +00.00100s
+|`->config-scripts-vendor ran successfully @15.17700s +00.00000s
+|`->config-scripts-per-once ran successfully @15.17800s +00.00100s
+|`->config-scripts-per-boot ran successfully @15.17900s +00.00000s
+|`->config-scripts-per-instance ran successfully @15.18000s +00.00100s
+|`->config-scripts-user ran successfully @15.18100s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @15.18200s +00.10200s
+|`->config-keys-to-console ran successfully @15.28500s +00.05600s
+|`->config-phone-home ran successfully @15.34200s +00.00100s
+|`->config-final-message ran successfully @15.34300s +00.00400s
+|`->config-power-state-change ran successfully @15.34800s +00.00100s
+Finished stage: (modules-final) 00.20000 seconds
+
+Total Time: 9.90800 seconds
+
+1 boot records analyzed
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cloud-init analyze blame
+-- Boot Record 01 --
+     01.62000s (modules-config/config-ssh-import-id)
+     00.75700s (init-network/config-disk_setup)
+     00.70600s (modules-config/config-grub-dpkg)
+     00.37900s (azure-ds/obtain-dhcp-lease)
+     00.37400s (init-network/config-resizefs)
+     00.31900s (init-network/config-mounts)
+     00.21100s (azure-ds/list_possible_azure_ds_devs)
+     00.20800s (init-network/config-ssh)
+     00.15100s (modules-config/config-apt-configure)
+     00.13500s (azure-ds/_has_ntfs_filesystem)
+     00.12200s (init-network/config-growpart)
+     00.10200s (modules-final/config-ssh-authkey-fingerprints)
+     00.05800s (init-network/config-users-groups)
+     00.05600s (modules-final/config-keys-to-console)
+     00.02700s (modules-config/config-locale)
+     00.02600s (azure-ds/generate_certificate)
+     00.02000s (init-network/check-cache)
+     00.01800s (azure-ds/get_boot_telemetry)
+     00.01300s (azure-ds/_decrypt_certs_from_xml)
+     00.01200s (azure-ds/check-platform-viability)
+     00.01000s (modules-config/config-emit_upstart)
+     00.00800s (azure-ds/_get_metadata_from_imds)
+     00.00700s (init-network/consume-user-data)
+     00.00700s (init-network/config-set_hostname)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_run_x509_action)
+     00.00600s (azure-ds/_report_ready)
+     00.00500s (modules-config/config-snap)
+     00.00400s (modules-final/config-final-message)
+     00.00300s (init-network/config-bootcmd)
+     00.00200s (azure-ds/write_files)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/parse_network_config)
+     00.00100s (azure-ds/load_azure_ds_dir)
+     00.00100s (azure-ds/_networkd_get_value_from_leases)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-package-update-upgrade-install)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/wait-for-ephemeral-disk)
+     00.00000s (azure-ds/temporary_hostname)
+     00.00000s (azure-ds/maybe_remove_ubuntu_network_config_scripts)
+     00.00000s (azure-ds/load_azure_ovf_pubkeys)
+     00.00000s (azure-ds/get_system_info)
+     00.00000s (azure-ds/_get_random_seed)
+     00.00000s (azure-ds/_extract_preprovisioned_vm_setting)
+
+1 boot records analyzed
++ echo After upgrade write network config: upgrade-network.out
+After upgrade write network config: upgrade-network.out
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- cat /etc/netplan/50-cloud-init.yaml
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -4 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 route
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- ip -6 addr
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ubuntu@52.252.115.168 -- grep DHCP /var/log/syslog
++ echo ------- Diff previous-network to post-upgrade-network ------
+------- Diff previous-network to post-upgrade-network ------
++ diff -urN previous-network.out upgrade-network.out
+--- previous-network.out	2020-06-18 18:48:58.904705001 +0000
++++ upgrade-network.out	2020-06-18 18:50:49.518381051 +0000
+@@ -38,3 +38,9 @@
+ Jun 18 18:48:14 SRU-worked-azure dhclient[503]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x282147ed)
+ Jun 18 18:48:14 SRU-worked-azure dhclient[503]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0xed472128)
+ Jun 18 18:48:14 SRU-worked-azure systemd-networkd[531]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
++Jun 18 18:50:03 SRU-worked-azure dhclient[528]: Internet Systems Consortium DHCP Client 4.4.1
++Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xc711112b)
++Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPOFFER of 10.0.0.6 from 168.63.129.16
++Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x2b1111c7)
++Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0xc711112b)
++Jun 18 18:50:03 SRU-worked-azure systemd-networkd[556]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
+=== END verification output ===
+

--- a/manual/azure-sru-20.2.45.txt
+++ b/manual/azure-sru-20.2.45.txt
@@ -1493,6 +1493,18 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPREQUEST of 10.0.0.4 on eth0 to 255.255.255.255 port 67 (xid=0x701d9f8)
 +Jun 18 18:36:54 SRU-worked-azure dhclient[1037]: DHCPACK of 10.0.0.4 from 168.63.129.16
 +Jun 18 18:36:54 SRU-worked-azure ifup[942]: DHCPACK of 10.0.0.4 from 168.63.129.16
++ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Azure needs to use __builtin__ agent by default on all releases
++ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Azure needs to use __builtin__ agent by default on all releases
+2020-06-18 18:36:52,070 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
+2020-06-18 18:36:52,070 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
+2020-06-18 18:36:52,071 - azure.py[DEBUG]: Generating certificate for communication with fabric...
+2020-06-18 18:36:52,181 - azure.py[DEBUG]: Reporting ready to Azure fabric.
+2020-06-18 18:36:52,186 - azure.py[INFO]: Reported ready to Azure fabric.
+2020-06-18 18:36:52,187 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
+
+
 + SRU_VARS=./sru-scripts/sru-vars.template
 + [ ! -f ./sru-scripts/sru-vars.template ]
 + . ./sru-scripts/sru-vars.template
@@ -2375,6 +2387,16 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPOFFER of 10.0.0.4 from 168.63.129.16
 +Jun 18 18:41:48 SRU-worked-azure dhclient[821]: DHCPACK of 10.0.0.4 from 168.63.129.16
 +Jun 18 18:41:48 SRU-worked-azure systemd-networkd[856]: eth0: DHCPv4 address 10.0.0.4/24 via 10.0.0.1
++ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Azure needs to use __builtin__ agent by default on all releases
++ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Azure needs to use __builtin__ agent by default on all releases
+2020-06-18 18:41:45,859 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
+2020-06-18 18:41:45,859 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
+2020-06-18 18:41:45,859 - azure.py[DEBUG]: Generating certificate for communication with fabric...
+2020-06-18 18:41:46,030 - azure.py[DEBUG]: Reporting ready to Azure fabric.
+2020-06-18 18:41:46,049 - azure.py[INFO]: Reported ready to Azure fabric.
+2020-06-18 18:41:46,050 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
 + SRU_VARS=./sru-scripts/sru-vars.template
 + [ ! -f ./sru-scripts/sru-vars.template ]
 + . ./sru-scripts/sru-vars.template
@@ -3279,6 +3301,16 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPREQUEST for 10.0.0.5 on eth0 to 255.255.255.255 port 67 (xid=0x72920ae6)
 +Jun 18 18:45:50 SRU-worked-azure dhclient[518]: DHCPACK of 10.0.0.5 from 168.63.129.16 (xid=0xe60a9272)
 +Jun 18 18:45:50 SRU-worked-azure systemd-networkd[543]: eth0: DHCPv4 address 10.0.0.5/24 via 10.0.0.1
++ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Azure needs to use __builtin__ agent by default on all releases
++ echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+Azure needs to use __builtin__ agent by default on all releases
+2020-06-18 18:45:46,061 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
+2020-06-18 18:45:46,061 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
+2020-06-18 18:45:46,061 - azure.py[DEBUG]: Generating certificate for communication with fabric...
+2020-06-18 18:45:46,253 - azure.py[DEBUG]: Reporting ready to Azure fabric.
+2020-06-18 18:45:46,259 - azure.py[INFO]: Reported ready to Azure fabric.
+2020-06-18 18:45:46,260 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
 + SRU_VARS=./sru-scripts/sru-vars.template
 + [ ! -f ./sru-scripts/sru-vars.template ]
 + . ./sru-scripts/sru-vars.template
@@ -4191,5 +4223,12 @@ After upgrade write network config: upgrade-network.out
 +Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPREQUEST for 10.0.0.6 on eth0 to 255.255.255.255 port 67 (xid=0x2b1111c7)
 +Jun 18 18:50:03 SRU-worked-azure dhclient[528]: DHCPACK of 10.0.0.6 from 168.63.129.16 (xid=0xc711112b)
 +Jun 18 18:50:03 SRU-worked-azure systemd-networkd[556]: eth0: DHCPv4 address 10.0.0.6/24 via 10.0.0.1
+2020-06-18 18:49:59,943 - DataSourceAzure.py[DEBUG]: negotiating with fabric via agent command __builtin__
+2020-06-18 18:49:59,943 - handlers.py[DEBUG]: start: azure-ds/get_metadata_from_fabric: get_metadata_from_fabric
+2020-06-18 18:49:59,944 - azure.py[DEBUG]: Generating certificate for communication with fabric...
+2020-06-18 18:50:00,044 - azure.py[DEBUG]: Reporting ready to Azure fabric.
+2020-06-18 18:50:00,050 - azure.py[INFO]: Reported ready to Azure fabric.
+2020-06-18 18:50:00,051 - handlers.py[DEBUG]: finish: azure-ds/get_metadata_from_fabric: SUCCESS: get_metadata_from_fabric
+
 === END verification output ===
 

--- a/sru-scripts/manual/azure-sru
+++ b/sru-scripts/manual/azure-sru
@@ -320,7 +320,7 @@ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELE
     echo 'Get cloud-id'
     ssh $sshopts $IP -- cloud-id
     ssh $sshopts $IP -- cloud-init query --format "'cloud-region: {{cloud_name}}-{{ds.meta_data.imds.compute.location}}'"
-    echo 'Validating whether metadata is being updated per boot LP:1819913. Expect last log to be Sytem Boot'
+    echo 'Validating whether metadata is being updated per boot LP:1819913. Expect last log to be System Boot'
     ssh $sshopts $IP -- sudo reboot || true
     sleep 30
     ssh $sshopts $IP -- cloud-init status --wait --long

--- a/sru-scripts/manual/azure-sru
+++ b/sru-scripts/manual/azure-sru
@@ -326,5 +326,9 @@ for nics in "" "--nics $AZURE_NIC_NAME-$UBUNTU_RELEASE ${NIC_NAME}2-$UBUNTU_RELE
     ssh $sshopts $IP -- cloud-init status --wait --long
     echo 'After reboot'
     ssh $sshopts $IP -- "grep 'Update datasource' /var/log/cloud-init.log"
+
+    echo "Validate https://github.com/canonical/cloud-init/commit/22e683df"
+    echo "Azure needs to use __builtin__ agent by default on all releases"
+    ssh $sshopts $IP -- "egrep 'fabric' /var/log/cloud-init.log"
 done
 echo "### END $UBUNTU_RELEASE"


### PR DESCRIPTION
Add the SRU verification results by running:
sru-scripts/manual/azure-sru (xenial|bionic|eoan|focal)


No additional custom tests were added to the test run.

Please double check the following:
- No tracebacks discovered,
- the right version of cloud-init was upgraded to 20.2.45 
 - all ubuntu releases were tested for this SRU X, B, E and F
 - no noticeable regression in datasource detection (like not detecting DataSourceAzure)
- no significant regression in cloud-init analyze or systemd-analyze boot  speed 
- no regression in network configuration rendered before vs after upgrade