### PR TITLE
20.4 ec2,gce,oracle runs for xenial,bionic,focal,groovy

### DIFF
--- a/manual/ec2-sru-20.4.0.txt
+++ b/manual/ec2-sru-20.4.0.txt
@@ -1,0 +1,289 @@
+Upstream test at:
+https://github.com/canonical/cloud-init/blob/master/tests/integration_tests/test_upgrade.py
+
+Logs from individual before/after runs in ec2-sru-20.4.0 subdirectory
+
+
+==== Xenial ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=xenial
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=xenial
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ami-05edbb8e25e281608
+wait=False
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ami-05edbb8e25e281608
+wait=False
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7fe4ad424c18>, instance=ec2.Instance(id='i-0454e3706794ddd06'))
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7fe4ad424c18>, instance=ec2.Instance(id='i-0454e3706794ddd06'))
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~16.04.1
+Installed cloud-init version: 20.4-0ubuntu1~16.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_xenial_before_201211154007.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_xenial_after_201211154007.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_xenial_before_201211154007.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_xenial_after_201211154007.log
+.
+
+=========================================================================================== 1 passed in 211.55s (0:03:31) ===========================================================================================
+
+==== Bionic ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=bionic
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=bionic
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=ami-0b9487791bf873774
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=ami-0b9487791bf873774
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f4cb12d1c18>, instance=ec2.Instance(id='i-06c3468f75821fea6'))
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f4cb12d1c18>, instance=ec2.Instance(id='i-06c3468f75821fea6'))
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~18.04.1
+Installed cloud-init version: 20.4-0ubuntu1~18.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_bionic_before_201211155132.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_bionic_after_201211155132.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_bionic_before_201211155132.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_bionic_after_201211155132.log
+.
+
+=========================================================================================== 1 passed in 183.52s (0:03:03) ===========================================================================================
+
+==== Focal ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=focal
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=focal
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=ami-0b289b3e97908e84e
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=ami-0b289b3e97908e84e
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7fd0cd051d30>, instance=ec2.Instance(id='i-0b676c2cf5857588d'))
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7fd0cd051d30>, instance=ec2.Instance(id='i-0b676c2cf5857588d'))
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~20.04.1
+Installed cloud-init version: 20.4-0ubuntu1~20.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_focal_before_201211160259.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_focal_after_201211160259.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_focal_before_201211160259.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_focal_after_201211160259.log
+.
+
+=========================================================================================== 1 passed in 201.80s (0:03:21) ===========================================================================================
+
+==== Groovy ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=groovy
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=groovy
+PLATFORM=ec2
+RUN_UNSTABLE=False
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Launching instance with launch_kwargs:
+image_id=ami-04804ce6d06dadb2c
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+Launching instance with launch_kwargs:
+image_id=ami-04804ce6d06dadb2c
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f5536ed2c88>, instance=ec2.Instance(id='i-06a962cbec343f654'))
+Launched instance: EC2Instance(key_pair=KeyPair(/home/james/.ssh/id_rsa, /home/james/.ssh/id_rsa.pub, name=james), client=<botocore.client.EC2 object at 0x7f5536ed2c88>, instance=ec2.Instance(id='i-06a962cbec343f654'))
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~20.10.1
+Installed cloud-init version: 20.4-0ubuntu1~20.10.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_groovy_before_201211161431.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_groovy_after_201211161431.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_ec2_groovy_before_201211161431.log and /tmp/cloud_init_test_logs/test_upgrade_ec2_groovy_after_201211161431.log
+.
+
+=========================================================================================== 1 passed in 197.90s (0:03:17) ===========================================================================================

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_bionic_after_201211155132.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_bionic_after_201211155132.log
@@ -1,0 +1,221 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~18.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 4.816s (kernel) + 14.070s (userspace) = 18.886s
+graphical.target reached after 13.294s in userspace
+===== systemd-analyze blame =====
+          2.715s snapd.service
+          2.326s cloud-config.service
+          2.013s dev-xvda1.device
+          1.994s keyboard-setup.service
+          1.850s cloud-init-local.service
+          1.404s systemd-networkd-wait-online.service
+          1.227s cloud-init.service
+           778ms networkd-dispatcher.service
+           769ms cloud-final.service
+           448ms lxd-containers.service
+           430ms apparmor.service
+           327ms accounts-daemon.service
+           305ms systemd-udev-trigger.service
+           294ms systemd-modules-load.service
+           252ms apport.service
+           245ms grub-common.service
+           235ms systemd-journald.service
+           226ms ssh.service
+           214ms ebtables.service
+           203ms snapd.seeded.service
+           196ms dev-loop2.device
+           194ms systemd-hostnamed.service
+           188ms hibinit-agent.service
+           184ms rsyslog.service
+           170ms systemd-udevd.service
+           164ms systemd-logind.service
+           155ms snap-snapd-10492.mount
+           153ms snap-core18-1932.mount
+           147ms systemd-journal-flush.service
+           143ms plymouth-read-write.service
+           142ms systemd-tmpfiles-setup.service
+           137ms lvm2-monitor.service
+           125ms blk-availability.service
+           120ms console-setup.service
+           119ms ufw.service
+           116ms polkit.service
+           116ms snap-amazon\x2dssm\x2dagent-2996.mount
+           110ms user@1000.service
+           103ms kmod-static-nodes.service
+           102ms dev-mqueue.mount
+           102ms dev-hugepages.mount
+           100ms systemd-remount-fs.service
+            99ms lxd.socket
+            98ms sys-kernel-debug.mount
+            94ms dev-loop0.device
+            93ms dev-loop1.device
+            92ms systemd-timesyncd.service
+            82ms systemd-tmpfiles-setup-dev.service
+            62ms systemd-resolved.service
+            56ms systemd-networkd.service
+            53ms systemd-sysctl.service
+            53ms systemd-update-utmp.service
+            50ms snapd.socket
+            46ms snapd.apparmor.service
+            32ms plymouth-quit.service
+            21ms sys-fs-fuse-connections.mount
+            19ms systemd-random-seed.service
+            18ms sys-kernel-config.mount
+            18ms systemd-update-utmp-runlevel.service
+            16ms setvtrgb.service
+            15ms plymouth-quit-wait.service
+            15ms systemd-user-sessions.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00000s
+|`->found local data from DataSourceEc2Local @00.01300s +00.35500s
+Finished stage: (init-local) 00.58000 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @02.59400s +00.00300s
+|`->setting up datasource @02.66000s +00.00000s
+|`->reading and applying user-data @02.66700s +00.00400s
+|`->reading and applying vendor-data @02.67100s +00.00000s
+|`->activating datasource @02.70500s +00.00100s
+|`->config-migrator ran successfully @02.74300s +00.00100s
+|`->config-seed_random ran successfully @02.74400s +00.00100s
+|`->config-bootcmd ran successfully @02.74500s +00.00000s
+|`->config-write-files ran successfully @02.74500s +00.00100s
+|`->config-growpart ran successfully @02.74600s +00.11600s
+|`->config-resizefs ran successfully @02.86300s +00.04100s
+|`->config-disk_setup ran successfully @02.90400s +00.00100s
+|`->config-mounts ran successfully @02.90600s +00.00100s
+|`->config-set_hostname ran successfully @02.90700s +00.00500s
+|`->config-update_hostname ran successfully @02.91300s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.91400s +00.00100s
+|`->config-ca-certs ran successfully @02.91500s +00.00000s
+|`->config-rsyslog ran successfully @02.91600s +00.00000s
+|`->config-users-groups ran successfully @02.91700s +00.02500s
+|`->config-ssh ran successfully @02.94200s +00.32500s
+Finished stage: (init-network) 00.68800 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @08.33900s +00.00000s
+|`->config-snap ran successfully @08.33900s +00.00100s
+|`->config-ssh-import-id ran successfully @08.34100s +00.00000s
+|`->config-locale ran successfully @08.34200s +00.00500s
+|`->config-set-passwords ran successfully @08.34700s +00.00100s
+|`->config-grub-dpkg ran successfully @08.34800s +00.29500s
+|`->config-apt-pipelining ran successfully @08.64300s +00.00100s
+|`->config-apt-configure ran successfully @08.64400s +00.11800s
+|`->config-ubuntu-advantage ran successfully @08.76200s +00.00100s
+|`->config-ntp ran successfully @08.76300s +00.00100s
+|`->config-timezone ran successfully @08.76400s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @08.76500s +00.00000s
+|`->config-runcmd ran successfully @08.76500s +00.00100s
+|`->config-byobu ran successfully @08.76600s +00.00100s
+Finished stage: (modules-config) 00.45500 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @09.61700s +00.00100s
+|`->config-fan ran successfully @09.61800s +00.00100s
+|`->config-landscape ran successfully @09.61900s +00.00100s
+|`->config-lxd ran successfully @09.62000s +00.00000s
+|`->config-ubuntu-drivers ran successfully @09.62100s +00.00000s
+|`->config-puppet ran successfully @09.62200s +00.00000s
+|`->config-chef ran successfully @09.62200s +00.00100s
+|`->config-mcollective ran successfully @09.62300s +00.00000s
+|`->config-salt-minion ran successfully @09.62400s +00.00100s
+|`->config-reset_rmc ran successfully @09.62500s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @09.62600s +00.00100s
+|`->config-rightscale_userdata ran successfully @09.62700s +00.00100s
+|`->config-scripts-vendor ran successfully @09.62800s +00.00000s
+|`->config-scripts-per-once ran successfully @09.62900s +00.00000s
+|`->config-scripts-per-boot ran successfully @09.63000s +00.00000s
+|`->config-scripts-per-instance ran successfully @09.63000s +00.00100s
+|`->config-scripts-user ran successfully @09.63100s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @09.63200s +00.03500s
+|`->config-keys-to-console ran successfully @09.66700s +00.08000s
+|`->config-phone-home ran successfully @09.74800s +00.00100s
+|`->config-final-message ran successfully @09.74900s +00.00500s
+|`->config-power-state-change ran successfully @09.75400s +00.00100s
+Finished stage: (modules-final) 00.18500 seconds
+
+Total Time: 1.90800 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.35500s (init-local/search-Ec2Local)
+     00.32500s (init-network/config-ssh)
+     00.29500s (modules-config/config-grub-dpkg)
+     00.11800s (modules-config/config-apt-configure)
+     00.11600s (init-network/config-growpart)
+     00.08000s (modules-final/config-keys-to-console)
+     00.04100s (init-network/config-resizefs)
+     00.03500s (modules-final/config-ssh-authkey-fingerprints)
+     00.02500s (init-network/config-users-groups)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (modules-config/config-locale)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (init-network/consume-user-data)
+     00.00300s (init-network/check-cache)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-refresh_rmc_and_interface)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-config/config-ssh-import-id)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_bionic_before_201211155132.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_bionic_before_201211155132.log
@@ -1,0 +1,219 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~18.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 5.400s (kernel) + 27.444s (userspace) = 32.845s
+graphical.target reached after 26.662s in userspace
+===== systemd-analyze blame =====
+         14.723s snapd.seeded.service
+          2.505s dev-xvda1.device
+          2.430s cloud-init-local.service
+          1.845s keyboard-setup.service
+          1.703s cloud-init.service
+          1.394s systemd-networkd-wait-online.service
+          1.237s cloud-config.service
+          1.201s pollinate.service
+          1.151s apparmor.service
+           964ms snapd.service
+           792ms lxd-containers.service
+           777ms cloud-final.service
+           676ms networkd-dispatcher.service
+           360ms apport.service
+           346ms accounts-daemon.service
+           319ms grub-common.service
+           274ms systemd-udev-trigger.service
+           255ms systemd-modules-load.service
+           233ms systemd-remount-fs.service
+           207ms systemd-logind.service
+           188ms lvm2-monitor.service
+           185ms systemd-hostnamed.service
+           184ms systemd-journald.service
+           144ms ebtables.service
+           143ms hibinit-agent.service
+           141ms polkit.service
+           140ms rsyslog.service
+           128ms blk-availability.service
+           117ms lxd.socket
+           117ms systemd-journal-flush.service
+           112ms systemd-user-sessions.service
+            96ms systemd-udevd.service
+            93ms sys-kernel-debug.mount
+            90ms dev-hugepages.mount
+            89ms systemd-networkd.service
+            86ms dev-mqueue.mount
+            84ms user@1000.service
+            82ms systemd-timesyncd.service
+            77ms kmod-static-nodes.service
+            71ms systemd-tmpfiles-setup.service
+            70ms ssh.service
+            68ms dev-loop2.device
+            67ms dev-loop1.device
+            65ms systemd-tmpfiles-setup-dev.service
+            53ms plymouth-read-write.service
+            51ms systemd-random-seed.service
+            48ms systemd-resolved.service
+            46ms systemd-sysctl.service
+            44ms snapd.socket
+            41ms systemd-machine-id-commit.service
+            40ms ufw.service
+            39ms plymouth-quit.service
+            38ms console-setup.service
+            36ms snap-core18-1932.mount
+            33ms snap-amazon\x2dssm\x2dagent-2996.mount
+            31ms sys-fs-fuse-connections.mount
+            31ms sys-kernel-config.mount
+            28ms snapd.apparmor.service
+            28ms setvtrgb.service
+            27ms dev-loop0.device
+            25ms snap-snapd-10492.mount
+            24ms systemd-update-utmp-runlevel.service
+            23ms systemd-update-utmp.service
+            17ms plymouth-quit-wait.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00000s
+|`->found local data from DataSourceEc2Local @00.01200s +00.34900s
+Finished stage: (init-local) 00.57900 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @02.61300s +00.00300s
+|`->setting up datasource @02.67700s +00.00000s
+|`->reading and applying user-data @02.68400s +00.00300s
+|`->reading and applying vendor-data @02.68800s +00.00000s
+|`->activating datasource @02.72100s +00.00100s
+|`->config-migrator ran successfully @02.76400s +00.00100s
+|`->config-seed_random ran successfully @02.76500s +00.00100s
+|`->config-bootcmd ran successfully @02.76600s +00.00000s
+|`->config-write-files ran successfully @02.76700s +00.00000s
+|`->config-growpart ran successfully @02.76700s +00.21700s
+|`->config-resizefs ran successfully @02.98400s +00.28200s
+|`->config-disk_setup ran successfully @03.26600s +00.00100s
+|`->config-mounts ran successfully @03.26700s +00.00200s
+|`->config-set_hostname ran successfully @03.26900s +00.00500s
+|`->config-update_hostname ran successfully @03.27400s +00.00200s
+|`->config-update_etc_hosts ran successfully @03.27600s +00.00000s
+|`->config-ca-certs ran successfully @03.27600s +00.00100s
+|`->config-rsyslog ran successfully @03.27700s +00.00100s
+|`->config-users-groups ran successfully @03.27800s +00.13000s
+|`->config-ssh ran successfully @03.40900s +00.33100s
+Finished stage: (init-network) 01.14300 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @20.27500s +00.00000s
+|`->config-snap ran successfully @20.27500s +00.00100s
+|`->config-ssh-import-id ran successfully @20.27600s +00.00100s
+|`->config-locale ran successfully @20.27700s +00.00600s
+|`->config-set-passwords ran successfully @20.28300s +00.00000s
+|`->config-grub-dpkg ran successfully @20.28400s +00.43500s
+|`->config-apt-pipelining ran successfully @20.71900s +00.00100s
+|`->config-apt-configure ran successfully @20.72100s +00.20600s
+|`->config-ubuntu-advantage ran successfully @20.92800s +00.00000s
+|`->config-ntp ran successfully @20.92900s +00.00000s
+|`->config-timezone ran successfully @20.93000s +00.00000s
+|`->config-disable-ec2-metadata ran successfully @20.93000s +00.00100s
+|`->config-runcmd ran successfully @20.93100s +00.00000s
+|`->config-byobu ran successfully @20.93200s +00.00000s
+Finished stage: (modules-config) 00.67800 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @21.71300s +00.00100s
+|`->config-fan ran successfully @21.71400s +00.00100s
+|`->config-landscape ran successfully @21.71500s +00.00100s
+|`->config-lxd ran successfully @21.71600s +00.00100s
+|`->config-ubuntu-drivers ran successfully @21.71700s +00.00000s
+|`->config-puppet ran successfully @21.71800s +00.00000s
+|`->config-chef ran successfully @21.71900s +00.00000s
+|`->config-mcollective ran successfully @21.71900s +00.00100s
+|`->config-salt-minion ran successfully @21.72000s +00.00100s
+|`->config-rightscale_userdata ran successfully @21.72100s +00.00000s
+|`->config-scripts-vendor ran successfully @21.72200s +00.00000s
+|`->config-scripts-per-once ran successfully @21.72300s +00.00000s
+|`->config-scripts-per-boot ran successfully @21.72300s +00.00100s
+|`->config-scripts-per-instance ran successfully @21.72400s +00.00100s
+|`->config-scripts-user ran successfully @21.72500s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @21.72600s +00.04900s
+|`->config-keys-to-console ran successfully @21.77600s +00.08200s
+|`->config-phone-home ran successfully @21.85900s +00.00100s
+|`->config-final-message ran successfully @21.86000s +00.00500s
+|`->config-power-state-change ran successfully @21.86500s +00.00100s
+Finished stage: (modules-final) 00.18000 seconds
+
+Total Time: 2.58000 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.43500s (modules-config/config-grub-dpkg)
+     00.34900s (init-local/search-Ec2Local)
+     00.33100s (init-network/config-ssh)
+     00.28200s (init-network/config-resizefs)
+     00.21700s (init-network/config-growpart)
+     00.20600s (modules-config/config-apt-configure)
+     00.13000s (init-network/config-users-groups)
+     00.08200s (modules-final/config-keys-to-console)
+     00.04900s (modules-final/config-ssh-authkey-fingerprints)
+     00.00600s (modules-config/config-locale)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (init-network/config-set_hostname)
+     00.00300s (init-network/consume-user-data)
+     00.00300s (init-network/check-cache)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (init-network/config-mounts)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-timezone)
+     00.00000s (modules-config/config-set-passwords)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_focal_after_201211160259.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_focal_after_201211160259.log
@@ -1,0 +1,232 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~20.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.697s (kernel) + 15.047s (userspace) = 16.744s 
+graphical.target reached after 14.265s in userspace
+===== systemd-analyze blame =====
+3.446s snap.lxd.activate.service             
+3.264s snapd.service                         
+1.962s cloud-init-local.service              
+1.942s cloud-init.service                    
+1.744s ec2-instance-connect.service          
+1.742s systemd-networkd-wait-online.service  
+1.628s accounts-daemon.service               
+1.576s lvm2-monitor.service                  
+1.399s dev-xvda1.device                      
+1.204s cloud-config.service                  
+1.149s systemd-udev-settle.service           
+ 908ms networkd-dispatcher.service           
+ 850ms apport.service                        
+ 829ms systemd-logind.service                
+ 776ms cloud-final.service                   
+ 756ms grub-common.service                   
+ 644ms systemd-hostnamed.service             
+ 446ms rsyslog.service                       
+ 419ms grub-initrd-fallback.service          
+ 415ms atd.service                           
+ 374ms e2scrub_reap.service                  
+ 344ms systemd-timesyncd.service             
+ 343ms dev-hugepages.mount                   
+ 337ms dev-mqueue.mount                      
+ 329ms sys-kernel-debug.mount                
+ 322ms sys-kernel-tracing.mount              
+ 298ms keyboard-setup.service                
+ 285ms systemd-journald.service              
+ 279ms kmod-static-nodes.service             
+ 254ms hibinit-agent.service                 
+ 245ms systemd-udev-trigger.service          
+ 236ms dev-loop0.device                      
+ 229ms ssh.service                           
+ 220ms dev-loop1.device                      
+ 218ms dev-loop2.device                      
+ 202ms dev-loop3.device                      
+ 198ms snapd.apparmor.service                
+ 189ms modprobe@drm.service                  
+ 178ms snapd.seeded.service                  
+ 170ms systemd-resolved.service              
+ 169ms plymouth-quit.service                 
+ 169ms plymouth-quit-wait.service            
+ 157ms systemd-user-sessions.service         
+ 148ms apparmor.service                      
+ 140ms systemd-networkd.service              
+ 119ms user@1000.service                     
+ 114ms systemd-modules-load.service          
+ 108ms systemd-udevd.service                 
+ 103ms systemd-random-seed.service           
+ 103ms systemd-remount-fs.service            
+ 102ms systemd-journal-flush.service         
+ 101ms sys-kernel-config.mount               
+  98ms sys-fs-fuse-connections.mount         
+  89ms multipathd.service                    
+  85ms systemd-tmpfiles-setup.service        
+  85ms polkit.service                        
+  84ms systemd-sysctl.service                
+  79ms systemd-sysusers.service              
+  75ms finalrd.service                       
+  74ms console-setup.service                 
+  73ms ufw.service                           
+  73ms snap-core18-1932.mount                
+  72ms plymouth-read-write.service           
+  72ms systemd-update-utmp.service           
+  70ms setvtrgb.service                      
+  69ms snap-lxd-18150.mount                  
+  65ms snap-amazon\x2dssm\x2dagent-2996.mount
+  61ms snap-snapd-10492.mount                
+  48ms snapd.socket                          
+  31ms systemd-tmpfiles-setup-dev.service    
+  30ms systemd-update-utmp-runlevel.service  
+  25ms blk-availability.service              
+  19ms user-runtime-dir@1000.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00100s
+|`->found local data from DataSourceEc2Local @00.01400s +00.35300s
+Finished stage: (init-local) 00.61600 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @03.04000s +00.00400s
+|`->setting up datasource @03.09700s +00.00000s
+|`->reading and applying user-data @03.10500s +00.00400s
+|`->reading and applying vendor-data @03.10900s +00.00000s
+|`->activating datasource @03.13600s +00.00200s
+|`->config-migrator ran successfully @03.17900s +00.00000s
+|`->config-seed_random ran successfully @03.18000s +00.00100s
+|`->config-bootcmd ran successfully @03.18100s +00.00100s
+|`->config-write-files ran successfully @03.18200s +00.00000s
+|`->config-growpart ran successfully @03.18300s +00.13000s
+|`->config-resizefs ran successfully @03.31400s +00.09900s
+|`->config-disk_setup ran successfully @03.41300s +00.00100s
+|`->config-mounts ran successfully @03.41500s +00.00300s
+|`->config-set_hostname ran successfully @03.41800s +00.00600s
+|`->config-update_hostname ran successfully @03.42400s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.42600s +00.00000s
+|`->config-ca-certs ran successfully @03.42600s +00.00100s
+|`->config-rsyslog ran successfully @03.42700s +00.00100s
+|`->config-users-groups ran successfully @03.42800s +00.02500s
+|`->config-ssh ran successfully @03.45400s +00.93300s
+Finished stage: (init-network) 01.36500 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @09.32100s +00.00100s
+|`->config-snap ran successfully @09.32200s +00.00100s
+|`->config-ssh-import-id ran successfully @09.32300s +00.00100s
+|`->config-locale ran successfully @09.32400s +00.02900s
+|`->config-set-passwords ran successfully @09.35300s +00.00100s
+|`->config-grub-dpkg ran successfully @09.35400s +00.24600s
+|`->config-apt-pipelining ran successfully @09.60000s +00.00100s
+|`->config-apt-configure ran successfully @09.60200s +00.11900s
+|`->config-ubuntu-advantage ran successfully @09.72200s +00.00100s
+|`->config-ntp ran successfully @09.72300s +00.00000s
+|`->config-timezone ran successfully @09.72400s +00.00000s
+|`->config-disable-ec2-metadata ran successfully @09.72500s +00.00000s
+|`->config-runcmd ran successfully @09.72500s +00.00100s
+|`->config-byobu ran successfully @09.72600s +00.00100s
+Finished stage: (modules-config) 00.42900 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @10.61300s +00.00100s
+|`->config-fan ran successfully @10.61400s +00.00100s
+|`->config-landscape ran successfully @10.61500s +00.00000s
+|`->config-lxd ran successfully @10.61600s +00.00000s
+|`->config-ubuntu-drivers ran successfully @10.61700s +00.00000s
+|`->config-puppet ran successfully @10.61700s +00.00100s
+|`->config-chef ran successfully @10.61800s +00.00100s
+|`->config-mcollective ran successfully @10.61900s +00.00000s
+|`->config-salt-minion ran successfully @10.62000s +00.00000s
+|`->config-reset_rmc ran successfully @10.62100s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @10.62200s +00.00100s
+|`->config-rightscale_userdata ran successfully @10.62300s +00.00000s
+|`->config-scripts-vendor ran successfully @10.62400s +00.00000s
+|`->config-scripts-per-once ran successfully @10.62500s +00.00100s
+|`->config-scripts-per-boot ran successfully @10.62700s +00.00000s
+|`->config-scripts-per-instance ran successfully @10.62700s +00.00100s
+|`->config-scripts-user ran successfully @10.62800s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @10.62900s +00.03400s
+|`->config-keys-to-console ran successfully @10.66400s +00.08900s
+|`->config-phone-home ran successfully @10.75400s +00.00100s
+|`->config-final-message ran successfully @10.75500s +00.00500s
+|`->config-power-state-change ran successfully @10.76000s +00.00000s
+Finished stage: (modules-final) 00.18000 seconds
+
+Total Time: 2.59000 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.93300s (init-network/config-ssh)
+     00.35300s (init-local/search-Ec2Local)
+     00.24600s (modules-config/config-grub-dpkg)
+     00.13000s (init-network/config-growpart)
+     00.11900s (modules-config/config-apt-configure)
+     00.09900s (init-network/config-resizefs)
+     00.08900s (modules-final/config-keys-to-console)
+     00.03400s (modules-final/config-ssh-authkey-fingerprints)
+     00.02900s (modules-config/config-locale)
+     00.02500s (init-network/config-users-groups)
+     00.00600s (init-network/config-set_hostname)
+     00.00500s (modules-final/config-final-message)
+     00.00400s (init-network/consume-user-data)
+     00.00400s (init-network/check-cache)
+     00.00300s (init-network/config-mounts)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-refresh_rmc_and_interface)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (init-local/check-cache)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-config/config-timezone)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-migrator)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_focal_before_201211160259.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_focal_before_201211160259.log
@@ -1,0 +1,230 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~20.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.865s (kernel) + 24.590s (userspace) = 26.456s 
+graphical.target reached after 22.722s in userspace
+===== systemd-analyze blame =====
+6.572s snapd.seeded.service                  
+2.806s cloud-init-local.service              
+2.302s snapd.apparmor.service                
+2.244s snapd.service                         
+2.095s cloud-config.service                  
+1.957s lvm2-monitor.service                  
+1.832s cloud-final.service                   
+1.807s cloud-init.service                    
+1.708s dev-xvda1.device                      
+1.636s systemd-networkd-wait-online.service  
+1.491s systemd-udev-settle.service           
+1.288s ec2-instance-connect.service          
+1.240s accounts-daemon.service               
+1.138s pollinate.service                     
+1.045s apparmor.service                      
+ 649ms networkd-dispatcher.service           
+ 607ms snap.lxd.activate.service             
+ 602ms systemd-logind.service                
+ 597ms apport.service                        
+ 510ms systemd-hostnamed.service             
+ 479ms grub-common.service                   
+ 401ms hibinit-agent.service                 
+ 344ms atd.service                           
+ 300ms dev-hugepages.mount                   
+ 299ms dev-mqueue.mount                      
+ 296ms grub-initrd-fallback.service          
+ 295ms sys-kernel-debug.mount                
+ 290ms sys-kernel-tracing.mount              
+ 287ms e2scrub_reap.service                  
+ 277ms rsyslog.service                       
+ 267ms keyboard-setup.service                
+ 264ms dev-loop0.device                      
+ 264ms systemd-udev-trigger.service          
+ 255ms kmod-static-nodes.service             
+ 251ms systemd-timesyncd.service             
+ 250ms dev-loop1.device                      
+ 243ms systemd-udevd.service                 
+ 240ms systemd-journald.service              
+ 236ms dev-loop2.device                      
+ 234ms dev-loop3.device                      
+ 203ms modprobe@drm.service                  
+ 201ms systemd-resolved.service              
+ 177ms systemd-modules-load.service          
+ 146ms systemd-remount-fs.service            
+ 142ms ssh.service                           
+ 125ms user@1000.service                     
+ 124ms systemd-user-sessions.service         
+ 115ms systemd-machine-id-commit.service     
+ 115ms multipathd.service                    
+ 114ms plymouth-read-write.service           
+ 113ms console-setup.service                 
+ 112ms systemd-tmpfiles-setup.service        
+ 109ms systemd-networkd.service              
+ 107ms finalrd.service                       
+ 105ms systemd-sysusers.service              
+  92ms sys-kernel-config.mount               
+  92ms systemd-journal-flush.service         
+  92ms systemd-random-seed.service           
+  90ms ufw.service                           
+  85ms sys-fs-fuse-connections.mount         
+  84ms systemd-sysctl.service                
+  70ms polkit.service                        
+  69ms snap-core18-1932.mount                
+  68ms plymouth-quit-wait.service            
+  68ms snap-amazon\x2dssm\x2dagent-2996.mount
+  66ms systemd-update-utmp-runlevel.service  
+  66ms snap-lxd-18150.mount                  
+  56ms snap-snapd-10492.mount                
+  53ms plymouth-quit.service                 
+  53ms snapd.socket                          
+  45ms setvtrgb.service                      
+  29ms user-runtime-dir@1000.service         
+  27ms systemd-update-utmp.service           
+  27ms blk-availability.service              
+  19ms systemd-tmpfiles-setup-dev.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.01500s +00.00000s
+|`->found local data from DataSourceEc2Local @00.03400s +00.50300s
+Finished stage: (init-local) 00.78800 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @03.09700s +00.00400s
+|`->setting up datasource @03.15300s +00.00000s
+|`->reading and applying user-data @03.16000s +00.00400s
+|`->reading and applying vendor-data @03.16400s +00.00000s
+|`->activating datasource @03.19300s +00.00200s
+|`->config-migrator ran successfully @03.24000s +00.00100s
+|`->config-seed_random ran successfully @03.24100s +00.00100s
+|`->config-bootcmd ran successfully @03.24200s +00.00000s
+|`->config-write-files ran successfully @03.24200s +00.00100s
+|`->config-growpart ran successfully @03.24300s +00.20100s
+|`->config-resizefs ran successfully @03.44500s +00.37200s
+|`->config-disk_setup ran successfully @03.81700s +00.00100s
+|`->config-mounts ran successfully @03.81900s +00.00100s
+|`->config-set_hostname ran successfully @03.82100s +00.00600s
+|`->config-update_hostname ran successfully @03.82700s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.82800s +00.00100s
+|`->config-ca-certs ran successfully @03.82900s +00.00100s
+|`->config-rsyslog ran successfully @03.83000s +00.00000s
+|`->config-users-groups ran successfully @03.83100s +00.12200s
+|`->config-ssh ran successfully @03.95400s +00.35100s
+Finished stage: (init-network) 01.23900 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @14.79500s +00.00100s
+|`->config-snap ran successfully @14.79600s +00.00100s
+|`->config-ssh-import-id ran successfully @14.80100s +00.00100s
+|`->config-locale ran successfully @14.80200s +00.06000s
+|`->config-set-passwords ran successfully @14.86200s +00.00100s
+|`->config-grub-dpkg ran successfully @14.86300s +00.60600s
+|`->config-apt-pipelining ran successfully @15.47000s +00.00100s
+|`->config-apt-configure ran successfully @15.47100s +00.27900s
+|`->config-ubuntu-advantage ran successfully @15.75000s +00.00100s
+|`->config-ntp ran successfully @15.75100s +00.00100s
+|`->config-timezone ran successfully @15.75200s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @15.76100s +00.00000s
+|`->config-runcmd ran successfully @15.76100s +00.00200s
+|`->config-byobu ran successfully @15.76300s +00.00000s
+Finished stage: (modules-config) 01.00000 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @18.06700s +00.00100s
+|`->config-fan ran successfully @18.06800s +00.00500s
+|`->config-landscape ran successfully @18.07300s +00.00100s
+|`->config-lxd ran successfully @18.07400s +00.00100s
+|`->config-ubuntu-drivers ran successfully @18.07500s +00.00100s
+|`->config-puppet ran successfully @18.07600s +00.00500s
+|`->config-chef ran successfully @18.08100s +00.00000s
+|`->config-mcollective ran successfully @18.08200s +00.00100s
+|`->config-salt-minion ran successfully @18.08300s +00.00000s
+|`->config-rightscale_userdata ran successfully @18.08400s +00.00000s
+|`->config-scripts-vendor ran successfully @18.08500s +00.00400s
+|`->config-scripts-per-once ran successfully @18.09000s +00.00000s
+|`->config-scripts-per-boot ran successfully @18.09100s +00.00000s
+|`->config-scripts-per-instance ran successfully @18.09100s +00.00100s
+|`->config-scripts-user ran successfully @18.09200s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @18.09700s +00.05700s
+|`->config-keys-to-console ran successfully @18.15400s +00.10000s
+|`->config-phone-home ran successfully @18.25500s +00.00100s
+|`->config-final-message ran successfully @18.25600s +00.00400s
+|`->config-power-state-change ran successfully @18.26100s +00.00000s
+Finished stage: (modules-final) 00.24700 seconds
+
+Total Time: 3.27400 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.60600s (modules-config/config-grub-dpkg)
+     00.50300s (init-local/search-Ec2Local)
+     00.37200s (init-network/config-resizefs)
+     00.35100s (init-network/config-ssh)
+     00.27900s (modules-config/config-apt-configure)
+     00.20100s (init-network/config-growpart)
+     00.12200s (init-network/config-users-groups)
+     00.10000s (modules-final/config-keys-to-console)
+     00.06000s (modules-config/config-locale)
+     00.05700s (modules-final/config-ssh-authkey-fingerprints)
+     00.00600s (init-network/config-set_hostname)
+     00.00500s (modules-final/config-puppet)
+     00.00500s (modules-final/config-fan)
+     00.00400s (modules-final/config-scripts-vendor)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (init-network/consume-user-data)
+     00.00400s (init-network/check-cache)
+     00.00200s (modules-config/config-runcmd)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_groovy_after_201211161431.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_groovy_after_201211161431.log
@@ -1,0 +1,227 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~20.10.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.756s (kernel) + 15.748s (userspace) = 17.504s 
+graphical.target reached after 13.905s in userspace
+===== systemd-analyze blame =====
+6.843s snap.lxd.activate.service             
+4.270s snapd.service                         
+2.885s cloud-config.service                  
+1.586s cloud-init-local.service              
+1.443s systemd-networkd-wait-online.service  
+1.370s accounts-daemon.service               
+1.173s ec2-instance-connect.service          
+1.169s lvm2-monitor.service                  
+1.151s cloud-init.service                    
+ 987ms dev-xvda1.device                      
+ 895ms cloud-final.service                   
+ 804ms systemd-udev-settle.service           
+ 784ms apport.service                        
+ 779ms networkd-dispatcher.service           
+ 745ms systemd-logind.service                
+ 621ms grub-common.service                   
+ 495ms snapd.seeded.service                  
+ 461ms rsyslog.service                       
+ 437ms grub-initrd-fallback.service          
+ 404ms systemd-hostnamed.service             
+ 370ms atd.service                           
+ 365ms e2scrub_reap.service                  
+ 358ms user@1000.service                     
+ 323ms dev-hugepages.mount                   
+ 321ms dev-mqueue.mount                      
+ 315ms sys-kernel-debug.mount                
+ 309ms sys-kernel-tracing.mount              
+ 286ms keyboard-setup.service                
+ 274ms systemd-timesyncd.service             
+ 265ms systemd-journald.service              
+ 263ms kmod-static-nodes.service             
+ 260ms snapd.apparmor.service                
+ 248ms polkit.service                        
+ 226ms systemd-udev-trigger.service          
+ 186ms modprobe@drm.service                  
+ 181ms systemd-user-sessions.service         
+ 154ms setvtrgb.service                      
+ 141ms plymouth-quit-wait.service            
+ 135ms apparmor.service                      
+ 122ms systemd-resolved.service              
+ 114ms systemd-modules-load.service          
+ 108ms plymouth-quit.service                 
+ 103ms ssh.service                           
+ 103ms systemd-remount-fs.service            
+  92ms systemd-journal-flush.service         
+  91ms sys-kernel-config.mount               
+  89ms systemd-random-seed.service           
+  85ms sys-fs-fuse-connections.mount         
+  80ms systemd-sysctl.service                
+  78ms systemd-networkd.service              
+  75ms ufw.service                           
+  70ms systemd-sysusers.service              
+  69ms systemd-update-utmp.service           
+  63ms multipathd.service                    
+  56ms systemd-tmpfiles-setup.service        
+  55ms snapd.socket                          
+  47ms snap-core18-1932.mount                
+  45ms snap-lxd-18546.mount                  
+  45ms systemd-udevd.service                 
+  45ms snap-snapd-10492.mount                
+  41ms user-runtime-dir@1000.service         
+  41ms plymouth-read-write.service           
+  38ms console-setup.service                 
+  37ms finalrd.service                       
+  31ms snap-amazon\x2dssm\x2dagent-2996.mount
+  25ms systemd-tmpfiles-setup-dev.service    
+  24ms systemd-update-utmp-runlevel.service  
+  22ms blk-availability.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+|`->found local data from DataSourceEc2Local @00.01200s +00.39600s
+Finished stage: (init-local) 00.61600 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @02.58500s +00.00300s
+|`->setting up datasource @02.64000s +00.00100s
+|`->reading and applying user-data @02.64900s +00.00400s
+|`->reading and applying vendor-data @02.65300s +00.00000s
+|`->activating datasource @02.67900s +00.00100s
+|`->config-migrator ran successfully @02.71900s +00.00000s
+|`->config-seed_random ran successfully @02.71900s +00.00100s
+|`->config-bootcmd ran successfully @02.72000s +00.00000s
+|`->config-write-files ran successfully @02.72000s +00.00100s
+|`->config-growpart ran successfully @02.72100s +00.11500s
+|`->config-resizefs ran successfully @02.83700s +00.08100s
+|`->config-disk_setup ran successfully @02.91800s +00.00100s
+|`->config-mounts ran successfully @02.91900s +00.00200s
+|`->config-set_hostname ran successfully @02.92100s +00.00500s
+|`->config-update_hostname ran successfully @02.92600s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.92800s +00.00000s
+|`->config-ca-certs ran successfully @02.92800s +00.00100s
+|`->config-rsyslog ran successfully @02.92900s +00.00100s
+|`->config-users-groups ran successfully @02.93000s +00.01600s
+|`->config-ssh ran successfully @02.94600s +00.31800s
+Finished stage: (init-network) 00.69400 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @10.93300s +00.00400s
+|`->config-snap ran successfully @10.93700s +00.00100s
+|`->config-ssh-import-id ran successfully @10.93800s +00.00600s
+|`->config-locale ran successfully @10.94400s +00.08400s
+|`->config-set-passwords ran successfully @11.02800s +00.00100s
+|`->config-grub-dpkg ran successfully @11.02900s +00.36500s
+|`->config-apt-pipelining ran successfully @11.39500s +00.00100s
+|`->config-apt-configure ran successfully @11.39600s +00.16300s
+|`->config-ubuntu-advantage ran successfully @11.56000s +00.00000s
+|`->config-ntp ran successfully @11.56100s +00.00000s
+|`->config-timezone ran successfully @11.56100s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @11.56200s +00.00000s
+|`->config-runcmd ran successfully @11.56300s +00.00400s
+|`->config-byobu ran successfully @11.56800s +00.00000s
+Finished stage: (modules-config) 00.70000 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @12.32800s +00.00100s
+|`->config-fan ran successfully @12.32900s +00.00100s
+|`->config-landscape ran successfully @12.33000s +00.00100s
+|`->config-lxd ran successfully @12.33100s +00.00000s
+|`->config-ubuntu-drivers ran successfully @12.33200s +00.00000s
+|`->config-puppet ran successfully @12.33200s +00.00100s
+|`->config-chef ran successfully @12.33300s +00.00000s
+|`->config-mcollective ran successfully @12.33400s +00.00000s
+|`->config-salt-minion ran successfully @12.33400s +00.00100s
+|`->config-reset_rmc ran successfully @12.33500s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @12.33700s +00.00000s
+|`->config-rightscale_userdata ran successfully @12.33700s +00.00100s
+|`->config-scripts-vendor ran successfully @12.33800s +00.00000s
+|`->config-scripts-per-once ran successfully @12.33900s +00.00000s
+|`->config-scripts-per-boot ran successfully @12.34000s +00.00000s
+|`->config-scripts-per-instance ran successfully @12.34000s +00.00100s
+|`->config-scripts-user ran successfully @12.34100s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @12.34200s +00.05200s
+|`->config-keys-to-console ran successfully @12.39500s +00.11200s
+|`->config-phone-home ran successfully @12.50700s +00.00100s
+|`->config-final-message ran successfully @12.50900s +00.00400s
+|`->config-power-state-change ran successfully @12.51300s +00.00100s
+Finished stage: (modules-final) 00.20900 seconds
+
+Total Time: 2.21900 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.39600s (init-local/search-Ec2Local)
+     00.36500s (modules-config/config-grub-dpkg)
+     00.31800s (init-network/config-ssh)
+     00.16300s (modules-config/config-apt-configure)
+     00.11500s (init-network/config-growpart)
+     00.11200s (modules-final/config-keys-to-console)
+     00.08400s (modules-config/config-locale)
+     00.08100s (init-network/config-resizefs)
+     00.05200s (modules-final/config-ssh-authkey-fingerprints)
+     00.01600s (init-network/config-users-groups)
+     00.00600s (modules-config/config-ssh-import-id)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (modules-config/config-runcmd)
+     00.00400s (modules-config/config-emit_upstart)
+     00.00400s (init-network/consume-user-data)
+     00.00300s (init-network/check-cache)
+     00.00200s (init-network/config-mounts)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/setup-datasource)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_groovy_before_201211161431.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_groovy_before_201211161431.log
@@ -1,0 +1,225 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-15-g6d332e5c-0ubuntu1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.993s (kernel) + 20.772s (userspace) = 22.766s 
+graphical.target reached after 17.602s in userspace
+===== systemd-analyze blame =====
+7.501s snapd.seeded.service                  
+2.842s snapd.apparmor.service                
+2.352s cloud-config.service                  
+1.895s cloud-init-local.service              
+1.806s snapd.service                         
+1.302s systemd-networkd-wait-online.service  
+1.292s lvm2-monitor.service                  
+1.222s snap.lxd.activate.service             
+1.139s accounts-daemon.service               
+1.110s cloud-init.service                    
+1.088s pollinate.service                     
+1.017s dev-xvda1.device                      
+ 991ms apparmor.service                      
+ 985ms ec2-instance-connect.service          
+ 831ms systemd-udev-settle.service           
+ 815ms cloud-final.service                   
+ 687ms networkd-dispatcher.service           
+ 642ms systemd-logind.service                
+ 581ms grub-common.service                   
+ 548ms apport.service                        
+ 398ms dev-hugepages.mount                   
+ 391ms dev-mqueue.mount                      
+ 375ms sys-kernel-debug.mount                
+ 368ms sys-kernel-tracing.mount              
+ 340ms keyboard-setup.service                
+ 321ms systemd-journald.service              
+ 319ms atd.service                           
+ 312ms systemd-hostnamed.service             
+ 309ms grub-initrd-fallback.service          
+ 308ms kmod-static-nodes.service             
+ 294ms rsyslog.service                       
+ 288ms e2scrub_reap.service                  
+ 270ms systemd-udev-trigger.service          
+ 195ms modprobe@drm.service                  
+ 192ms systemd-resolved.service              
+ 172ms systemd-timesyncd.service             
+ 152ms systemd-modules-load.service          
+ 140ms systemd-remount-fs.service            
+ 137ms user@1000.service                     
+ 133ms systemd-networkd.service              
+ 117ms polkit.service                        
+ 109ms systemd-user-sessions.service         
+ 108ms sys-fs-fuse-connections.mount         
+ 105ms sys-kernel-config.mount               
+ 102ms plymouth-quit-wait.service            
+ 101ms ufw.service                           
+ 101ms systemd-journal-flush.service         
+  95ms plymouth-quit.service                 
+  88ms systemd-random-seed.service           
+  86ms ssh.service                           
+  83ms systemd-sysusers.service              
+  77ms systemd-machine-id-commit.service     
+  74ms systemd-sysctl.service                
+  73ms plymouth-read-write.service           
+  72ms systemd-tmpfiles-setup.service        
+  71ms finalrd.service                       
+  68ms console-setup.service                 
+  52ms setvtrgb.service                      
+  50ms multipathd.service                    
+  47ms snap-core18-1932.mount                
+  45ms snap-lxd-18546.mount                  
+  44ms snap-snapd-10492.mount                
+  43ms snap-amazon\x2dssm\x2dagent-2996.mount
+  43ms snapd.socket                          
+  41ms systemd-udevd.service                 
+  22ms systemd-update-utmp.service           
+  19ms systemd-update-utmp-runlevel.service  
+  17ms user-runtime-dir@1000.service         
+  17ms systemd-tmpfiles-setup-dev.service    
+  17ms blk-availability.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00800s +00.00100s
+|`->found local data from DataSourceEc2Local @00.02000s +00.45600s
+Finished stage: (init-local) 00.88400 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @02.86100s +00.00400s
+|`->setting up datasource @02.91400s +00.00000s
+|`->reading and applying user-data @02.92100s +00.00300s
+|`->reading and applying vendor-data @02.92400s +00.00000s
+|`->activating datasource @02.95100s +00.00200s
+|`->config-migrator ran successfully @02.99100s +00.00100s
+|`->config-seed_random ran successfully @02.99200s +00.00100s
+|`->config-bootcmd ran successfully @02.99300s +00.00100s
+|`->config-write-files ran successfully @02.99400s +00.00100s
+|`->config-growpart ran successfully @02.99500s +00.11100s
+|`->config-resizefs ran successfully @03.10600s +00.09100s
+|`->config-disk_setup ran successfully @03.19800s +00.00000s
+|`->config-mounts ran successfully @03.19900s +00.00100s
+|`->config-set_hostname ran successfully @03.20000s +00.00600s
+|`->config-update_hostname ran successfully @03.20600s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.20700s +00.00100s
+|`->config-ca-certs ran successfully @03.20800s +00.00000s
+|`->config-rsyslog ran successfully @03.20900s +00.00000s
+|`->config-users-groups ran successfully @03.21000s +00.06600s
+|`->config-ssh ran successfully @03.27700s +00.17400s
+Finished stage: (init-network) 00.61600 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @13.82600s +00.00000s
+|`->config-snap ran successfully @13.82600s +00.00100s
+|`->config-ssh-import-id ran successfully @13.82700s +00.00100s
+|`->config-locale ran successfully @13.82800s +00.02400s
+|`->config-set-passwords ran successfully @13.85200s +00.00000s
+|`->config-grub-dpkg ran successfully @13.85300s +01.53900s
+|`->config-apt-pipelining ran successfully @15.39200s +00.00100s
+|`->config-apt-configure ran successfully @15.39300s +00.26100s
+|`->config-ubuntu-advantage ran successfully @15.65400s +00.00000s
+|`->config-ntp ran successfully @15.65500s +00.00000s
+|`->config-timezone ran successfully @15.65600s +00.00000s
+|`->config-disable-ec2-metadata ran successfully @15.65600s +00.00100s
+|`->config-runcmd ran successfully @15.65700s +00.00000s
+|`->config-byobu ran successfully @15.65800s +00.00000s
+Finished stage: (modules-config) 01.84900 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @16.23500s +00.00100s
+|`->config-fan ran successfully @16.23600s +00.00000s
+|`->config-landscape ran successfully @16.23700s +00.00000s
+|`->config-lxd ran successfully @16.23700s +00.00100s
+|`->config-ubuntu-drivers ran successfully @16.23800s +00.00100s
+|`->config-puppet ran successfully @16.23900s +00.00300s
+|`->config-chef ran successfully @16.24200s +00.00100s
+|`->config-mcollective ran successfully @16.24400s +00.00100s
+|`->config-salt-minion ran successfully @16.24500s +00.00000s
+|`->config-rightscale_userdata ran successfully @16.24600s +00.00000s
+|`->config-scripts-vendor ran successfully @16.24600s +00.00100s
+|`->config-scripts-per-once ran successfully @16.24700s +00.00100s
+|`->config-scripts-per-boot ran successfully @16.24800s +00.00000s
+|`->config-scripts-per-instance ran successfully @16.24800s +00.00100s
+|`->config-scripts-user ran successfully @16.24900s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @16.25000s +00.03200s
+|`->config-keys-to-console ran successfully @16.28200s +00.19100s
+|`->config-phone-home ran successfully @16.47400s +00.00400s
+|`->config-final-message ran successfully @16.47800s +00.01000s
+|`->config-power-state-change ran successfully @16.49300s +00.00300s
+Finished stage: (modules-final) 00.29000 seconds
+
+Total Time: 3.63900 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     01.53900s (modules-config/config-grub-dpkg)
+     00.45600s (init-local/search-Ec2Local)
+     00.26100s (modules-config/config-apt-configure)
+     00.19100s (modules-final/config-keys-to-console)
+     00.17400s (init-network/config-ssh)
+     00.11100s (init-network/config-growpart)
+     00.09100s (init-network/config-resizefs)
+     00.06600s (init-network/config-users-groups)
+     00.03200s (modules-final/config-ssh-authkey-fingerprints)
+     00.02400s (modules-config/config-locale)
+     00.01000s (modules-final/config-final-message)
+     00.00600s (init-network/config-set_hostname)
+     00.00400s (modules-final/config-phone-home)
+     00.00400s (init-network/check-cache)
+     00.00300s (modules-final/config-puppet)
+     00.00300s (modules-final/config-power-state-change)
+     00.00300s (init-network/consume-user-data)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (init-local/check-cache)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-fan)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-timezone)
+     00.00000s (modules-config/config-set-passwords)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-disk_setup)
+     00.00000s (init-network/config-ca-certs)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_xenial_after_201211154007.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_xenial_after_201211154007.log
@@ -1,0 +1,245 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~16.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/network/interfaces.d/50-cloud-init.cfg =====
+
+===== systemd-analyze =====
+Startup finished in 4.110s (kernel) + 9.724s (userspace) = 13.834s
+===== systemd-analyze blame =====
+          3.378s cloud-init-local.service
+          2.989s console-setup.service
+          2.625s dev-xvda1.device
+          2.111s snapd.service
+          1.988s systemd-update-utmp.service
+          1.972s apparmor.service
+          1.501s dev-loop0.device
+          1.488s dev-loop1.device
+          1.476s dev-loop2.device
+          1.405s systemd-timesyncd.service
+           974ms cloud-config.service
+           861ms cloud-init.service
+           617ms lvm2-monitor.service
+           546ms cloud-final.service
+           394ms accounts-daemon.service
+           374ms lxd-containers.service
+           290ms resolvconf.service
+           259ms mdadm.service
+           236ms systemd-remount-fs.service
+           219ms iscsid.service
+           219ms sys-kernel-debug.mount
+           215ms apport.service
+           213ms systemd-modules-load.service
+           213ms ondemand.service
+           212ms ssh.service
+           209ms keyboard-setup.service
+           205ms irqbalance.service
+           199ms ufw.service
+           188ms dev-mqueue.mount
+           182ms systemd-logind.service
+           173ms polkitd.service
+           138ms networking.service
+           135ms grub-common.service
+           132ms systemd-journald.service
+           123ms rc-local.service
+           117ms setvtrgb.service
+           114ms systemd-udev-trigger.service
+           108ms snap-core18-1932.mount
+           103ms kmod-static-nodes.service
+           103ms snapd.apparmor.service
+            96ms systemd-tmpfiles-setup.service
+            95ms plymouth-read-write.service
+            87ms rsyslog.service
+            79ms open-iscsi.service
+            78ms dev-hugepages.mount
+            71ms systemd-tmpfiles-setup-dev.service
+            61ms systemd-sysctl.service
+            60ms lxd.socket
+            58ms systemd-journal-flush.service
+            57ms snapd.socket
+            54ms sys-fs-fuse-connections.mount
+            52ms systemd-udevd.service
+            50ms snapd.seeded.service
+            43ms systemd-random-seed.service
+            38ms snap-amazon\x2dssm\x2dagent-2996.mount
+            36ms snap-snapd-10492.mount
+            25ms plymouth-quit.service
+            23ms user@1000.service
+            22ms plymouth-quit-wait.service
+            18ms systemd-user-sessions.service
+            15ms systemd-update-utmp-runlevel.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00900s +00.00000s
+|`->no local data found from DataSourceNoCloud @00.14700s +00.16000s
+|`->no local data found from DataSourceConfigDrive @00.30700s +00.17000s
+|`->no local data found from DataSourceOpenNebula @00.47700s +00.13400s
+|`->no local data found from DataSourceDigitalOcean @00.61100s +00.00700s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->Non-Azure DMI asset tag '' discovered. @00.61900s +00.00000s
+Finished stage: (azure-ds/_get_data) 00.00000 seconds
+
+Finished stage: (init-local/search-Azure) 00.00200 seconds
+
+|`->no local data found from DataSourceOVF @00.62000s +00.03500s
+|`->no local data found from DataSourceOpenStackLocal @00.65500s +00.00100s
+|`->no local data found from DataSourceCloudSigma @00.65600s +00.00100s
+|`->no local data found from DataSourceSmartOS @00.65700s +00.00100s
+|`->no local data found from DataSourceScaleway @00.66200s +00.00000s
+|`->found local data from DataSourceEc2Local @00.66300s +01.44300s
+Finished stage: (init-local) 02.18700 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @02.72300s +00.00400s
+|`->setting up datasource @02.79500s +00.00000s
+|`->reading and applying user-data @02.80400s +00.00400s
+|`->reading and applying vendor-data @02.80800s +00.00000s
+|`->activating datasource @02.83700s +00.00200s
+|`->config-migrator ran successfully @02.85700s +00.00000s
+|`->config-seed_random ran successfully @02.85800s +00.00100s
+|`->config-bootcmd ran successfully @02.85900s +00.00000s
+|`->config-write-files ran successfully @02.85900s +00.00100s
+|`->config-growpart ran successfully @02.86100s +00.04300s
+|`->config-resizefs ran successfully @02.90500s +00.01800s
+|`->config-disk_setup ran successfully @02.92400s +00.00100s
+|`->config-mounts ran successfully @02.92500s +00.00200s
+|`->config-set_hostname ran successfully @02.92700s +00.00500s
+|`->config-update_hostname ran successfully @02.93200s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.93400s +00.00000s
+|`->config-ca-certs ran successfully @02.93400s +00.00100s
+|`->config-rsyslog ran successfully @02.93500s +00.00100s
+|`->config-users-groups ran successfully @02.93600s +00.01500s
+|`->config-ssh ran successfully @02.95100s +00.21800s
+Finished stage: (init-network) 00.45900 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @06.36900s +00.00000s
+|`->config-snap ran successfully @06.37000s +00.00000s
+|`->config-ssh-import-id ran successfully @06.37100s +00.00000s
+|`->config-locale ran successfully @06.37200s +00.00100s
+|`->config-set-passwords ran successfully @06.37300s +00.00100s
+|`->config-grub-dpkg ran successfully @06.37400s +00.22000s
+|`->config-apt-pipelining ran successfully @06.59500s +00.00100s
+|`->config-apt-configure ran successfully @06.59600s +00.11500s
+|`->config-ubuntu-advantage ran successfully @06.71100s +00.00100s
+|`->config-ntp ran successfully @06.71200s +00.00100s
+|`->config-timezone ran successfully @06.71300s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @06.71400s +00.00000s
+|`->config-runcmd ran successfully @06.71400s +00.00100s
+|`->config-byobu ran successfully @06.71500s +00.00100s
+Finished stage: (modules-config) 00.36600 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @07.13300s +00.00100s
+|`->config-fan ran successfully @07.13400s +00.00100s
+|`->config-landscape ran successfully @07.13500s +00.00100s
+|`->config-lxd ran successfully @07.13600s +00.00100s
+|`->config-ubuntu-drivers ran successfully @07.13700s +00.00100s
+|`->config-puppet ran successfully @07.13800s +00.00100s
+|`->config-chef ran successfully @07.13900s +00.00000s
+|`->config-mcollective ran successfully @07.13900s +00.00100s
+|`->config-salt-minion ran successfully @07.14000s +00.00100s
+|`->config-reset_rmc ran successfully @07.14100s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @07.14300s +00.00000s
+|`->config-rightscale_userdata ran successfully @07.14300s +00.00100s
+|`->config-scripts-vendor ran successfully @07.14400s +00.00100s
+|`->config-scripts-per-once ran successfully @07.14500s +00.00100s
+|`->config-scripts-per-boot ran successfully @07.14600s +00.00000s
+|`->config-scripts-per-instance ran successfully @07.14700s +00.00100s
+|`->config-scripts-user ran successfully @07.14800s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @07.14900s +00.04000s
+|`->config-keys-to-console ran successfully @07.19000s +00.06600s
+|`->config-phone-home ran successfully @07.25600s +00.00100s
+|`->config-final-message ran successfully @07.25800s +00.00400s
+|`->config-power-state-change ran successfully @07.26200s +00.00100s
+Finished stage: (modules-final) 00.15400 seconds
+
+Total Time: 3.16800 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     01.44300s (init-local/search-Ec2Local)
+     00.22000s (modules-config/config-grub-dpkg)
+     00.21800s (init-network/config-ssh)
+     00.17000s (init-local/search-ConfigDrive)
+     00.16000s (init-local/search-NoCloud)
+     00.13400s (init-local/search-OpenNebula)
+     00.11500s (modules-config/config-apt-configure)
+     00.06600s (modules-final/config-keys-to-console)
+     00.04300s (init-network/config-growpart)
+     00.04000s (modules-final/config-ssh-authkey-fingerprints)
+     00.03500s (init-local/search-OVF)
+     00.01800s (init-network/config-resizefs)
+     00.01500s (init-network/config-users-groups)
+     00.00700s (init-local/search-DigitalOcean)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (init-network/consume-user-data)
+     00.00400s (init-network/check-cache)
+     00.00200s (init-network/config-mounts)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-locale)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-local/search-SmartOS)
+     00.00100s (init-local/search-OpenStackLocal)
+     00.00100s (init-local/search-CloudSigma)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ssh-import-id)
+     00.00000s (modules-config/config-snap)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/search-Scaleway)
+     00.00000s (init-local/check-cache)
+     00.00000s (azure-ds/check-platform-viability)
+
+1 boot records analyzed

--- a/manual/ec2-sru-20.4.0/test_upgrade_ec2_xenial_before_201211154007.log
+++ b/manual/ec2-sru-20.4.0/test_upgrade_ec2_xenial_before_201211154007.log
@@ -1,0 +1,243 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~16.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceEc2Local",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/network/interfaces.d/50-cloud-init.cfg =====
+
+===== systemd-analyze =====
+Startup finished in 4.130s (kernel) + 25.978s (userspace) = 30.109s
+===== systemd-analyze blame =====
+         13.850s snapd.seeded.service
+          4.283s cloud-init-local.service
+          3.797s console-setup.service
+          2.865s apparmor.service
+          2.561s cloud-config.service
+          2.185s dev-xvda1.device
+          1.230s pollinate.service
+          1.154s cloud-final.service
+          1.108s cloud-init.service
+          1.041s lxd-containers.service
+           847ms snapd.service
+           649ms accounts-daemon.service
+           395ms iscsid.service
+           368ms polkitd.service
+           345ms keyboard-setup.service
+           325ms systemd-remount-fs.service
+           298ms systemd-modules-load.service
+           270ms sys-kernel-debug.mount
+           250ms systemd-udev-trigger.service
+           249ms dev-mqueue.mount
+           238ms lvm2-monitor.service
+           229ms ufw.service
+           217ms rc-local.service
+           213ms resolvconf.service
+           212ms dev-hugepages.mount
+           192ms systemd-logind.service
+           174ms grub-common.service
+           173ms mdadm.service
+           162ms kmod-static-nodes.service
+           140ms ondemand.service
+           138ms systemd-journald.service
+           136ms systemd-udevd.service
+           136ms networking.service
+           104ms rsyslog.service
+            99ms apport.service
+            98ms irqbalance.service
+            83ms systemd-machine-id-commit.service
+            71ms systemd-sysctl.service
+            70ms systemd-tmpfiles-setup-dev.service
+            69ms plymouth-read-write.service
+            69ms systemd-tmpfiles-setup.service
+            60ms systemd-random-seed.service
+            57ms systemd-journal-flush.service
+            54ms lxd.socket
+            47ms snapd.socket
+            47ms setvtrgb.service
+            44ms systemd-update-utmp.service
+            39ms plymouth-quit.service
+            38ms systemd-timesyncd.service
+            35ms sys-fs-fuse-connections.mount
+            35ms snap-snapd-10492.mount
+            34ms user@1000.service
+            31ms open-iscsi.service
+            25ms snap-amazon\x2dssm\x2dagent-2996.mount
+            24ms snap-core18-1932.mount
+            20ms ssh.service
+            18ms systemd-user-sessions.service
+            16ms systemd-update-utmp-runlevel.service
+            15ms plymouth-quit-wait.service
+            15ms snapd.apparmor.service
+             6ms dev-loop2.device
+             5ms dev-loop1.device
+             2ms dev-loop0.device
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.03100s +00.00000s
+|`->no local data found from DataSourceNoCloud @00.19800s +00.25200s
+|`->no local data found from DataSourceConfigDrive @00.45000s +00.21600s
+|`->no local data found from DataSourceOpenNebula @00.66600s +00.13700s
+|`->no local data found from DataSourceDigitalOcean @00.80300s +00.01600s
+Starting stage: init-local/search-Azure
+Starting stage: azure-ds/_get_data
+|`->Non-Azure DMI asset tag '' discovered. @00.82000s +00.02300s
+Finished stage: (azure-ds/_get_data) 00.02300 seconds
+
+Finished stage: (init-local/search-Azure) 00.02400 seconds
+
+|`->no local data found from DataSourceOVF @00.84300s +00.07100s
+|`->no local data found from DataSourceOpenStackLocal @00.91400s +00.04900s
+|`->no local data found from DataSourceCloudSigma @00.96300s +00.01600s
+|`->no local data found from DataSourceSmartOS @00.97900s +00.02400s
+|`->no local data found from DataSourceScaleway @01.00300s +00.02200s
+|`->found local data from DataSourceEc2Local @01.02500s +01.60700s
+Finished stage: (init-local) 02.71200 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceEc2Local @03.25100s +00.00300s
+|`->setting up datasource @03.32100s +00.00000s
+|`->reading and applying user-data @03.32800s +00.00400s
+|`->reading and applying vendor-data @03.33200s +00.00000s
+|`->activating datasource @03.36200s +00.00200s
+|`->config-migrator ran successfully @03.38200s +00.00000s
+|`->config-seed_random ran successfully @03.38200s +00.00100s
+|`->config-bootcmd ran successfully @03.38400s +00.00000s
+|`->config-write-files ran successfully @03.38400s +00.00100s
+|`->config-growpart ran successfully @03.38500s +00.04100s
+|`->config-resizefs ran successfully @03.42600s +00.01500s
+|`->config-disk_setup ran successfully @03.44100s +00.00100s
+|`->config-mounts ran successfully @03.44300s +00.00100s
+|`->config-set_hostname ran successfully @03.44400s +00.00500s
+|`->config-update_hostname ran successfully @03.44900s +00.00200s
+|`->config-update_etc_hosts ran successfully @03.45100s +00.00000s
+|`->config-ca-certs ran successfully @03.45100s +00.00100s
+|`->config-rsyslog ran successfully @03.45200s +00.00100s
+|`->config-users-groups ran successfully @03.45400s +00.07200s
+|`->config-ssh ran successfully @03.52600s +00.42500s
+Finished stage: (init-network) 00.71600 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @20.30400s +00.00100s
+|`->config-snap ran successfully @20.30500s +00.00100s
+|`->config-ssh-import-id ran successfully @20.30600s +00.00100s
+|`->config-locale ran successfully @20.30700s +01.65900s
+|`->config-set-passwords ran successfully @21.96700s +00.00100s
+|`->config-grub-dpkg ran successfully @21.96800s +00.35500s
+|`->config-apt-pipelining ran successfully @22.32300s +00.00100s
+|`->config-apt-configure ran successfully @22.32500s +00.10000s
+|`->config-ubuntu-advantage ran successfully @22.42500s +00.00100s
+|`->config-ntp ran successfully @22.42600s +00.00100s
+|`->config-timezone ran successfully @22.42700s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @22.42800s +00.00000s
+|`->config-runcmd ran successfully @22.42900s +00.00000s
+|`->config-byobu ran successfully @22.43000s +00.00000s
+Finished stage: (modules-config) 02.14500 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @23.15500s +00.00000s
+|`->config-fan ran successfully @23.15600s +00.00100s
+|`->config-landscape ran successfully @23.15700s +00.00600s
+|`->config-lxd ran successfully @23.16400s +00.00000s
+|`->config-ubuntu-drivers ran successfully @23.16500s +00.00500s
+|`->config-puppet ran successfully @23.17000s +00.00100s
+|`->config-chef ran successfully @23.17100s +00.00100s
+|`->config-mcollective ran successfully @23.17200s +00.00100s
+|`->config-salt-minion ran successfully @23.17900s +00.00000s
+|`->config-rightscale_userdata ran successfully @23.18000s +00.00000s
+|`->config-scripts-vendor ran successfully @23.18100s +00.00000s
+|`->config-scripts-per-once ran successfully @23.18200s +00.00000s
+|`->config-scripts-per-boot ran successfully @23.18300s +00.00000s
+|`->config-scripts-per-instance ran successfully @23.18300s +00.00100s
+|`->config-scripts-user ran successfully @23.18400s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @23.19200s +00.10200s
+|`->config-keys-to-console ran successfully @23.29400s +00.21900s
+|`->config-phone-home ran successfully @23.51800s +00.00100s
+|`->config-final-message ran successfully @23.51900s +00.00600s
+|`->config-power-state-change ran successfully @23.52800s +00.00100s
+Finished stage: (modules-final) 00.46200 seconds
+
+Total Time: 6.08200 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     01.65900s (modules-config/config-locale)
+     01.60700s (init-local/search-Ec2Local)
+     00.42500s (init-network/config-ssh)
+     00.35500s (modules-config/config-grub-dpkg)
+     00.25200s (init-local/search-NoCloud)
+     00.21900s (modules-final/config-keys-to-console)
+     00.21600s (init-local/search-ConfigDrive)
+     00.13700s (init-local/search-OpenNebula)
+     00.10200s (modules-final/config-ssh-authkey-fingerprints)
+     00.10000s (modules-config/config-apt-configure)
+     00.07200s (init-network/config-users-groups)
+     00.07100s (init-local/search-OVF)
+     00.04900s (init-local/search-OpenStackLocal)
+     00.04100s (init-network/config-growpart)
+     00.02400s (init-local/search-SmartOS)
+     00.02300s (azure-ds/check-platform-viability)
+     00.02200s (init-local/search-Scaleway)
+     00.01600s (init-local/search-DigitalOcean)
+     00.01600s (init-local/search-CloudSigma)
+     00.01500s (init-network/config-resizefs)
+     00.00600s (modules-final/config-landscape)
+     00.00600s (modules-final/config-final-message)
+     00.00500s (modules-final/config-ubuntu-drivers)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (init-network/consume-user-data)
+     00.00300s (init-network/check-cache)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-package-update-upgrade-install)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0.txt
+++ b/manual/gce-sru-20.4.0.txt
@@ -1,0 +1,289 @@
+Upstream test at:
+https://github.com/canonical/cloud-init/blob/master/tests/integration_tests/test_upgrade.py
+
+Logs from individual before/after runs in gce-sru-20.4.0 subdirectory
+
+==== Xenial ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=xenial
+PLATFORM=gce
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=xenial
+PLATFORM=gce
+RUN_UNSTABLE=False
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1604-xenial-v20201210
+wait=False
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1604-xenial-v20201210
+wait=False
+Launched instance: GceInstance(instance_id=5326178758279714545)
+Launched instance: GceInstance(instance_id=5326178758279714545)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~16.04.1
+Installed cloud-init version: 20.4-0ubuntu1~16.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_xenial_before_201211154340.log and /tmp/cloud_init_test_logs/test_upgrade_gce_xenial_after_201211154340.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_xenial_before_201211154340.log and /tmp/cloud_init_test_logs/test_upgrade_gce_xenial_after_201211154340.log
+.
+
+=========================================================================================== 1 passed in 146.00s (0:02:26) ===========================================================================================
+
+==== Bionic ====
+
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=bionic
+PLATFORM=gce
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=bionic
+PLATFORM=gce
+RUN_UNSTABLE=False
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20201211a
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-1804-bionic-v20201211a
+Launched instance: GceInstance(instance_id=1727796673121244227)
+Launched instance: GceInstance(instance_id=1727796673121244227)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~18.04.1
+Installed cloud-init version: 20.4-0ubuntu1~18.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_bionic_before_201211155437.log and /tmp/cloud_init_test_logs/test_upgrade_gce_bionic_after_201211155437.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_bionic_before_201211155437.log and /tmp/cloud_init_test_logs/test_upgrade_gce_bionic_after_201211155437.log
+.
+
+=========================================================================================== 1 passed in 146.39s (0:02:26) ===========================================================================================
+
+==== Focal ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=focal
+PLATFORM=gce
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=focal
+PLATFORM=gce
+RUN_UNSTABLE=False
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20201211
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2004-focal-v20201211
+Launched instance: GceInstance(instance_id=3221830879877682049)
+Launched instance: GceInstance(instance_id=3221830879877682049)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~20.04.1
+Installed cloud-init version: 20.4-0ubuntu1~20.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_focal_before_201211160622.log and /tmp/cloud_init_test_logs/test_upgrade_gce_focal_after_201211160622.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_focal_before_201211160622.log and /tmp/cloud_init_test_logs/test_upgrade_gce_focal_after_201211160622.log
+.
+
+=========================================================================================== 1 passed in 185.57s (0:03:05) ===========================================================================================
+
+==== Groovy ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=groovy
+PLATFORM=gce
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=groovy
+PLATFORM=gce
+RUN_UNSTABLE=False
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Detected image: image_id=groovy os=ubuntu release=groovy
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2010-groovy-v20201210
+wait=False
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=projects/ubuntu-os-cloud-devel/global/images/daily-ubuntu-2010-groovy-v20201210
+wait=False
+Launched instance: GceInstance(instance_id=7135800809689599695)
+Launched instance: GceInstance(instance_id=7135800809689599695)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~20.10.1
+Installed cloud-init version: 20.4-0ubuntu1~20.10.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_groovy_before_201211161750.log and /tmp/cloud_init_test_logs/test_upgrade_gce_groovy_after_201211161750.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_gce_groovy_before_201211161750.log and /tmp/cloud_init_test_logs/test_upgrade_gce_groovy_after_201211161750.log
+.
+
+=========================================================================================== 1 passed in 172.79s (0:02:52) ===========================================================================================

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_bionic_after_201211155437.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_bionic_after_201211155437.log
@@ -1,0 +1,226 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~18.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 3.988s (kernel) + 17.071s (userspace) = 21.060s
+graphical.target reached after 13.751s in userspace
+===== systemd-analyze blame =====
+          3.809s grub-common.service
+          3.552s apport.service
+          2.856s rsyslog.service
+          2.823s networkd-dispatcher.service
+          2.786s lxd-containers.service
+          2.368s google-oslogin-cache.service
+          1.964s cloud-config.service
+          1.931s dev-sda1.device
+          1.723s accounts-daemon.service
+          1.590s systemd-networkd-wait-online.service
+          1.367s snapd.service
+          1.357s systemd-user-sessions.service
+          1.331s cloud-init-local.service
+          1.163s cloud-init.service
+          1.023s sshguard.service
+          1.017s polkit.service
+          1.013s systemd-hostnamed.service
+           818ms systemd-logind.service
+           816ms cloud-final.service
+           676ms google-instance-setup.service
+           622ms ssh.service
+           612ms google-shutdown-scripts.service
+           537ms google-startup-scripts.service
+           479ms blk-availability.service
+           439ms dev-loop1.device
+           439ms dev-loop0.device
+           409ms systemd-journal-flush.service
+           401ms dev-loop2.device
+           381ms apparmor.service
+           341ms plymouth-quit.service
+           341ms plymouth-quit-wait.service
+           313ms snapd.seeded.service
+           312ms setvtrgb.service
+           295ms snapd.socket
+           246ms lxd.socket
+           231ms lvm2-monitor.service
+           163ms systemd-modules-load.service
+           159ms systemd-remount-fs.service
+           155ms ufw.service
+           155ms dev-mqueue.mount
+           139ms systemd-udev-trigger.service
+           112ms systemd-udevd.service
+           106ms dev-hugepages.mount
+            99ms systemd-tmpfiles-setup.service
+            97ms keyboard-setup.service
+            89ms kmod-static-nodes.service
+            84ms user@1000.service
+            79ms systemd-journald.service
+            79ms sys-kernel-debug.mount
+            77ms systemd-networkd.service
+            77ms systemd-tmpfiles-setup-dev.service
+            75ms ebtables.service
+            55ms systemd-sysctl.service
+            49ms systemd-resolved.service
+            49ms snap-google\x2dcloud\x2dsdk-161.mount
+            46ms snap-snapd-10492.mount
+            46ms snap-core18-1932.mount
+            45ms chrony.service
+            38ms snapd.apparmor.service
+            33ms plymouth-read-write.service
+            22ms sys-fs-fuse-connections.mount
+            21ms sys-kernel-config.mount
+            21ms systemd-random-seed.service
+            18ms console-setup.service
+            18ms boot-efi.mount
+            17ms systemd-update-utmp-runlevel.service
+             9ms systemd-update-utmp.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Finished stage: (init-local) 00.19800 seconds
+
+Starting stage: init-network
+|`->no cache found @02.45100s +00.00100s
+|`->found network data from DataSourceGCE @02.45500s +00.05500s
+|`->setting up datasource @02.68000s +00.00100s
+|`->reading and applying user-data @02.69300s +00.00300s
+|`->reading and applying vendor-data @02.69600s +00.00000s
+|`->activating datasource @02.72100s +00.00100s
+|`->config-migrator ran successfully @02.74300s +00.00100s
+|`->config-seed_random ran successfully @02.74400s +00.00100s
+|`->config-bootcmd ran successfully @02.74500s +00.00000s
+|`->config-write-files ran successfully @02.74600s +00.00000s
+|`->config-growpart ran successfully @02.74700s +00.06300s
+|`->config-resizefs ran successfully @02.81100s +00.03100s
+|`->config-disk_setup ran successfully @02.84200s +00.00200s
+|`->config-mounts ran successfully @02.84400s +00.00400s
+|`->config-set_hostname ran successfully @02.84800s +00.00500s
+|`->config-update_hostname ran successfully @02.85400s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.85500s +00.00000s
+|`->config-ca-certs ran successfully @02.85500s +00.00100s
+|`->config-rsyslog ran successfully @02.85600s +00.00100s
+|`->config-users-groups ran successfully @02.85700s +00.05600s
+|`->config-ssh ran successfully @02.91300s +00.19800s
+Finished stage: (init-network) 00.67500 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @10.33500s +00.00000s
+|`->config-snap ran successfully @10.33500s +00.00100s
+|`->config-ssh-import-id ran successfully @10.33600s +00.00100s
+|`->config-locale ran successfully @10.33700s +00.00600s
+|`->config-set-passwords ran successfully @10.34300s +00.00000s
+|`->config-grub-dpkg ran successfully @10.34300s +00.53300s
+|`->config-apt-pipelining ran successfully @10.87600s +00.00100s
+|`->config-apt-configure ran successfully @10.87800s +00.14500s
+|`->config-ubuntu-advantage ran successfully @11.02300s +00.00000s
+|`->config-ntp ran successfully @11.02400s +00.71100s
+|`->config-timezone ran successfully @11.73500s +00.00200s
+|`->config-disable-ec2-metadata ran successfully @11.73700s +00.00000s
+|`->config-runcmd ran successfully @11.73700s +00.00100s
+|`->config-byobu ran successfully @11.73800s +00.00100s
+Finished stage: (modules-config) 01.42800 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @12.97000s +00.00100s
+|`->config-fan ran successfully @12.97100s +00.00100s
+|`->config-landscape ran successfully @12.97200s +00.00000s
+|`->config-lxd ran successfully @12.97300s +00.00000s
+|`->config-ubuntu-drivers ran successfully @12.97300s +00.00100s
+|`->config-puppet ran successfully @12.97400s +00.00100s
+|`->config-chef ran successfully @12.97500s +00.00000s
+|`->config-mcollective ran successfully @12.97500s +00.00100s
+|`->config-salt-minion ran successfully @12.97600s +00.00100s
+|`->config-reset_rmc ran successfully @12.97700s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @12.97900s +00.00000s
+|`->config-rightscale_userdata ran successfully @12.97900s +00.00100s
+|`->config-scripts-vendor ran successfully @12.98000s +00.00000s
+|`->config-scripts-per-once ran successfully @12.98100s +00.00000s
+|`->config-scripts-per-boot ran successfully @12.98100s +00.00100s
+|`->config-scripts-per-instance ran successfully @12.98200s +00.00000s
+|`->config-scripts-user ran successfully @12.98200s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @12.98300s +00.00200s
+|`->config-keys-to-console ran successfully @12.98500s +00.02400s
+|`->config-phone-home ran successfully @13.01000s +00.00100s
+|`->config-final-message ran successfully @13.01100s +00.00500s
+|`->config-power-state-change ran successfully @13.01600s +00.00100s
+Finished stage: (modules-final) 00.09600 seconds
+
+Total Time: 2.39700 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.71100s (modules-config/config-ntp)
+     00.53300s (modules-config/config-grub-dpkg)
+     00.19800s (init-network/config-ssh)
+     00.14500s (modules-config/config-apt-configure)
+     00.06300s (init-network/config-growpart)
+     00.05600s (init-network/config-users-groups)
+     00.05500s (init-network/search-GCE)
+     00.03100s (init-network/config-resizefs)
+     00.02400s (modules-final/config-keys-to-console)
+     00.00600s (modules-config/config-locale)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (init-network/config-mounts)
+     00.00300s (init-network/consume-user-data)
+     00.00200s (modules-final/config-ssh-authkey-fingerprints)
+     00.00200s (modules-config/config-timezone)
+     00.00200s (init-network/config-disk_setup)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/setup-datasource)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/check-cache)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-instance)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-set-passwords)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_bionic_before_201211155437.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_bionic_before_201211155437.log
@@ -1,0 +1,224 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~18.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 3.754s (kernel) + 28.762s (userspace) = 32.517s
+graphical.target reached after 26.733s in userspace
+===== systemd-analyze blame =====
+         14.536s snapd.seeded.service
+          2.748s accounts-daemon.service
+          2.648s apport.service
+          1.913s systemd-networkd-wait-online.service
+          1.892s systemd-user-sessions.service
+          1.860s lxd-containers.service
+          1.843s pollinate.service
+          1.794s sshguard.service
+          1.721s grub-common.service
+          1.586s networkd-dispatcher.service
+          1.458s cloud-init.service
+          1.396s cloud-init-local.service
+          1.376s google-oslogin-cache.service
+          1.364s polkit.service
+          1.265s rsyslog.service
+          1.262s dev-sda1.device
+          1.102s cloud-config.service
+          1.053s systemd-logind.service
+          1.019s snapd.service
+          1.004s apparmor.service
+           709ms ssh.service
+           694ms systemd-hostnamed.service
+           683ms google-shutdown-scripts.service
+           683ms google-instance-setup.service
+           628ms cloud-final.service
+           527ms blk-availability.service
+           348ms plymouth-quit-wait.service
+           345ms plymouth-quit.service
+           287ms google-startup-scripts.service
+           260ms snap-snapd-10492.mount
+           222ms systemd-udev-trigger.service
+           215ms dev-hugepages.mount
+           206ms systemd-remount-fs.service
+           205ms systemd-modules-load.service
+           196ms dev-mqueue.mount
+           194ms lvm2-monitor.service
+           191ms ufw.service
+           187ms sys-kernel-debug.mount
+           154ms systemd-journal-flush.service
+           151ms snapd.socket
+           125ms kmod-static-nodes.service
+           118ms lxd.socket
+           115ms keyboard-setup.service
+           111ms ebtables.service
+           107ms user@1000.service
+            98ms systemd-networkd.service
+            87ms systemd-sysctl.service
+            87ms systemd-tmpfiles-setup-dev.service
+            87ms sys-fs-fuse-connections.mount
+            87ms sys-kernel-config.mount
+            79ms systemd-random-seed.service
+            73ms systemd-udevd.service
+            67ms systemd-journald.service
+            65ms dev-loop1.device
+            61ms systemd-tmpfiles-setup.service
+            50ms chrony.service
+            48ms systemd-resolved.service
+            45ms snap-core18-1932.mount
+            42ms plymouth-read-write.service
+            37ms dev-loop2.device
+            33ms systemd-machine-id-commit.service
+            29ms snap-google\x2dcloud\x2dsdk-161.mount
+            23ms snapd.apparmor.service
+            21ms systemd-update-utmp.service
+            20ms systemd-update-utmp-runlevel.service
+            14ms boot-efi.mount
+            13ms console-setup.service
+             9ms setvtrgb.service
+             1ms dev-loop0.device
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Finished stage: (init-local) 00.20100 seconds
+
+Starting stage: init-network
+|`->no cache found @02.78500s +00.00000s
+|`->found network data from DataSourceGCE @02.79000s +00.06800s
+|`->setting up datasource @03.03200s +00.00000s
+|`->reading and applying user-data @03.04600s +00.00300s
+|`->reading and applying vendor-data @03.05000s +00.00000s
+|`->activating datasource @03.07400s +00.00100s
+|`->config-migrator ran successfully @03.10000s +00.00100s
+|`->config-seed_random ran successfully @03.10100s +00.00100s
+|`->config-bootcmd ran successfully @03.10300s +00.00000s
+|`->config-write-files ran successfully @03.10300s +00.00100s
+|`->config-growpart ran successfully @03.10400s +00.16300s
+|`->config-resizefs ran successfully @03.26700s +00.13100s
+|`->config-disk_setup ran successfully @03.39800s +00.00100s
+|`->config-mounts ran successfully @03.40000s +00.00100s
+|`->config-set_hostname ran successfully @03.40100s +00.00500s
+|`->config-update_hostname ran successfully @03.40700s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.40800s +00.00000s
+|`->config-ca-certs ran successfully @03.40900s +00.00000s
+|`->config-rsyslog ran successfully @03.40900s +00.00100s
+|`->config-users-groups ran successfully @03.41000s +00.08500s
+|`->config-ssh ran successfully @03.49500s +00.22200s
+Finished stage: (init-network) 00.95000 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @23.54200s +00.00100s
+|`->config-snap ran successfully @23.54300s +00.00000s
+|`->config-ssh-import-id ran successfully @23.54400s +00.00000s
+|`->config-locale ran successfully @23.54500s +00.00400s
+|`->config-set-passwords ran successfully @23.54900s +00.00100s
+|`->config-grub-dpkg ran successfully @23.55000s +00.26800s
+|`->config-apt-pipelining ran successfully @23.81800s +00.00100s
+|`->config-apt-configure ran successfully @23.81900s +00.09800s
+|`->config-ubuntu-advantage ran successfully @23.91800s +00.00100s
+|`->config-ntp ran successfully @23.91900s +00.07200s
+|`->config-timezone ran successfully @23.99100s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @23.99300s +00.00000s
+|`->config-runcmd ran successfully @23.99300s +00.00100s
+|`->config-byobu ran successfully @23.99400s +00.00000s
+Finished stage: (modules-config) 00.48600 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @24.61300s +00.00100s
+|`->config-fan ran successfully @24.61400s +00.00100s
+|`->config-landscape ran successfully @24.61500s +00.00000s
+|`->config-lxd ran successfully @24.61500s +00.00100s
+|`->config-ubuntu-drivers ran successfully @24.61600s +00.00100s
+|`->config-puppet ran successfully @24.61700s +00.00100s
+|`->config-chef ran successfully @24.61800s +00.00000s
+|`->config-mcollective ran successfully @24.61800s +00.00100s
+|`->config-salt-minion ran successfully @24.61900s +00.00000s
+|`->config-rightscale_userdata ran successfully @24.61900s +00.00100s
+|`->config-scripts-vendor ran successfully @24.62000s +00.00100s
+|`->config-scripts-per-once ran successfully @24.62100s +00.00100s
+|`->config-scripts-per-boot ran successfully @24.62200s +00.00000s
+|`->config-scripts-per-instance ran successfully @24.62200s +00.00100s
+|`->config-scripts-user ran successfully @24.62300s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @24.62400s +00.00200s
+|`->config-keys-to-console ran successfully @24.62600s +00.02600s
+|`->config-phone-home ran successfully @24.65300s +00.00100s
+|`->config-final-message ran successfully @24.65400s +00.00500s
+|`->config-power-state-change ran successfully @24.65900s +00.00100s
+Finished stage: (modules-final) 00.08200 seconds
+
+Total Time: 1.71900 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.26800s (modules-config/config-grub-dpkg)
+     00.22200s (init-network/config-ssh)
+     00.16300s (init-network/config-growpart)
+     00.13100s (init-network/config-resizefs)
+     00.09800s (modules-config/config-apt-configure)
+     00.08500s (init-network/config-users-groups)
+     00.07200s (modules-config/config-ntp)
+     00.06800s (init-network/search-GCE)
+     00.02600s (modules-final/config-keys-to-console)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (modules-config/config-locale)
+     00.00300s (init-network/consume-user-data)
+     00.00200s (modules-final/config-ssh-authkey-fingerprints)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ssh-import-id)
+     00.00000s (modules-config/config-snap)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_focal_after_201211160622.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_focal_after_201211160622.log
@@ -1,0 +1,236 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~20.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.434s (kernel) + 23.960s (userspace) = 25.394s 
+graphical.target reached after 21.651s in userspace
+===== systemd-analyze blame =====
+11.872s accounts-daemon.service              
+ 6.079s polkit.service                       
+ 5.726s google-shutdown-scripts.service      
+ 3.786s networkd-dispatcher.service          
+ 3.706s snap.lxd.activate.service            
+ 3.135s grub-common.service                  
+ 3.010s systemd-logind.service               
+ 2.798s setvtrgb.service                     
+ 2.344s snapd.service                        
+ 2.184s apport.service                       
+ 2.078s cloud-init-local.service             
+ 2.061s snapd.seeded.service                 
+ 1.777s cloud-init.service                   
+ 1.698s google-instance-setup.service        
+ 1.686s plymouth-quit-wait.service           
+ 1.504s lvm2-monitor.service                 
+ 1.490s systemd-networkd-wait-online.service 
+ 1.390s cloud-config.service                 
+ 1.379s ssh.service                          
+ 1.355s plymouth-quit.service                
+ 1.303s dev-sda1.device                      
+ 1.184s systemd-udev-settle.service          
+  718ms systemd-hostnamed.service            
+  594ms cloud-final.service                  
+  488ms atd.service                          
+  379ms systemd-journal-flush.service        
+  341ms google-startup-scripts.service       
+  325ms snapd.apparmor.service               
+  287ms secureboot-db.service                
+  285ms rsyslog.service                      
+  283ms snapd.socket                         
+  283ms grub-initrd-fallback.service         
+  260ms google-oslogin-cache.service         
+  250ms e2scrub_reap.service                 
+  235ms systemd-journald.service             
+  220ms keyboard-setup.service               
+  211ms dev-loop2.device                     
+  202ms sys-kernel-tracing.mount             
+  201ms dev-loop3.device                     
+  197ms sys-kernel-debug.mount               
+  190ms kmod-static-nodes.service            
+  189ms dev-mqueue.mount                     
+  183ms systemd-udev-trigger.service         
+  180ms dev-hugepages.mount                  
+  168ms modprobe@drm.service                 
+  162ms systemd-resolved.service             
+  150ms user@1000.service                    
+  133ms apparmor.service                     
+  131ms systemd-modules-load.service         
+  118ms systemd-remount-fs.service           
+  103ms ufw.service                          
+  101ms systemd-networkd.service             
+   99ms blk-availability.service             
+   99ms systemd-user-sessions.service        
+   97ms systemd-udevd.service                
+   93ms systemd-sysusers.service             
+   77ms chrony.service                       
+   69ms multipathd.service                   
+   68ms systemd-tmpfiles-setup.service       
+   64ms snap-lxd-18150.mount                 
+   63ms dev-loop0.device                     
+   63ms snap-snapd-10492.mount               
+   59ms snap-google\x2dcloud\x2dsdk-161.mount
+   56ms sys-fs-fuse-connections.mount        
+   55ms boot-efi.mount                       
+   55ms snap-core18-1932.mount               
+   52ms dev-loop1.device                     
+   45ms sys-kernel-config.mount              
+   42ms systemd-sysctl.service               
+   36ms systemd-random-seed.service          
+   31ms console-setup.service                
+   28ms plymouth-read-write.service          
+   26ms finalrd.service                      
+   22ms systemd-tmpfiles-setup-dev.service   
+   22ms systemd-update-utmp-runlevel.service 
+   21ms user-runtime-dir@1000.service        
+   16ms systemd-update-utmp.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+Finished stage: (init-local) 00.22100 seconds
+
+Starting stage: init-network
+|`->no cache found @02.32000s +00.00100s
+|`->found network data from DataSourceGCE @02.32400s +00.05900s
+|`->setting up datasource @02.54400s +00.00100s
+|`->reading and applying user-data @02.55800s +00.00300s
+|`->reading and applying vendor-data @02.56100s +00.00000s
+|`->activating datasource @02.58500s +00.00100s
+|`->config-migrator ran successfully @02.61000s +00.00100s
+|`->config-seed_random ran successfully @02.61100s +00.00100s
+|`->config-bootcmd ran successfully @02.61200s +00.00000s
+|`->config-write-files ran successfully @02.61300s +00.00000s
+|`->config-growpart ran successfully @02.61300s +00.06300s
+|`->config-resizefs ran successfully @02.67700s +00.08500s
+|`->config-disk_setup ran successfully @02.76300s +00.00100s
+|`->config-mounts ran successfully @02.76400s +00.00100s
+|`->config-set_hostname ran successfully @02.76600s +00.00400s
+|`->config-update_hostname ran successfully @02.77100s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.77200s +00.00100s
+|`->config-ca-certs ran successfully @02.77300s +00.00000s
+|`->config-rsyslog ran successfully @02.77400s +00.02200s
+|`->config-users-groups ran successfully @02.79600s +00.02400s
+|`->config-ssh ran successfully @02.82000s +00.80500s
+Finished stage: (init-network) 01.32200 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @18.53900s +00.00100s
+|`->config-snap ran successfully @18.54000s +00.00000s
+|`->config-ssh-import-id ran successfully @18.54100s +00.00000s
+|`->config-locale ran successfully @18.54100s +00.02600s
+|`->config-set-passwords ran successfully @18.56700s +00.00100s
+|`->config-grub-dpkg ran successfully @18.56800s +00.41600s
+|`->config-apt-pipelining ran successfully @18.98400s +00.00100s
+|`->config-apt-configure ran successfully @18.98600s +00.12200s
+|`->config-ubuntu-advantage ran successfully @19.10900s +00.00000s
+|`->config-ntp ran successfully @19.10900s +00.09700s
+|`->config-timezone ran successfully @19.20800s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @19.20900s +00.00000s
+|`->config-runcmd ran successfully @19.20900s +00.00100s
+|`->config-byobu ran successfully @19.21000s +00.00100s
+Finished stage: (modules-config) 00.76100 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @19.76600s +00.00000s
+|`->config-fan ran successfully @19.76700s +00.00000s
+|`->config-landscape ran successfully @19.76700s +00.00100s
+|`->config-lxd ran successfully @19.76800s +00.00100s
+|`->config-ubuntu-drivers ran successfully @19.76900s +00.00000s
+|`->config-puppet ran successfully @19.76900s +00.00100s
+|`->config-chef ran successfully @19.77000s +00.00000s
+|`->config-mcollective ran successfully @19.77000s +00.00100s
+|`->config-salt-minion ran successfully @19.77100s +00.00000s
+|`->config-reset_rmc ran successfully @19.77200s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @19.77300s +00.00000s
+|`->config-rightscale_userdata ran successfully @19.77400s +00.00000s
+|`->config-scripts-vendor ran successfully @19.77400s +00.00100s
+|`->config-scripts-per-once ran successfully @19.77500s +00.00100s
+|`->config-scripts-per-boot ran successfully @19.77600s +00.00000s
+|`->config-scripts-per-instance ran successfully @19.77700s +00.00100s
+|`->config-scripts-user ran successfully @19.77800s +00.00000s
+|`->config-ssh-authkey-fingerprints ran successfully @19.77900s +00.00100s
+|`->config-keys-to-console ran successfully @19.78100s +00.03500s
+|`->config-phone-home ran successfully @19.81700s +00.00100s
+|`->config-final-message ran successfully @19.81800s +00.00400s
+|`->config-power-state-change ran successfully @19.82300s +00.00000s
+Finished stage: (modules-final) 00.10500 seconds
+
+Total Time: 2.40900 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.80500s (init-network/config-ssh)
+     00.41600s (modules-config/config-grub-dpkg)
+     00.12200s (modules-config/config-apt-configure)
+     00.09700s (modules-config/config-ntp)
+     00.08500s (init-network/config-resizefs)
+     00.06300s (init-network/config-growpart)
+     00.05900s (init-network/search-GCE)
+     00.03500s (modules-final/config-keys-to-console)
+     00.02600s (modules-config/config-locale)
+     00.02400s (init-network/config-users-groups)
+     00.02200s (init-network/config-rsyslog)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (init-network/config-set_hostname)
+     00.00300s (init-network/consume-user-data)
+     00.00100s (modules-final/config-ssh-authkey-fingerprints)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/setup-datasource)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/check-cache)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-user)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-final/config-power-state-change)
+     00.00000s (modules-final/config-package-update-upgrade-install)
+     00.00000s (modules-final/config-fan)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-ssh-import-id)
+     00.00000s (modules-config/config-snap)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_focal_before_201211160622.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_focal_before_201211160622.log
@@ -1,0 +1,234 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~20.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.097s (kernel) + 29.264s (userspace) = 30.361s 
+graphical.target reached after 27.286s in userspace
+===== systemd-analyze blame =====
+11.625s accounts-daemon.service              
+10.621s systemd-logind.service               
+10.057s networkd-dispatcher.service          
+ 6.835s snapd.seeded.service                 
+ 5.392s grub-common.service                  
+ 5.315s pollinate.service                    
+ 2.544s snapd.apparmor.service               
+ 2.032s google-instance-setup.service        
+ 1.973s cloud-init.service                   
+ 1.607s cloud-init-local.service             
+ 1.583s snapd.service                        
+ 1.521s apport.service                       
+ 1.475s lvm2-monitor.service                 
+ 1.366s plymouth-quit-wait.service           
+ 1.338s systemd-networkd-wait-online.service 
+ 1.274s dev-sda1.device                      
+ 1.150s cloud-config.service                 
+ 1.063s systemd-udev-settle.service          
+  882ms apparmor.service                     
+  773ms snap.lxd.activate.service            
+  627ms systemd-hostnamed.service            
+  567ms atd.service                          
+  533ms cloud-final.service                  
+  363ms snapd.socket                         
+  340ms plymouth-quit.service                
+  295ms google-startup-scripts.service       
+  273ms rsyslog.service                      
+  252ms systemd-udev-trigger.service         
+  240ms secureboot-db.service                
+  239ms grub-initrd-fallback.service         
+  228ms keyboard-setup.service               
+  223ms systemd-resolved.service             
+  219ms google-oslogin-cache.service         
+  218ms systemd-journald.service             
+  207ms sys-kernel-tracing.mount             
+  204ms e2scrub_reap.service                 
+  199ms sys-kernel-debug.mount               
+  198ms ssh.service                          
+  192ms dev-mqueue.mount                     
+  192ms kmod-static-nodes.service            
+  185ms dev-hugepages.mount                  
+  176ms google-shutdown-scripts.service      
+  171ms dev-loop3.device                     
+  162ms polkit.service                       
+  162ms modprobe@drm.service                 
+  159ms systemd-remount-fs.service           
+  158ms systemd-modules-load.service         
+  137ms user@1000.service                    
+  137ms ufw.service                          
+  126ms systemd-networkd.service             
+  122ms setvtrgb.service                     
+   95ms blk-availability.service             
+   88ms systemd-sysusers.service             
+   86ms systemd-user-sessions.service        
+   80ms chrony.service                       
+   72ms multipathd.service                   
+   66ms systemd-udevd.service                
+   60ms boot-efi.mount                       
+   59ms snap-core18-1932.mount               
+   59ms systemd-tmpfiles-setup.service       
+   59ms dev-loop1.device                     
+   59ms dev-loop0.device                     
+   59ms snap-snapd-10492.mount               
+   58ms snap-lxd-18150.mount                 
+   58ms snap-google\x2dcloud\x2dsdk-161.mount
+   56ms systemd-machine-id-commit.service    
+   55ms systemd-sysctl.service               
+   54ms sys-fs-fuse-connections.mount        
+   52ms systemd-journal-flush.service        
+   49ms plymouth-read-write.service          
+   48ms dev-loop2.device                     
+   46ms sys-kernel-config.mount              
+   45ms finalrd.service                      
+   44ms console-setup.service                
+   35ms systemd-random-seed.service          
+   34ms systemd-update-utmp-runlevel.service 
+   21ms systemd-tmpfiles-setup-dev.service   
+   19ms user-runtime-dir@1000.service        
+   14ms systemd-update-utmp.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00800s +00.00000s
+Finished stage: (init-local) 00.36200 seconds
+
+Starting stage: init-network
+|`->no cache found @02.36700s +00.00000s
+|`->found network data from DataSourceGCE @02.37000s +00.06200s
+|`->setting up datasource @02.58400s +00.00100s
+|`->reading and applying user-data @02.59700s +00.00400s
+|`->reading and applying vendor-data @02.60100s +00.00000s
+|`->activating datasource @02.62300s +00.00100s
+|`->config-migrator ran successfully @02.64800s +00.00000s
+|`->config-seed_random ran successfully @02.64900s +00.00000s
+|`->config-bootcmd ran successfully @02.65000s +00.00000s
+|`->config-write-files ran successfully @02.65000s +00.00100s
+|`->config-growpart ran successfully @02.65100s +00.42300s
+|`->config-resizefs ran successfully @03.07600s +00.20300s
+|`->config-disk_setup ran successfully @03.27900s +00.00100s
+|`->config-mounts ran successfully @03.28000s +00.00100s
+|`->config-set_hostname ran successfully @03.28200s +00.00600s
+|`->config-update_hostname ran successfully @03.28900s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.29000s +00.00000s
+|`->config-ca-certs ran successfully @03.29000s +00.00100s
+|`->config-rsyslog ran successfully @03.29100s +00.00100s
+|`->config-users-groups ran successfully @03.29200s +00.07900s
+|`->config-ssh ran successfully @03.37200s +00.51000s
+Finished stage: (init-network) 01.54300 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @23.91700s +00.00000s
+|`->config-snap ran successfully @23.91700s +00.00100s
+|`->config-ssh-import-id ran successfully @23.91800s +00.00100s
+|`->config-locale ran successfully @23.91900s +00.02500s
+|`->config-set-passwords ran successfully @23.94400s +00.00100s
+|`->config-grub-dpkg ran successfully @23.94500s +00.26600s
+|`->config-apt-pipelining ran successfully @24.21200s +00.00300s
+|`->config-apt-configure ran successfully @24.21600s +00.12800s
+|`->config-ubuntu-advantage ran successfully @24.34400s +00.00100s
+|`->config-ntp ran successfully @24.34500s +00.09900s
+|`->config-timezone ran successfully @24.44600s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @24.44700s +00.00000s
+|`->config-runcmd ran successfully @24.44700s +00.00100s
+|`->config-byobu ran successfully @24.44800s +00.00100s
+Finished stage: (modules-config) 00.55700 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @24.95300s +00.00000s
+|`->config-fan ran successfully @24.95300s +00.00100s
+|`->config-landscape ran successfully @24.95400s +00.00100s
+|`->config-lxd ran successfully @24.95500s +00.00000s
+|`->config-ubuntu-drivers ran successfully @24.95500s +00.00100s
+|`->config-puppet ran successfully @24.95600s +00.00100s
+|`->config-chef ran successfully @24.95700s +00.00000s
+|`->config-mcollective ran successfully @24.95700s +00.00100s
+|`->config-salt-minion ran successfully @24.95800s +00.00000s
+|`->config-rightscale_userdata ran successfully @24.95800s +00.00100s
+|`->config-scripts-vendor ran successfully @24.95900s +00.00100s
+|`->config-scripts-per-once ran successfully @24.96000s +00.00000s
+|`->config-scripts-per-boot ran successfully @24.96000s +00.00100s
+|`->config-scripts-per-instance ran successfully @24.96100s +00.00000s
+|`->config-scripts-user ran successfully @24.96100s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @24.96200s +00.00200s
+|`->config-keys-to-console ran successfully @24.96400s +00.02400s
+|`->config-phone-home ran successfully @24.98900s +00.00100s
+|`->config-final-message ran successfully @24.99000s +00.00400s
+|`->config-power-state-change ran successfully @24.99400s +00.00100s
+Finished stage: (modules-final) 00.07200 seconds
+
+Total Time: 2.53400 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.51000s (init-network/config-ssh)
+     00.42300s (init-network/config-growpart)
+     00.26600s (modules-config/config-grub-dpkg)
+     00.20300s (init-network/config-resizefs)
+     00.12800s (modules-config/config-apt-configure)
+     00.09900s (modules-config/config-ntp)
+     00.07900s (init-network/config-users-groups)
+     00.06200s (init-network/search-GCE)
+     00.02500s (modules-config/config-locale)
+     00.02400s (modules-final/config-keys-to-console)
+     00.00600s (init-network/config-set_hostname)
+     00.00400s (modules-final/config-final-message)
+     00.00400s (init-network/consume-user-data)
+     00.00300s (modules-config/config-apt-pipelining)
+     00.00200s (modules-final/config-ssh-authkey-fingerprints)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (init-network/setup-datasource)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-scripts-per-instance)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-package-update-upgrade-install)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-seed_random)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_groovy_after_201211161750.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_groovy_after_201211161750.log
@@ -1,0 +1,231 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~20.10.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.303s (kernel) + 20.685s (userspace) = 21.989s 
+graphical.target reached after 15.067s in userspace
+===== systemd-analyze blame =====
+5.604s snap.lxd.activate.service            
+5.577s accounts-daemon.service              
+5.035s snapd.service                        
+4.736s networkd-dispatcher.service          
+4.202s cloud-final.service                  
+3.535s apport.service                       
+3.372s grub-common.service                  
+1.820s cloud-init-local.service             
+1.675s cloud-init.service                   
+1.620s cloud-config.service                 
+1.193s lvm2-monitor.service                 
+1.079s setvtrgb.service                     
+1.053s systemd-networkd-wait-online.service 
+1.028s dev-sda1.device                      
+1.016s plymouth-quit-wait.service           
+ 806ms systemd-udev-settle.service          
+ 531ms systemd-hostnamed.service            
+ 394ms systemd-journal-flush.service        
+ 390ms snapd.apparmor.service               
+ 347ms snapd.socket                         
+ 343ms plymouth-quit.service                
+ 292ms keyboard-setup.service               
+ 290ms systemd-journald.service             
+ 268ms snapd.seeded.service                 
+ 268ms atd.service                          
+ 265ms rsyslog.service                      
+ 254ms secureboot-db.service                
+ 219ms grub-initrd-fallback.service         
+ 218ms e2scrub_reap.service                 
+ 210ms google-oslogin-cache.service         
+ 204ms systemd-udev-trigger.service         
+ 200ms systemd-logind.service               
+ 188ms dev-hugepages.mount                  
+ 187ms sys-kernel-tracing.mount             
+ 186ms dev-mqueue.mount                     
+ 184ms sys-kernel-debug.mount               
+ 171ms blk-availability.service             
+ 170ms kmod-static-nodes.service            
+ 155ms google-startup-scripts.service       
+ 149ms modprobe@drm.service                 
+ 130ms systemd-resolved.service             
+ 121ms systemd-modules-load.service         
+ 119ms apparmor.service                     
+ 111ms user@1000.service                    
+ 111ms systemd-remount-fs.service           
+ 111ms ssh.service                          
+ 110ms systemd-tmpfiles-setup.service       
+ 106ms google-shutdown-scripts.service      
+ 105ms polkit.service                       
+  97ms sys-fs-fuse-connections.mount        
+  96ms systemd-sysusers.service             
+  96ms sys-kernel-config.mount              
+  95ms systemd-networkd.service             
+  95ms ufw.service                          
+  92ms systemd-sysctl.service               
+  90ms systemd-user-sessions.service        
+  87ms systemd-random-seed.service          
+  61ms multipathd.service                   
+  61ms boot-efi.mount                       
+  58ms systemd-udevd.service                
+  51ms snap-google\x2dcloud\x2dsdk-161.mount
+  51ms snap-snapd-10492.mount               
+  50ms snap-lxd-18546.mount                 
+  49ms snap-core18-1932.mount               
+  36ms chrony.service                       
+  35ms systemd-tmpfiles-setup-dev.service   
+  26ms plymouth-read-write.service          
+  24ms finalrd.service                      
+  21ms console-setup.service                
+  20ms systemd-update-utmp-runlevel.service 
+  20ms systemd-update-utmp.service          
+  11ms user-runtime-dir@1000.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00300s +00.00100s
+Finished stage: (init-local) 00.19700 seconds
+
+Starting stage: init-network
+|`->no cache found @01.81300s +00.00000s
+|`->found network data from DataSourceGCE @01.81600s +00.05400s
+|`->setting up datasource @02.03100s +00.00000s
+|`->reading and applying user-data @02.04400s +00.00300s
+|`->reading and applying vendor-data @02.04700s +00.00100s
+|`->activating datasource @02.07200s +00.00100s
+|`->config-migrator ran successfully @02.09400s +00.00100s
+|`->config-seed_random ran successfully @02.09500s +00.00100s
+|`->config-bootcmd ran successfully @02.09600s +00.00000s
+|`->config-write-files ran successfully @02.09600s +00.00100s
+|`->config-growpart ran successfully @02.09700s +00.06300s
+|`->config-resizefs ran successfully @02.16000s +00.07600s
+|`->config-disk_setup ran successfully @02.23600s +00.00100s
+|`->config-mounts ran successfully @02.23700s +00.00200s
+|`->config-set_hostname ran successfully @02.23900s +00.00500s
+|`->config-update_hostname ran successfully @02.24500s +00.00100s
+|`->config-update_etc_hosts ran successfully @02.24600s +00.00000s
+|`->config-ca-certs ran successfully @02.24600s +00.00100s
+|`->config-rsyslog ran successfully @02.24700s +00.00100s
+|`->config-users-groups ran successfully @02.24800s +00.03900s
+|`->config-ssh ran successfully @02.28700s +00.78600s
+Finished stage: (init-network) 01.27600 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @11.07700s +00.00100s
+|`->config-snap ran successfully @11.07800s +00.00100s
+|`->config-ssh-import-id ran successfully @11.07900s +00.00000s
+|`->config-locale ran successfully @11.08000s +00.02400s
+|`->config-set-passwords ran successfully @11.10500s +00.00000s
+|`->config-grub-dpkg ran successfully @11.10500s +00.39100s
+|`->config-apt-pipelining ran successfully @11.49600s +00.00100s
+|`->config-apt-configure ran successfully @11.49800s +00.17700s
+|`->config-ubuntu-advantage ran successfully @11.67600s +00.00000s
+|`->config-ntp ran successfully @11.67700s +00.05500s
+|`->config-timezone ran successfully @11.73300s +00.00200s
+|`->config-disable-ec2-metadata ran successfully @11.73500s +00.00000s
+|`->config-runcmd ran successfully @11.73500s +00.00100s
+|`->config-byobu ran successfully @11.73600s +00.00000s
+Finished stage: (modules-config) 00.82300 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @12.22500s +00.00100s
+|`->config-fan ran successfully @12.22600s +00.00100s
+|`->config-landscape ran successfully @12.22700s +00.00000s
+|`->config-lxd ran successfully @12.22800s +00.00000s
+|`->config-ubuntu-drivers ran successfully @12.22800s +00.00100s
+|`->config-puppet ran successfully @12.22900s +00.00100s
+|`->config-chef ran successfully @12.23000s +00.00000s
+|`->config-mcollective ran successfully @12.23000s +00.00100s
+|`->config-salt-minion ran successfully @12.23100s +00.00000s
+|`->config-reset_rmc ran successfully @12.23200s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @12.23300s +00.00000s
+|`->config-rightscale_userdata ran successfully @12.23400s +00.00000s
+|`->config-scripts-vendor ran successfully @12.23400s +00.00100s
+|`->config-scripts-per-once ran successfully @12.23500s +00.00100s
+|`->config-scripts-per-boot ran successfully @12.23600s +00.00000s
+|`->config-scripts-per-instance ran successfully @12.23600s +00.00100s
+|`->config-scripts-user ran successfully @12.23700s +00.00200s
+|`->config-ssh-authkey-fingerprints ran successfully @12.23900s +03.00700s
+|`->config-keys-to-console ran successfully @15.24700s +00.67300s
+|`->config-phone-home ran successfully @15.92000s +00.00100s
+|`->config-final-message ran successfully @15.92100s +00.00800s
+|`->config-power-state-change ran successfully @15.92900s +00.00300s
+Finished stage: (modules-final) 03.73900 seconds
+
+Total Time: 6.03500 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     03.00700s (modules-final/config-ssh-authkey-fingerprints)
+     00.78600s (init-network/config-ssh)
+     00.67300s (modules-final/config-keys-to-console)
+     00.39100s (modules-config/config-grub-dpkg)
+     00.17700s (modules-config/config-apt-configure)
+     00.07600s (init-network/config-resizefs)
+     00.06300s (init-network/config-growpart)
+     00.05500s (modules-config/config-ntp)
+     00.05400s (init-network/search-GCE)
+     00.03900s (init-network/config-users-groups)
+     00.02400s (modules-config/config-locale)
+     00.00800s (modules-final/config-final-message)
+     00.00500s (init-network/config-set_hostname)
+     00.00300s (modules-final/config-power-state-change)
+     00.00300s (init-network/consume-user-data)
+     00.00200s (modules-final/config-scripts-user)
+     00.00200s (modules-config/config-timezone)
+     00.00200s (init-network/config-mounts)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/consume-vendor-data)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/activate-datasource)
+     00.00100s (init-local/check-cache)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-ssh-import-id)
+     00.00000s (modules-config/config-set-passwords)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_groovy_before_201211161750.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_groovy_before_201211161750.log
@@ -1,0 +1,229 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-15-g6d332e5c-0ubuntu1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 1.218s (kernel) + 26.198s (userspace) = 27.416s 
+graphical.target reached after 24.574s in userspace
+===== systemd-analyze blame =====
+11.657s accounts-daemon.service              
+ 5.682s networkd-dispatcher.service          
+ 5.384s grub-common.service                  
+ 5.332s pollinate.service                    
+ 4.036s plymouth-quit-wait.service           
+ 3.371s plymouth-quit.service                
+ 3.250s snapd.seeded.service                 
+ 3.166s apport.service                       
+ 2.758s snapd.apparmor.service               
+ 2.584s snapd.service                        
+ 1.952s cloud-init.service                   
+ 1.653s cloud-init-local.service             
+ 1.377s systemd-networkd-wait-online.service 
+ 1.334s google-shutdown-scripts.service      
+ 1.272s lvm2-monitor.service                 
+ 1.094s dev-sda1.device                      
+  940ms cloud-config.service                 
+  899ms apparmor.service                     
+  880ms systemd-udev-settle.service          
+  728ms polkit.service                       
+  563ms secureboot-db.service                
+  552ms snap.lxd.activate.service            
+  509ms atd.service                          
+  507ms cloud-final.service                  
+  407ms systemd-hostnamed.service            
+  327ms snapd.socket                         
+  248ms systemd-logind.service               
+  247ms rsyslog.service                      
+  247ms grub-initrd-fallback.service         
+  236ms systemd-udev-trigger.service         
+  233ms systemd-journald.service             
+  223ms keyboard-setup.service               
+  219ms google-oslogin-cache.service         
+  212ms e2scrub_reap.service                 
+  206ms sys-kernel-debug.mount               
+  206ms systemd-resolved.service             
+  202ms sys-kernel-tracing.mount             
+  196ms dev-mqueue.mount                     
+  185ms dev-hugepages.mount                  
+  171ms kmod-static-nodes.service            
+  163ms google-startup-scripts.service       
+  161ms systemd-modules-load.service         
+  151ms systemd-remount-fs.service           
+  151ms blk-availability.service             
+  149ms ssh.service                          
+  143ms systemd-networkd.service             
+  142ms modprobe@drm.service                 
+  140ms ufw.service                          
+  121ms user@1000.service                    
+  100ms setvtrgb.service                     
+   96ms systemd-user-sessions.service        
+   92ms systemd-sysusers.service             
+   78ms systemd-udevd.service                
+   74ms sys-fs-fuse-connections.mount        
+   67ms snap-core18-1932.mount               
+   65ms snap-google\x2dcloud\x2dsdk-161.mount
+   65ms boot-efi.mount                       
+   64ms sys-kernel-config.mount              
+   63ms systemd-sysctl.service               
+   63ms systemd-random-seed.service          
+   63ms snap-snapd-10492.mount               
+   62ms snap-lxd-18546.mount                 
+   62ms systemd-journal-flush.service        
+   60ms multipathd.service                   
+   49ms systemd-machine-id-commit.service    
+   48ms systemd-tmpfiles-setup.service       
+   40ms plymouth-read-write.service          
+   39ms chrony.service                       
+   31ms finalrd.service                      
+   30ms console-setup.service                
+   24ms systemd-tmpfiles-setup-dev.service   
+   19ms systemd-update-utmp-runlevel.service 
+   15ms systemd-update-utmp.service          
+   13ms user-runtime-dir@1000.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.01800s +00.00000s
+Finished stage: (init-local) 00.40400 seconds
+
+Starting stage: init-network
+|`->no cache found @02.50700s +00.00000s
+|`->found network data from DataSourceGCE @02.51100s +00.06300s
+|`->setting up datasource @02.73300s +00.00000s
+|`->reading and applying user-data @02.74800s +00.00400s
+|`->reading and applying vendor-data @02.75200s +00.00000s
+|`->activating datasource @02.77600s +00.00100s
+|`->config-migrator ran successfully @02.80000s +00.00000s
+|`->config-seed_random ran successfully @02.80100s +00.00000s
+|`->config-bootcmd ran successfully @02.80200s +00.00000s
+|`->config-write-files ran successfully @02.80200s +00.00100s
+|`->config-growpart ran successfully @02.80300s +00.60100s
+|`->config-resizefs ran successfully @03.40400s +00.17100s
+|`->config-disk_setup ran successfully @03.57600s +00.00100s
+|`->config-mounts ran successfully @03.57700s +00.00100s
+|`->config-set_hostname ran successfully @03.57900s +00.00600s
+|`->config-update_hostname ran successfully @03.58500s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.58700s +00.00000s
+|`->config-ca-certs ran successfully @03.58700s +00.00000s
+|`->config-rsyslog ran successfully @03.58800s +00.00000s
+|`->config-users-groups ran successfully @03.58800s +00.08100s
+|`->config-ssh ran successfully @03.67000s +00.34500s
+Finished stage: (init-network) 01.53800 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @20.19200s +00.00000s
+|`->config-snap ran successfully @20.19200s +00.00100s
+|`->config-ssh-import-id ran successfully @20.19300s +00.00100s
+|`->config-locale ran successfully @20.19400s +00.02300s
+|`->config-set-passwords ran successfully @20.21700s +00.00100s
+|`->config-grub-dpkg ran successfully @20.21800s +00.26300s
+|`->config-apt-pipelining ran successfully @20.48100s +00.00100s
+|`->config-apt-configure ran successfully @20.48300s +00.09700s
+|`->config-ubuntu-advantage ran successfully @20.58100s +00.00000s
+|`->config-ntp ran successfully @20.58200s +00.05900s
+|`->config-timezone ran successfully @20.64200s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @20.64300s +00.00100s
+|`->config-runcmd ran successfully @20.64400s +00.00000s
+|`->config-byobu ran successfully @20.64500s +00.00000s
+Finished stage: (modules-config) 00.47600 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @21.11600s +00.00100s
+|`->config-fan ran successfully @21.11700s +00.00100s
+|`->config-landscape ran successfully @21.11800s +00.00000s
+|`->config-lxd ran successfully @21.11800s +00.00100s
+|`->config-ubuntu-drivers ran successfully @21.11900s +00.00100s
+|`->config-puppet ran successfully @21.12000s +00.00000s
+|`->config-chef ran successfully @21.12000s +00.00100s
+|`->config-mcollective ran successfully @21.12100s +00.00000s
+|`->config-salt-minion ran successfully @21.12100s +00.00100s
+|`->config-rightscale_userdata ran successfully @21.12200s +00.00100s
+|`->config-scripts-vendor ran successfully @21.12300s +00.00000s
+|`->config-scripts-per-once ran successfully @21.12300s +00.00100s
+|`->config-scripts-per-boot ran successfully @21.12400s +00.00000s
+|`->config-scripts-per-instance ran successfully @21.12400s +00.00100s
+|`->config-scripts-user ran successfully @21.12500s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @21.12600s +00.00200s
+|`->config-keys-to-console ran successfully @21.12800s +00.02600s
+|`->config-phone-home ran successfully @21.15400s +00.00100s
+|`->config-final-message ran successfully @21.15500s +00.00500s
+|`->config-power-state-change ran successfully @21.16000s +00.00100s
+Finished stage: (modules-final) 00.07200 seconds
+
+Total Time: 2.49000 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.60100s (init-network/config-growpart)
+     00.34500s (init-network/config-ssh)
+     00.26300s (modules-config/config-grub-dpkg)
+     00.17100s (init-network/config-resizefs)
+     00.09700s (modules-config/config-apt-configure)
+     00.08100s (init-network/config-users-groups)
+     00.06300s (init-network/search-GCE)
+     00.05900s (modules-config/config-ntp)
+     00.02600s (modules-final/config-keys-to-console)
+     00.02300s (modules-config/config-locale)
+     00.00600s (init-network/config-set_hostname)
+     00.00500s (modules-final/config-final-message)
+     00.00400s (init-network/consume-user-data)
+     00.00200s (modules-final/config-ssh-authkey-fingerprints)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-seed_random)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-ca-certs)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_xenial_after_201211154340.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_xenial_after_201211154340.log
@@ -1,0 +1,219 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~16.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/network/interfaces.d/50-cloud-init.cfg =====
+
+===== systemd-analyze =====
+Startup finished in 2.982s (kernel) + 13.729s (userspace) = 16.712s
+===== systemd-analyze blame =====
+          2.825s cloud-final.service
+          1.731s cloud-config.service
+          1.717s cloud-init-local.service
+          1.215s google-instance-setup.service
+          1.185s dev-sda1.device
+          1.108s cloud-init.service
+          1.051s accounts-daemon.service
+           883ms snapd.service
+           827ms grub-common.service
+           767ms iscsid.service
+           709ms ssh.service
+           692ms rc-local.service
+           690ms sshguard.service
+           689ms lxd-containers.service
+           687ms google-oslogin-cache.service
+           674ms google-shutdown-scripts.service
+           671ms user@1000.service
+           665ms systemd-logind.service
+           663ms snapd.seeded.service
+           576ms rsyslog.service
+           574ms apparmor.service
+           479ms lvm2-monitor.service
+           447ms mdadm.service
+           346ms lxd.socket
+           296ms networking.service
+           239ms ntp.service
+           221ms google-startup-scripts.service
+           207ms snapd.socket
+           207ms ondemand.service
+           187ms resolvconf.service
+           177ms polkitd.service
+           175ms apport.service
+           175ms open-iscsi.service
+           167ms console-setup.service
+           160ms systemd-modules-load.service
+           159ms ufw.service
+           149ms keyboard-setup.service
+           147ms kmod-static-nodes.service
+           145ms systemd-remount-fs.service
+           131ms sys-kernel-debug.mount
+           129ms dev-hugepages.mount
+           124ms systemd-udev-trigger.service
+           104ms dev-mqueue.mount
+            75ms setvtrgb.service
+            63ms systemd-tmpfiles-setup-dev.service
+            60ms systemd-random-seed.service
+            56ms systemd-udevd.service
+            55ms systemd-journal-flush.service
+            48ms systemd-tmpfiles-setup.service
+            47ms systemd-journald.service
+            33ms plymouth-quit.service
+            32ms systemd-user-sessions.service
+            31ms plymouth-quit-wait.service
+            29ms systemd-update-utmp.service
+            26ms systemd-sysctl.service
+            25ms plymouth-read-write.service
+            20ms snapd.apparmor.service
+            19ms sys-fs-fuse-connections.mount
+            15ms boot-efi.mount
+             9ms sys-kernel-config.mount
+             8ms systemd-update-utmp-runlevel.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00000s
+Finished stage: (init-local) 00.04400 seconds
+
+Starting stage: init-network
+|`->no cache found @00.76700s +00.00000s
+|`->found network data from DataSourceGCE @00.77100s +00.06900s
+|`->setting up datasource @00.90500s +00.00000s
+|`->reading and applying user-data @00.91800s +00.00400s
+|`->reading and applying vendor-data @00.92200s +00.00000s
+|`->activating datasource @00.94800s +00.00100s
+|`->config-migrator ran successfully @01.00300s +00.00100s
+|`->config-seed_random ran successfully @01.00400s +00.00100s
+|`->config-bootcmd ran successfully @01.00500s +00.00000s
+|`->config-write-files ran successfully @01.00500s +00.00100s
+|`->config-growpart ran successfully @01.00600s +00.05200s
+|`->config-resizefs ran successfully @01.05900s +00.01800s
+|`->config-disk_setup ran successfully @01.07700s +00.00100s
+|`->config-mounts ran successfully @01.07900s +00.00300s
+|`->config-set_hostname ran successfully @01.08200s +00.00500s
+|`->config-update_hostname ran successfully @01.08700s +00.00200s
+|`->config-update_etc_hosts ran successfully @01.08900s +00.00000s
+|`->config-ca-certs ran successfully @01.08900s +00.00100s
+|`->config-rsyslog ran successfully @01.09000s +00.00100s
+|`->config-users-groups ran successfully @01.09100s +00.03800s
+|`->config-ssh ran successfully @01.12900s +00.36700s
+Finished stage: (init-network) 00.74500 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @05.28300s +00.00000s
+|`->config-snap ran successfully @05.28300s +00.00100s
+|`->config-ssh-import-id ran successfully @05.28400s +00.00100s
+|`->config-locale ran successfully @05.28500s +00.00100s
+|`->config-set-passwords ran successfully @05.28600s +00.00100s
+|`->config-grub-dpkg ran successfully @05.28700s +00.08200s
+|`->config-apt-pipelining ran successfully @05.37000s +00.00100s
+|`->config-apt-configure ran successfully @05.37100s +00.12800s
+|`->config-ubuntu-advantage ran successfully @05.49900s +00.00100s
+|`->config-ntp ran successfully @05.50000s +00.00100s
+|`->config-timezone ran successfully @05.50100s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @05.50200s +00.00000s
+|`->config-runcmd ran successfully @05.50200s +00.00100s
+|`->config-byobu ran successfully @05.50300s +00.00100s
+Finished stage: (modules-config) 00.27700 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @07.33200s +00.00100s
+|`->config-fan ran successfully @07.33300s +00.00200s
+|`->config-landscape ran successfully @07.33500s +00.00200s
+|`->config-lxd ran successfully @07.33700s +00.00100s
+|`->config-ubuntu-drivers ran successfully @07.33800s +00.00100s
+|`->config-puppet ran successfully @07.34000s +00.00000s
+|`->config-chef ran successfully @07.34000s +00.00100s
+|`->config-mcollective ran successfully @07.34100s +00.00100s
+|`->config-salt-minion ran successfully @07.34200s +00.00100s
+|`->config-reset_rmc ran successfully @07.34300s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @07.34500s +00.00000s
+|`->config-rightscale_userdata ran successfully @07.34500s +00.00100s
+|`->config-scripts-vendor ran successfully @07.34600s +00.00100s
+|`->config-scripts-per-once ran successfully @07.34700s +00.00100s
+|`->config-scripts-per-boot ran successfully @07.34800s +00.00000s
+|`->config-scripts-per-instance ran successfully @07.34800s +00.00100s
+|`->config-scripts-user ran successfully @07.34900s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @07.35000s +01.26800s
+|`->config-keys-to-console ran successfully @08.61800s +01.00700s
+|`->config-phone-home ran successfully @09.62600s +00.00100s
+|`->config-final-message ran successfully @09.62700s +00.00500s
+|`->config-power-state-change ran successfully @09.63200s +00.00100s
+Finished stage: (modules-final) 02.42100 seconds
+
+Total Time: 3.48700 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     01.26800s (modules-final/config-ssh-authkey-fingerprints)
+     01.00700s (modules-final/config-keys-to-console)
+     00.36700s (init-network/config-ssh)
+     00.12800s (modules-config/config-apt-configure)
+     00.08200s (modules-config/config-grub-dpkg)
+     00.06900s (init-network/search-GCE)
+     00.05200s (init-network/config-growpart)
+     00.03800s (init-network/config-users-groups)
+     00.01800s (init-network/config-resizefs)
+     00.00500s (modules-final/config-final-message)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (init-network/consume-user-data)
+     00.00300s (init-network/config-mounts)
+     00.00200s (modules-final/config-landscape)
+     00.00200s (modules-final/config-fan)
+     00.00200s (init-network/config-update_hostname)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-locale)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/activate-datasource)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/gce-sru-20.4.0/test_upgrade_gce_xenial_before_201211154340.log
+++ b/manual/gce-sru-20.4.0/test_upgrade_gce_xenial_before_201211154340.log
@@ -1,0 +1,217 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~16.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceGCE",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/network/interfaces.d/50-cloud-init.cfg =====
+
+===== systemd-analyze =====
+Startup finished in 3.642s (kernel) + 15.299s (userspace) = 18.942s
+===== systemd-analyze blame =====
+          4.983s open-iscsi.service
+          4.486s mdadm.service
+          4.471s grub-common.service
+          3.559s google-oslogin-cache.service
+          3.548s rc-local.service
+          3.470s rsyslog.service
+          3.440s systemd-logind.service
+          2.736s lxd-containers.service
+          2.415s accounts-daemon.service
+          2.405s apparmor.service
+          2.152s cloud-config.service
+          2.085s cloud-init-local.service
+          2.054s pollinate.service
+          1.755s console-setup.service
+          1.739s ondemand.service
+          1.738s ntp.service
+          1.738s apport.service
+          1.410s ssh.service
+          1.386s plymouth-quit.service
+          1.201s dev-sda1.device
+          1.057s plymouth-quit-wait.service
+          1.038s sshguard.service
+           964ms cloud-init.service
+           700ms google-shutdown-scripts.service
+           688ms google-instance-setup.service
+           687ms snapd.service
+           611ms iscsid.service
+           483ms lvm2-monitor.service
+           461ms cloud-final.service
+           425ms lxd.socket
+           404ms snapd.socket
+           357ms snapd.seeded.service
+           344ms systemd-user-sessions.service
+           342ms setvtrgb.service
+           341ms polkitd.service
+           332ms networking.service
+           225ms google-startup-scripts.service
+           188ms systemd-remount-fs.service
+           186ms resolvconf.service
+           180ms kmod-static-nodes.service
+           178ms keyboard-setup.service
+           178ms systemd-modules-load.service
+           160ms ufw.service
+           140ms dev-mqueue.mount
+           121ms systemd-udev-trigger.service
+            87ms systemd-random-seed.service
+            87ms systemd-tmpfiles-setup-dev.service
+            83ms dev-hugepages.mount
+            81ms systemd-journal-flush.service
+            80ms systemd-sysctl.service
+            74ms systemd-update-utmp.service
+            74ms sys-kernel-config.mount
+            72ms systemd-machine-id-commit.service
+            59ms systemd-udevd.service
+            58ms sys-fs-fuse-connections.mount
+            55ms systemd-journald.service
+            54ms sys-kernel-debug.mount
+            47ms systemd-tmpfiles-setup.service
+            34ms user@1000.service
+            16ms snapd.apparmor.service
+            15ms plymouth-read-write.service
+            13ms boot-efi.mount
+            12ms systemd-update-utmp-runlevel.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00000s
+Finished stage: (init-local) 00.05900 seconds
+
+Starting stage: init-network
+|`->no cache found @01.14000s +00.00000s
+|`->found network data from DataSourceGCE @01.14400s +00.06700s
+|`->setting up datasource @01.27500s +00.00000s
+|`->reading and applying user-data @01.28600s +00.00300s
+|`->reading and applying vendor-data @01.28900s +00.00000s
+|`->activating datasource @01.31400s +00.00200s
+|`->config-migrator ran successfully @01.34100s +00.00100s
+|`->config-seed_random ran successfully @01.34200s +00.00100s
+|`->config-bootcmd ran successfully @01.34300s +00.00000s
+|`->config-write-files ran successfully @01.34300s +00.00100s
+|`->config-growpart ran successfully @01.34400s +00.10800s
+|`->config-resizefs ran successfully @01.45200s +00.05100s
+|`->config-disk_setup ran successfully @01.50400s +00.00100s
+|`->config-mounts ran successfully @01.50500s +00.00100s
+|`->config-set_hostname ran successfully @01.50600s +00.00500s
+|`->config-update_hostname ran successfully @01.51100s +00.00100s
+|`->config-update_etc_hosts ran successfully @01.51300s +00.00000s
+|`->config-ca-certs ran successfully @01.51300s +00.00100s
+|`->config-rsyslog ran successfully @01.51400s +00.00100s
+|`->config-users-groups ran successfully @01.51500s +00.09000s
+|`->config-ssh ran successfully @01.60500s +00.12200s
+Finished stage: (init-network) 00.60500 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @09.86600s +00.00000s
+|`->config-snap ran successfully @09.86600s +00.00100s
+|`->config-ssh-import-id ran successfully @09.86700s +00.00100s
+|`->config-locale ran successfully @09.86900s +00.90700s
+|`->config-set-passwords ran successfully @10.77600s +00.00100s
+|`->config-grub-dpkg ran successfully @10.77800s +00.20900s
+|`->config-apt-pipelining ran successfully @10.98700s +00.00100s
+|`->config-apt-configure ran successfully @10.98800s +00.10300s
+|`->config-ubuntu-advantage ran successfully @11.09200s +00.00000s
+|`->config-ntp ran successfully @11.09300s +00.00000s
+|`->config-timezone ran successfully @11.09300s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @11.09400s +00.00000s
+|`->config-runcmd ran successfully @11.09400s +00.00100s
+|`->config-byobu ran successfully @11.09500s +00.00100s
+Finished stage: (modules-config) 01.25800 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @11.51200s +00.00100s
+|`->config-fan ran successfully @11.51300s +00.00100s
+|`->config-landscape ran successfully @11.51400s +00.00100s
+|`->config-lxd ran successfully @11.51500s +00.00100s
+|`->config-ubuntu-drivers ran successfully @11.51600s +00.00000s
+|`->config-puppet ran successfully @11.51700s +00.00000s
+|`->config-chef ran successfully @11.51800s +00.00000s
+|`->config-mcollective ran successfully @11.51800s +00.00000s
+|`->config-salt-minion ran successfully @11.51900s +00.00000s
+|`->config-rightscale_userdata ran successfully @11.51900s +00.00100s
+|`->config-scripts-vendor ran successfully @11.52000s +00.00100s
+|`->config-scripts-per-once ran successfully @11.52100s +00.00100s
+|`->config-scripts-per-boot ran successfully @11.52200s +00.00000s
+|`->config-scripts-per-instance ran successfully @11.52200s +00.00100s
+|`->config-scripts-user ran successfully @11.52300s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @11.52400s +00.00300s
+|`->config-keys-to-console ran successfully @11.52700s +00.02100s
+|`->config-phone-home ran successfully @11.54800s +00.00100s
+|`->config-final-message ran successfully @11.55000s +00.00400s
+|`->config-power-state-change ran successfully @11.55400s +00.00100s
+Finished stage: (modules-final) 00.07500 seconds
+
+Total Time: 1.99700 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.90700s (modules-config/config-locale)
+     00.20900s (modules-config/config-grub-dpkg)
+     00.12200s (init-network/config-ssh)
+     00.10800s (init-network/config-growpart)
+     00.10300s (modules-config/config-apt-configure)
+     00.09000s (init-network/config-users-groups)
+     00.06700s (init-network/search-GCE)
+     00.05100s (init-network/config-resizefs)
+     00.02100s (modules-final/config-keys-to-console)
+     00.00500s (init-network/config-set_hostname)
+     00.00400s (modules-final/config-final-message)
+     00.00300s (modules-final/config-ssh-authkey-fingerprints)
+     00.00300s (init-network/consume-user-data)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-phone-home)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-mounts)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-ubuntu-advantage)
+     00.00000s (modules-config/config-ntp)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/oracle-sru-20.4.0.txt
+++ b/manual/oracle-sru-20.4.0.txt
@@ -1,0 +1,219 @@
+Upstream test at:
+https://github.com/canonical/cloud-init/blob/master/tests/integration_tests/test_upgrade.py
+
+Logs from individual before/after runs in oracle-sru-20.4.0 subdirectory
+
+No manual test run for groovy because Oracle doesn't provide groovy images.
+
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=xenial
+PLATFORM=oci
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=xenial
+PLATFORM=oci
+RUN_UNSTABLE=False
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Detected image: image_id=xenial os=ubuntu release=xenial
+Launching instance with launch_kwargs:
+wait=False
+image_id=ocid1.image.oc1.phx.aaaaaaaat4zzrzukpf3fz7mgmcnedw4anzuzncpxowtmzntzowwvctrz7yya
+user_data=#cloud-config
+hostname: SRU-worked
+
+Launching instance with launch_kwargs:
+wait=False
+image_id=ocid1.image.oc1.phx.aaaaaaaat4zzrzukpf3fz7mgmcnedw4anzuzncpxowtmzntzowwvctrz7yya
+user_data=#cloud-config
+hostname: SRU-worked
+
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syce6kgqyajeidgtbankoovrvjfzqvk4v3ncurrgjnzwudq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syce6kgqyajeidgtbankoovrvjfzqvk4v3ncurrgjnzwudq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~16.04.1
+Installed cloud-init version: 20.4-0ubuntu1~16.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_oci_xenial_before_201211154608.log and /tmp/cloud_init_test_logs/test_upgrade_oci_xenial_after_201211154608.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_oci_xenial_before_201211154608.log and /tmp/cloud_init_test_logs/test_upgrade_oci_xenial_after_201211154608.log
+.
+
+=========================================================================================== 1 passed in 322.83s (0:05:22) ===========================================================================================
+
+==== Bionic ====
+
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=bionic
+PLATFORM=oci
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=bionic
+PLATFORM=oci
+RUN_UNSTABLE=False
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Detected image: image_id=bionic os=ubuntu release=bionic
+Launching instance with launch_kwargs:
+image_id=ocid1.image.oc1.phx.aaaaaaaar27kl5u4baitst3l4hooikmi7qyayt5hpnsy4vskjimex6bmxfoa
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+Launching instance with launch_kwargs:
+image_id=ocid1.image.oc1.phx.aaaaaaaar27kl5u4baitst3l4hooikmi7qyayt5hpnsy4vskjimex6bmxfoa
+user_data=#cloud-config
+hostname: SRU-worked
+
+wait=False
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syciiz3trul6yjmjt3ab5eb5z2o2byuohyejbuscxfd4ihq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syciiz3trul6yjmjt3ab5eb5z2o2byuohyejbuscxfd4ihq, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~18.04.1
+Installed cloud-init version: 20.4-0ubuntu1~18.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_oci_bionic_before_201211155706.log and /tmp/cloud_init_test_logs/test_upgrade_oci_bionic_after_201211155706.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_oci_bionic_before_201211155706.log and /tmp/cloud_init_test_logs/test_upgrade_oci_bionic_after_201211155706.log
+.
+
+=========================================================================================== 1 passed in 351.89s (0:05:51) ===========================================================================================
+
+==== Focal ====
+================================================================================================ test session starts ================================================================================================
+platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
+rootdir: /home/james/cloud-init-tests, inifile: tox.ini
+plugins: cov-2.9.0
+collected 1 item
+
+tests/integration_tests/test_upgrade.py Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=focal
+PLATFORM=oci
+RUN_UNSTABLE=False
+Settings:
+CLOUD_INIT_SOURCE=PROPOSED
+COLLECT_LOGS=NEVER
+EXISTING_INSTANCE_ID=None
+GCE_PROJECT=ubuntu-server-277015
+GCE_REGION=us-central1
+GCE_ZONE=a
+INSTANCE_TYPE=None
+KEEP_IMAGE=False
+KEEP_INSTANCE=False
+LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
+OS_IMAGE=focal
+PLATFORM=oci
+RUN_UNSTABLE=False
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Detected image: image_id=focal os=ubuntu release=focal
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa7erbqtk6wgxvo6yvn2gqnua2pzooplts5pupncv66ceazy3pex5a
+wait=False
+Launching instance with launch_kwargs:
+user_data=#cloud-config
+hostname: SRU-worked
+
+image_id=ocid1.image.oc1.phx.aaaaaaaa7erbqtk6wgxvo6yvn2gqnua2pzooplts5pupncv66ceazy3pex5a
+wait=False
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycnu53ji2dvzfihg7fzhm4xh2ukggddflbynl7if7pn5ua, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycnu53ji2dvzfihg7fzhm4xh2ukggddflbynl7if7pn5ua, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa)
+Installing proposed image
+Installing proposed image
+Installed cloud-init version: 20.4-0ubuntu1~20.04.1
+Installed cloud-init version: 20.4-0ubuntu1~20.04.1
+Instance restarted; waiting for boot
+Instance restarted; waiting for boot
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_oci_focal_before_201211160929.log and /tmp/cloud_init_test_logs/test_upgrade_oci_focal_after_201211160929.log
+Wrote upgrade test logs to /tmp/cloud_init_test_logs/test_upgrade_oci_focal_before_201211160929.log and /tmp/cloud_init_test_logs/test_upgrade_oci_focal_after_201211160929.log
+.
+
+=========================================================================================== 1 passed in 300.08s (0:05:00) ===========================================================================================

--- a/manual/oracle-sru-20.4.0/test_upgrade_oci_bionic_after_201211155706.log
+++ b/manual/oracle-sru-20.4.0/test_upgrade_oci_bionic_after_201211155706.log
@@ -1,0 +1,228 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~18.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceOpenStack [net,ver=2]",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 9.077s (kernel) + 17.610s (userspace) = 26.688s
+graphical.target reached after 11.758s in userspace
+===== systemd-analyze blame =====
+          6.384s cloud-init.service
+          3.398s cloud-config.service
+          2.459s cloud-final.service
+          1.469s dev-sda1.device
+          1.384s cloud-init-local.service
+          1.051s snapd.service
+           949ms networkd-dispatcher.service
+           584ms dev-loop0.device
+           583ms dev-loop1.device
+           543ms dev-loop2.device
+           541ms lxd-containers.service
+           458ms apparmor.service
+           423ms accounts-daemon.service
+           409ms systemd-udev-trigger.service
+           396ms keyboard-setup.service
+           390ms grub-common.service
+           359ms apport.service
+           313ms iscsid.service
+           302ms ssh.service
+           272ms systemd-logind.service
+           243ms systemd-journald.service
+           233ms netfilter-persistent.service
+           219ms ebtables.service
+           199ms systemd-modules-load.service
+           188ms systemd-timesyncd.service
+           181ms user@1001.service
+           147ms lvm2-monitor.service
+           142ms kmod-static-nodes.service
+           141ms systemd-udevd.service
+           141ms rsyslog.service
+           136ms systemd-journal-flush.service
+           135ms run-rpc_pipefs.mount
+           134ms dev-mqueue.mount
+           133ms ufw.service
+           107ms systemd-remount-fs.service
+           105ms polkit.service
+           101ms systemd-resolved.service
+            97ms systemd-tmpfiles-setup-dev.service
+            95ms snap-core18-1932.mount
+            92ms blk-availability.service
+            86ms snap-snapd-9721.mount
+            85ms sys-kernel-debug.mount
+            81ms systemd-update-utmp.service
+            81ms dev-hugepages.mount
+            76ms iscsi-cleanup.service
+            74ms snap-oracle\x2dcloud\x2dagent-10.mount
+            71ms systemd-sysctl.service
+            70ms systemd-user-sessions.service
+            67ms snapd.seeded.service
+            64ms lxd.socket
+            61ms snapd.apparmor.service
+            57ms nfs-config.service
+            56ms plymouth-read-write.service
+            54ms systemd-tmpfiles-setup.service
+            49ms systemd-networkd.service
+            49ms rpcbind.service
+            47ms console-setup.service
+            42ms plymouth-quit.service
+            39ms plymouth-quit-wait.service
+            38ms systemd-random-seed.service
+            34ms systemd-networkd-wait-online.service
+            34ms snapd.socket
+            27ms setvtrgb.service
+            26ms sys-kernel-config.mount
+            18ms boot-efi.mount
+            17ms systemd-update-utmp-runlevel.service
+            11ms sys-fs-fuse-connections.mount
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00000s
+|`->no local data found from DataSourceOpenStackLocal @00.03300s +00.09800s
+Finished stage: (init-local) 00.14000 seconds
+
+Starting stage: init-network
+|`->no cache found @00.84500s +00.00000s
+|`->found network data from DataSourceOpenStack @00.85600s +05.06500s
+|`->setting up datasource @06.08300s +00.00100s
+|`->reading and applying user-data @06.13700s +00.00800s
+|`->reading and applying vendor-data @06.14500s +00.00000s
+|`->activating datasource @06.17100s +00.00200s
+|`->config-migrator ran successfully @06.24000s +00.00000s
+|`->config-seed_random ran successfully @06.24100s +00.00000s
+|`->config-bootcmd ran successfully @06.24200s +00.00000s
+|`->config-write-files ran successfully @06.24200s +00.00100s
+|`->config-growpart ran successfully @06.24300s +00.07300s
+|`->config-resizefs ran successfully @06.31600s +00.02500s
+|`->config-disk_setup ran successfully @06.34200s +00.00200s
+|`->config-mounts ran successfully @06.34400s +00.04400s
+|`->config-set_hostname ran successfully @06.38800s +00.00600s
+|`->config-update_hostname ran successfully @06.39400s +00.00200s
+|`->config-update_etc_hosts ran successfully @06.39600s +00.00000s
+|`->config-ca-certs ran successfully @06.39600s +00.00100s
+|`->config-rsyslog ran successfully @06.39700s +00.00100s
+|`->config-users-groups ran successfully @06.39800s +00.03600s
+|`->config-ssh ran successfully @06.43500s +00.16400s
+Finished stage: (init-network) 05.77300 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @10.27700s +00.00300s
+|`->config-snap ran successfully @10.28000s +00.01400s
+|`->config-ssh-import-id ran successfully @10.29500s +00.00100s
+|`->config-locale ran successfully @10.29700s +00.02800s
+|`->config-set-passwords ran successfully @10.32600s +00.00100s
+|`->config-grub-dpkg ran successfully @10.32700s +00.76500s
+|`->config-apt-pipelining ran successfully @11.09900s +00.00200s
+|`->config-apt-configure ran successfully @11.10100s +00.33200s
+|`->config-ubuntu-advantage ran successfully @11.43400s +00.00900s
+|`->config-ntp ran successfully @11.44300s +00.00100s
+|`->config-timezone ran successfully @11.44400s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @11.44600s +00.00000s
+|`->config-runcmd ran successfully @11.44600s +00.00100s
+|`->config-byobu ran successfully @11.44800s +00.00100s
+Finished stage: (modules-config) 01.34700 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @13.60400s +00.00100s
+|`->config-fan ran successfully @13.60500s +00.00200s
+|`->config-landscape ran successfully @13.60700s +00.00100s
+|`->config-lxd ran successfully @13.60900s +00.00100s
+|`->config-ubuntu-drivers ran successfully @13.61000s +00.00100s
+|`->config-puppet ran successfully @13.61200s +00.00100s
+|`->config-chef ran successfully @13.61300s +00.00100s
+|`->config-mcollective ran successfully @13.61400s +00.00100s
+|`->config-salt-minion ran successfully @13.61600s +00.00100s
+|`->config-reset_rmc ran successfully @13.61700s +00.00200s
+|`->config-refresh_rmc_and_interface ran successfully @13.61900s +00.00100s
+|`->config-rightscale_userdata ran successfully @13.62000s +00.00200s
+|`->config-scripts-vendor ran successfully @13.62200s +00.00100s
+|`->config-scripts-per-once ran successfully @13.62400s +00.00100s
+|`->config-scripts-per-boot ran successfully @13.62500s +00.00000s
+|`->config-scripts-per-instance ran successfully @13.62600s +00.00100s
+|`->config-scripts-user ran successfully @13.62700s +00.00200s
+|`->config-ssh-authkey-fingerprints ran successfully @13.62900s +00.18400s
+|`->config-keys-to-console ran successfully @13.81300s +00.12400s
+|`->config-phone-home ran successfully @13.93800s +00.00200s
+|`->config-final-message ran successfully @13.94100s +00.00800s
+|`->config-power-state-change ran successfully @13.95000s +00.00100s
+Finished stage: (modules-final) 00.42500 seconds
+
+Total Time: 7.68500 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     05.06500s (init-network/search-OpenStack)
+     00.76500s (modules-config/config-grub-dpkg)
+     00.33200s (modules-config/config-apt-configure)
+     00.18400s (modules-final/config-ssh-authkey-fingerprints)
+     00.16400s (init-network/config-ssh)
+     00.12400s (modules-final/config-keys-to-console)
+     00.09800s (init-local/search-OpenStackLocal)
+     00.07300s (init-network/config-growpart)
+     00.04400s (init-network/config-mounts)
+     00.03600s (init-network/config-users-groups)
+     00.02800s (modules-config/config-locale)
+     00.02500s (init-network/config-resizefs)
+     00.01400s (modules-config/config-snap)
+     00.00900s (modules-config/config-ubuntu-advantage)
+     00.00800s (modules-final/config-final-message)
+     00.00800s (init-network/consume-user-data)
+     00.00600s (init-network/config-set_hostname)
+     00.00300s (modules-config/config-emit_upstart)
+     00.00200s (modules-final/config-scripts-user)
+     00.00200s (modules-final/config-rightscale_userdata)
+     00.00200s (modules-final/config-reset_rmc)
+     00.00200s (modules-final/config-phone-home)
+     00.00200s (modules-final/config-fan)
+     00.00200s (modules-config/config-apt-pipelining)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (init-network/config-disk_setup)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-refresh_rmc_and_interface)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-power-state-change)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (init-network/setup-datasource)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-ca-certs)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/config-seed_random)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/oracle-sru-20.4.0/test_upgrade_oci_bionic_before_201211155706.log
+++ b/manual/oracle-sru-20.4.0/test_upgrade_oci_bionic_before_201211155706.log
@@ -1,0 +1,226 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~18.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceOpenStack [net,ver=2]",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 6.722s (kernel) + 28.971s (userspace) = 35.694s
+graphical.target reached after 26.404s in userspace
+===== systemd-analyze blame =====
+         13.858s snapd.seeded.service
+          7.276s cloud-init.service
+          1.752s cloud-config.service
+          1.298s cloud-init-local.service
+          1.290s dev-sda1.device
+          1.251s pollinate.service
+          1.175s apparmor.service
+           826ms cloud-final.service
+           672ms networkd-dispatcher.service
+           465ms lxd-containers.service
+           417ms grub-common.service
+           394ms systemd-udev-trigger.service
+           392ms accounts-daemon.service
+           388ms keyboard-setup.service
+           291ms apport.service
+           274ms iscsid.service
+           271ms systemd-journald.service
+           241ms netfilter-persistent.service
+           229ms systemd-modules-load.service
+           222ms snapd.service
+           200ms lvm2-monitor.service
+           192ms systemd-logind.service
+           191ms systemd-timesyncd.service
+           166ms ebtables.service
+           118ms polkit.service
+           112ms dev-hugepages.mount
+           111ms systemd-remount-fs.service
+           109ms systemd-tmpfiles-setup-dev.service
+           106ms kmod-static-nodes.service
+           105ms user@1001.service
+           102ms dev-mqueue.mount
+           102ms run-rpc_pipefs.mount
+            87ms sys-kernel-debug.mount
+            85ms ufw.service
+            78ms systemd-udevd.service
+            78ms rpcbind.service
+            72ms lxd.socket
+            72ms systemd-journal-flush.service
+            69ms systemd-resolved.service
+            63ms iscsi-cleanup.service
+            62ms snapd.socket
+            60ms systemd-sysctl.service
+            60ms systemd-tmpfiles-setup.service
+            59ms systemd-user-sessions.service
+            59ms snap-oracle\x2dcloud\x2dagent-10.mount
+            57ms blk-availability.service
+            50ms ssh.service
+            49ms systemd-machine-id-commit.service
+            49ms plymouth-read-write.service
+            49ms setvtrgb.service
+            48ms systemd-networkd.service
+            46ms dev-loop2.device
+            46ms snap-core18-1932.mount
+            41ms dev-loop1.device
+            40ms snap-snapd-9721.mount
+            37ms console-setup.service
+            37ms systemd-update-utmp.service
+            36ms sys-fs-fuse-connections.mount
+            35ms rsyslog.service
+            31ms plymouth-quit-wait.service
+            31ms sys-kernel-config.mount
+            28ms snapd.apparmor.service
+            27ms dev-loop0.device
+            24ms systemd-random-seed.service
+            23ms systemd-networkd-wait-online.service
+            23ms plymouth-quit.service
+            20ms systemd-update-utmp-runlevel.service
+            18ms boot-efi.mount
+            10ms nfs-config.service
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00000s
+|`->no local data found from DataSourceOpenStackLocal @00.01900s +00.11500s
+Finished stage: (init-local) 00.14900 seconds
+
+Starting stage: init-network
+|`->no cache found @00.86300s +00.00100s
+|`->found network data from DataSourceOpenStack @00.87100s +05.11800s
+|`->setting up datasource @06.20500s +00.00000s
+|`->reading and applying user-data @06.22100s +00.00400s
+|`->reading and applying vendor-data @06.22500s +00.00000s
+|`->activating datasource @06.25100s +00.00200s
+|`->config-migrator ran successfully @06.27800s +00.00000s
+|`->config-seed_random ran successfully @06.27800s +00.00100s
+|`->config-bootcmd ran successfully @06.27900s +00.00100s
+|`->config-write-files ran successfully @06.28000s +00.00100s
+|`->config-growpart ran successfully @06.28100s +00.17300s
+|`->config-resizefs ran successfully @06.45500s +00.48900s
+|`->config-disk_setup ran successfully @06.94500s +00.00100s
+|`->config-mounts ran successfully @06.94600s +00.03100s
+|`->config-set_hostname ran successfully @06.97800s +00.00600s
+|`->config-update_hostname ran successfully @06.98500s +00.00100s
+|`->config-update_etc_hosts ran successfully @06.98600s +00.00100s
+|`->config-ca-certs ran successfully @06.98700s +00.00100s
+|`->config-rsyslog ran successfully @06.98900s +00.00000s
+|`->config-users-groups ran successfully @06.99000s +00.13000s
+|`->config-ssh ran successfully @07.12100s +00.25700s
+Finished stage: (init-network) 06.53600 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @23.29000s +00.00000s
+|`->config-snap ran successfully @23.29000s +00.00100s
+|`->config-ssh-import-id ran successfully @23.29100s +00.00100s
+|`->config-locale ran successfully @23.29300s +00.00500s
+|`->config-set-passwords ran successfully @23.29800s +00.00100s
+|`->config-grub-dpkg ran successfully @23.29900s +00.33000s
+|`->config-apt-pipelining ran successfully @23.63100s +00.00100s
+|`->config-apt-configure ran successfully @23.63200s +00.46000s
+|`->config-ubuntu-advantage ran successfully @24.09300s +00.00100s
+|`->config-ntp ran successfully @24.09500s +00.00100s
+|`->config-timezone ran successfully @24.09600s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @24.09700s +00.00000s
+|`->config-runcmd ran successfully @24.09800s +00.00000s
+|`->config-byobu ran successfully @24.09800s +00.00100s
+Finished stage: (modules-config) 00.83900 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @24.70500s +00.00100s
+|`->config-fan ran successfully @24.70600s +00.00100s
+|`->config-landscape ran successfully @24.70700s +00.00100s
+|`->config-lxd ran successfully @24.70800s +00.00100s
+|`->config-ubuntu-drivers ran successfully @24.70900s +00.00100s
+|`->config-puppet ran successfully @24.71000s +00.00000s
+|`->config-chef ran successfully @24.71100s +00.00000s
+|`->config-mcollective ran successfully @24.71100s +00.00100s
+|`->config-salt-minion ran successfully @24.71200s +00.00100s
+|`->config-rightscale_userdata ran successfully @24.71300s +00.00000s
+|`->config-scripts-vendor ran successfully @24.71400s +00.00000s
+|`->config-scripts-per-once ran successfully @24.71500s +00.00000s
+|`->config-scripts-per-boot ran successfully @24.71500s +00.00100s
+|`->config-scripts-per-instance ran successfully @24.71600s +00.00100s
+|`->config-scripts-user ran successfully @24.71700s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @24.71800s +00.03600s
+|`->config-keys-to-console ran successfully @24.75500s +00.07100s
+|`->config-phone-home ran successfully @24.82800s +00.00500s
+|`->config-final-message ran successfully @24.83500s +00.02800s
+|`->config-power-state-change ran successfully @24.86400s +00.00400s
+Finished stage: (modules-final) 00.20100 seconds
+
+Total Time: 7.72500 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     05.11800s (init-network/search-OpenStack)
+     00.48900s (init-network/config-resizefs)
+     00.46000s (modules-config/config-apt-configure)
+     00.33000s (modules-config/config-grub-dpkg)
+     00.25700s (init-network/config-ssh)
+     00.17300s (init-network/config-growpart)
+     00.13000s (init-network/config-users-groups)
+     00.11500s (init-local/search-OpenStackLocal)
+     00.07100s (modules-final/config-keys-to-console)
+     00.03600s (modules-final/config-ssh-authkey-fingerprints)
+     00.03100s (init-network/config-mounts)
+     00.02800s (modules-final/config-final-message)
+     00.00600s (init-network/config-set_hostname)
+     00.00500s (modules-final/config-phone-home)
+     00.00500s (modules-config/config-locale)
+     00.00400s (modules-final/config-power-state-change)
+     00.00400s (init-network/consume-user-data)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (init-network/check-cache)
+     00.00000s (modules-final/config-scripts-vendor)
+     00.00000s (modules-final/config-scripts-per-once)
+     00.00000s (modules-final/config-rightscale_userdata)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-network/config-migrator)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/oracle-sru-20.4.0/test_upgrade_oci_focal_after_201211160929.log
+++ b/manual/oracle-sru-20.4.0/test_upgrade_oci_focal_after_201211160929.log
@@ -1,0 +1,235 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~20.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceOracle",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 4.256s (kernel) + 12.551s (userspace) = 16.808s 
+graphical.target reached after 9.003s in userspace
+===== systemd-analyze blame =====
+2.873s cloud-config.service                  
+1.965s cloud-init.service                    
+1.857s snap.lxd.activate.service             
+1.823s cloud-init-local.service              
+1.479s dev-sda1.device                       
+1.390s accounts-daemon.service               
+1.334s cloud-final.service                   
+1.212s systemd-udev-settle.service           
+ 957ms snapd.service                         
+ 853ms networkd-dispatcher.service           
+ 762ms systemd-logind.service                
+ 696ms grub-common.service                   
+ 450ms iscsid.service                        
+ 403ms grub-initrd-fallback.service          
+ 387ms rsyslog.service                       
+ 385ms systemd-timesyncd.service             
+ 385ms dev-loop0.device                      
+ 365ms systemd-udev-trigger.service          
+ 349ms keyboard-setup.service                
+ 328ms systemd-journald.service              
+ 325ms netfilter-persistent.service          
+ 321ms dev-loop1.device                      
+ 319ms dev-loop2.device                      
+ 301ms modprobe@drm.service                  
+ 294ms snapd.apparmor.service                
+ 287ms e2scrub_reap.service                  
+ 281ms systemd-resolved.service              
+ 266ms apport.service                        
+ 260ms systemd-modules-load.service          
+ 257ms sys-kernel-tracing.mount              
+ 254ms sys-kernel-debug.mount                
+ 253ms run-rpc_pipefs.mount                  
+ 252ms lvm2-monitor.service                  
+ 251ms kmod-static-nodes.service             
+ 248ms dev-mqueue.mount                      
+ 245ms systemd-remount-fs.service            
+ 240ms dev-hugepages.mount                   
+ 199ms dev-loop3.device                      
+ 192ms ssh.service                           
+ 174ms apparmor.service                      
+ 172ms ufw.service                           
+ 147ms snapd.seeded.service                  
+ 127ms systemd-journal-flush.service         
+ 127ms user@1001.service                     
+ 120ms atd.service                           
+ 114ms systemd-networkd.service              
+ 107ms polkit.service                        
+  96ms systemd-sysctl.service                
+  94ms blk-availability.service              
+  87ms snap-oracle\x2dcloud\x2dagent-10.mount
+  84ms snap-core18-1932.mount                
+  84ms sys-kernel-config.mount               
+  83ms systemd-udevd.service                 
+  82ms systemd-tmpfiles-setup.service        
+  82ms snap-snapd-9721.mount                 
+  81ms systemd-update-utmp.service           
+  80ms sys-fs-fuse-connections.mount         
+  76ms systemd-random-seed.service           
+  75ms finalrd.service                       
+  75ms rpcbind.service                       
+  74ms plymouth-read-write.service           
+  73ms nfs-config.service                    
+  71ms multipathd.service                    
+  70ms snap-lxd-18150.mount                  
+  69ms console-setup.service                 
+  63ms boot-efi.mount                        
+  59ms systemd-sysusers.service              
+  54ms systemd-user-sessions.service         
+  50ms plymouth-quit-wait.service            
+  45ms systemd-tmpfiles-setup-dev.service    
+  41ms setvtrgb.service                      
+  40ms plymouth-quit.service                 
+  34ms systemd-update-utmp-runlevel.service  
+  27ms user-runtime-dir@1001.service         
+  26ms systemd-networkd-wait-online.service  
+  11ms snapd.socket
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00000s
+|`->found local data from DataSourceOracle @00.02600s +00.09400s
+Finished stage: (init-local) 00.36500 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceOracle @01.15600s +00.00300s
+|`->setting up datasource @01.22000s +00.00000s
+|`->reading and applying user-data @01.22800s +00.00400s
+|`->reading and applying vendor-data @01.23200s +00.00000s
+|`->activating datasource @01.25800s +00.00200s
+|`->config-migrator ran successfully @01.37600s +00.00100s
+|`->config-seed_random ran successfully @01.37800s +00.00700s
+|`->config-bootcmd ran successfully @01.38600s +00.00100s
+|`->config-write-files ran successfully @01.38800s +00.00400s
+|`->config-growpart ran successfully @01.39400s +00.11000s
+|`->config-resizefs ran successfully @01.50500s +00.08400s
+|`->config-disk_setup ran successfully @01.59000s +00.00200s
+|`->config-mounts ran successfully @01.59300s +00.00200s
+|`->config-set_hostname ran successfully @01.59500s +00.00600s
+|`->config-update_hostname ran successfully @01.60200s +00.00100s
+|`->config-update_etc_hosts ran successfully @01.60300s +00.00200s
+|`->config-ca-certs ran successfully @01.60500s +00.00100s
+|`->config-rsyslog ran successfully @01.60600s +00.00000s
+|`->config-users-groups ran successfully @01.60700s +00.03600s
+|`->config-ssh ran successfully @01.64300s +00.82500s
+Finished stage: (init-network) 01.32900 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @05.95000s +00.00000s
+|`->config-snap ran successfully @05.95100s +00.01100s
+|`->config-ssh-import-id ran successfully @05.96300s +00.00100s
+|`->config-locale ran successfully @05.96400s +00.11400s
+|`->config-set-passwords ran successfully @06.07900s +00.00100s
+|`->config-grub-dpkg ran successfully @06.08000s +00.59600s
+|`->config-apt-pipelining ran successfully @06.67700s +00.00100s
+|`->config-apt-configure ran successfully @06.67800s +00.23300s
+|`->config-ubuntu-advantage ran successfully @06.91100s +00.00100s
+|`->config-ntp ran successfully @06.91300s +00.00100s
+|`->config-timezone ran successfully @06.91400s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @06.91500s +00.00100s
+|`->config-runcmd ran successfully @06.91600s +00.00100s
+|`->config-byobu ran successfully @06.91700s +00.00100s
+Finished stage: (modules-config) 01.07100 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @08.07800s +00.00100s
+|`->config-fan ran successfully @08.08000s +00.00100s
+|`->config-landscape ran successfully @08.08100s +00.00100s
+|`->config-lxd ran successfully @08.08200s +00.00200s
+|`->config-ubuntu-drivers ran successfully @08.08400s +00.00100s
+|`->config-puppet ran successfully @08.08500s +00.00100s
+|`->config-chef ran successfully @08.08700s +00.00000s
+|`->config-mcollective ran successfully @08.08800s +00.00100s
+|`->config-salt-minion ran successfully @08.08900s +00.00100s
+|`->config-reset_rmc ran successfully @08.09000s +00.00200s
+|`->config-refresh_rmc_and_interface ran successfully @08.09200s +00.00100s
+|`->config-rightscale_userdata ran successfully @08.09300s +00.00100s
+|`->config-scripts-vendor ran successfully @08.09400s +00.00100s
+|`->config-scripts-per-once ran successfully @08.09600s +00.00100s
+|`->config-scripts-per-boot ran successfully @08.09700s +00.00100s
+|`->config-scripts-per-instance ran successfully @08.09800s +00.00100s
+|`->config-scripts-user ran successfully @08.09900s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @08.10100s +00.03600s
+|`->config-keys-to-console ran successfully @08.13800s +00.10400s
+|`->config-phone-home ran successfully @08.24300s +00.00200s
+|`->config-final-message ran successfully @08.24600s +00.00800s
+|`->config-power-state-change ran successfully @08.25500s +00.00200s
+Finished stage: (modules-final) 00.28200 seconds
+
+Total Time: 3.04700 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.82500s (init-network/config-ssh)
+     00.59600s (modules-config/config-grub-dpkg)
+     00.23300s (modules-config/config-apt-configure)
+     00.11400s (modules-config/config-locale)
+     00.11000s (init-network/config-growpart)
+     00.10400s (modules-final/config-keys-to-console)
+     00.09400s (init-local/search-Oracle)
+     00.08400s (init-network/config-resizefs)
+     00.03600s (modules-final/config-ssh-authkey-fingerprints)
+     00.03600s (init-network/config-users-groups)
+     00.01100s (modules-config/config-snap)
+     00.00800s (modules-final/config-final-message)
+     00.00700s (init-network/config-seed_random)
+     00.00600s (init-network/config-set_hostname)
+     00.00400s (init-network/consume-user-data)
+     00.00400s (init-network/config-write-files)
+     00.00300s (init-network/check-cache)
+     00.00200s (modules-final/config-reset_rmc)
+     00.00200s (modules-final/config-power-state-change)
+     00.00200s (modules-final/config-phone-home)
+     00.00200s (modules-final/config-lxd)
+     00.00200s (init-network/config-update_etc_hosts)
+     00.00200s (init-network/config-mounts)
+     00.00200s (init-network/config-disk_setup)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-refresh_rmc_and_interface)
+     00.00100s (modules-final/config-puppet)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-disable-ec2-metadata)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/config-bootcmd)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-rsyslog)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed

--- a/manual/oracle-sru-20.4.0/test_upgrade_oci_focal_before_201211160929.log
+++ b/manual/oracle-sru-20.4.0/test_upgrade_oci_focal_before_201211160929.log
@@ -1,0 +1,233 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~20.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceOracle",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/netplan/50-cloud-init.yaml =====
+
+===== systemd-analyze =====
+Startup finished in 4.431s (kernel) + 32.623s (userspace) = 37.054s 
+graphical.target reached after 30.399s in userspace
+===== systemd-analyze blame =====
+20.731s snapd.seeded.service                  
+ 2.837s cloud-init.service                    
+ 1.791s cloud-init-local.service              
+ 1.479s cloud-config.service                  
+ 1.359s dev-sda1.device                       
+ 1.234s systemd-udev-settle.service           
+ 1.096s apparmor.service                      
+ 1.093s pollinate.service                     
+  933ms accounts-daemon.service               
+  741ms cloud-final.service                   
+  573ms networkd-dispatcher.service           
+  557ms e2scrub_reap.service                  
+  524ms systemd-logind.service                
+  410ms snap.lxd.activate.service             
+  333ms netfilter-persistent.service          
+  320ms dev-hugepages.mount                   
+  318ms dev-mqueue.mount                      
+  316ms run-rpc_pipefs.mount                  
+  313ms sys-kernel-debug.mount                
+  311ms sys-kernel-tracing.mount              
+  308ms systemd-timesyncd.service             
+  301ms systemd-resolved.service              
+  298ms keyboard-setup.service                
+  292ms apport.service                        
+  284ms systemd-journald.service              
+  279ms kmod-static-nodes.service             
+  263ms systemd-udev-trigger.service          
+  257ms user@1001.service                     
+  256ms lvm2-monitor.service                  
+  251ms iscsid.service                        
+  211ms modprobe@drm.service                  
+  192ms grub-common.service                   
+  160ms systemd-modules-load.service          
+  153ms snapd.service                         
+  145ms grub-initrd-fallback.service          
+  143ms systemd-remount-fs.service            
+  135ms rsyslog.service                       
+  122ms plymouth-quit-wait.service            
+  120ms atd.service                           
+  118ms systemd-networkd.service              
+  118ms systemd-sysusers.service              
+  104ms blk-availability.service              
+   90ms systemd-journal-flush.service         
+   88ms systemd-sysctl.service                
+   78ms systemd-udevd.service                 
+   77ms multipathd.service                    
+   76ms systemd-machine-id-commit.service     
+   74ms systemd-tmpfiles-setup.service        
+   70ms sys-kernel-config.mount               
+   68ms plymouth-quit.service                 
+   67ms ssh.service                           
+   66ms sys-fs-fuse-connections.mount         
+   66ms polkit.service                        
+   63ms systemd-random-seed.service           
+   61ms console-setup.service                 
+   60ms finalrd.service                       
+   59ms ufw.service                           
+   55ms systemd-user-sessions.service         
+   52ms nfs-config.service                    
+   51ms snapd.apparmor.service                
+   50ms plymouth-read-write.service           
+   49ms snap-snapd-9721.mount                 
+   45ms snap-lxd-18150.mount                  
+   45ms rpcbind.service                       
+   40ms systemd-update-utmp-runlevel.service  
+   37ms setvtrgb.service                      
+   35ms snap-oracle\x2dcloud\x2dagent-10.mount
+   34ms user-runtime-dir@1001.service         
+   34ms snap-core18-1932.mount                
+   33ms systemd-update-utmp.service           
+   28ms systemd-networkd-wait-online.service  
+   26ms dev-loop0.device                      
+   26ms systemd-tmpfiles-setup-dev.service    
+   22ms boot-efi.mount                        
+   19ms snapd.socket                          
+   19ms dev-loop2.device                      
+   18ms dev-loop1.device                      
+   18ms dev-loop3.device
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00400s +00.00100s
+|`->found local data from DataSourceOracle @00.01400s +00.14000s
+Finished stage: (init-local) 00.42600 seconds
+
+Starting stage: init-network
+|`->restored from cache with run check: DataSourceOracle @01.69000s +00.00400s
+|`->setting up datasource @01.76100s +00.00000s
+|`->reading and applying user-data @01.76900s +00.00400s
+|`->reading and applying vendor-data @01.77300s +00.00000s
+|`->activating datasource @01.79900s +00.00300s
+|`->config-migrator ran successfully @01.84300s +00.00100s
+|`->config-seed_random ran successfully @01.84500s +00.00300s
+|`->config-bootcmd ran successfully @01.84900s +00.00000s
+|`->config-write-files ran successfully @01.85000s +00.00300s
+|`->config-growpart ran successfully @01.85400s +00.54300s
+|`->config-resizefs ran successfully @02.39800s +00.64400s
+|`->config-disk_setup ran successfully @03.04300s +00.00100s
+|`->config-mounts ran successfully @03.04400s +00.00200s
+|`->config-set_hostname ran successfully @03.04600s +00.00600s
+|`->config-update_hostname ran successfully @03.05300s +00.00100s
+|`->config-update_etc_hosts ran successfully @03.05400s +00.00200s
+|`->config-ca-certs ran successfully @03.05600s +00.00100s
+|`->config-rsyslog ran successfully @03.05700s +00.00100s
+|`->config-users-groups ran successfully @03.05800s +00.14100s
+|`->config-ssh ran successfully @03.19900s +00.57900s
+Finished stage: (init-network) 02.11800 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @26.73200s +00.00100s
+|`->config-snap ran successfully @26.73300s +00.00100s
+|`->config-ssh-import-id ran successfully @26.73500s +00.00100s
+|`->config-locale ran successfully @26.73700s +00.04500s
+|`->config-set-passwords ran successfully @26.78200s +00.00100s
+|`->config-grub-dpkg ran successfully @26.78300s +00.35800s
+|`->config-apt-pipelining ran successfully @27.14200s +00.00200s
+|`->config-apt-configure ran successfully @27.14400s +00.11200s
+|`->config-ubuntu-advantage ran successfully @27.25600s +00.00100s
+|`->config-ntp ran successfully @27.25700s +00.00100s
+|`->config-timezone ran successfully @27.25800s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @27.25900s +00.00000s
+|`->config-runcmd ran successfully @27.25900s +00.00100s
+|`->config-byobu ran successfully @27.26000s +00.00100s
+Finished stage: (modules-config) 00.56400 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @27.83200s +00.00100s
+|`->config-fan ran successfully @27.83300s +00.00100s
+|`->config-landscape ran successfully @27.83400s +00.00100s
+|`->config-lxd ran successfully @27.83500s +00.00100s
+|`->config-ubuntu-drivers ran successfully @27.83600s +00.00000s
+|`->config-puppet ran successfully @27.83700s +00.00000s
+|`->config-chef ran successfully @27.83700s +00.00100s
+|`->config-mcollective ran successfully @27.83800s +00.00000s
+|`->config-salt-minion ran successfully @27.83900s +00.00000s
+|`->config-rightscale_userdata ran successfully @27.83900s +00.00100s
+|`->config-scripts-vendor ran successfully @27.84000s +00.00100s
+|`->config-scripts-per-once ran successfully @27.84100s +00.00100s
+|`->config-scripts-per-boot ran successfully @27.84200s +00.00000s
+|`->config-scripts-per-instance ran successfully @27.84200s +00.00100s
+|`->config-scripts-user ran successfully @27.84300s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @27.84400s +00.02900s
+|`->config-keys-to-console ran successfully @27.87400s +00.07900s
+|`->config-phone-home ran successfully @27.96300s +00.01500s
+|`->config-final-message ran successfully @27.97900s +00.01500s
+|`->config-power-state-change ran successfully @27.99500s +00.00300s
+Finished stage: (modules-final) 00.19900 seconds
+
+Total Time: 3.30700 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     00.64400s (init-network/config-resizefs)
+     00.57900s (init-network/config-ssh)
+     00.54300s (init-network/config-growpart)
+     00.35800s (modules-config/config-grub-dpkg)
+     00.14100s (init-network/config-users-groups)
+     00.14000s (init-local/search-Oracle)
+     00.11200s (modules-config/config-apt-configure)
+     00.07900s (modules-final/config-keys-to-console)
+     00.04500s (modules-config/config-locale)
+     00.02900s (modules-final/config-ssh-authkey-fingerprints)
+     00.01500s (modules-final/config-phone-home)
+     00.01500s (modules-final/config-final-message)
+     00.00600s (init-network/config-set_hostname)
+     00.00400s (init-network/consume-user-data)
+     00.00400s (init-network/check-cache)
+     00.00300s (modules-final/config-power-state-change)
+     00.00300s (init-network/config-write-files)
+     00.00300s (init-network/config-seed_random)
+     00.00300s (init-network/activate-datasource)
+     00.00200s (modules-config/config-apt-pipelining)
+     00.00200s (init-network/config-update_etc_hosts)
+     00.00200s (init-network/config-mounts)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-fan)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-ssh-import-id)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-local/check-cache)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-salt-minion)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-mcollective)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-bootcmd)
+
+1 boot records analyzed

--- a/manual/oracle-sru-20.4.0/test_upgrade_oci_xenial_after_201211154608.log
+++ b/manual/oracle-sru-20.4.0/test_upgrade_oci_xenial_after_201211154608.log
@@ -1,0 +1,228 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.4-0ubuntu1~16.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceOpenStack [net,ver=2]",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/network/interfaces.d/50-cloud-init.cfg =====
+
+===== systemd-analyze =====
+Startup finished in 15.894s (kernel) + 15.920s (userspace) = 31.814s
+===== systemd-analyze blame =====
+          6.639s cloud-init.service
+          2.175s snapd.service
+          1.879s cloud-config.service
+          1.780s dev-sda1.device
+          1.361s cloud-init-local.service
+          1.135s cloud-final.service
+           679ms lxd-containers.service
+           491ms mdadm.service
+           479ms netfilter-persistent.service
+           464ms accounts-daemon.service
+           451ms irqbalance.service
+           445ms apparmor.service
+           362ms lvm2-monitor.service
+           360ms apport.service
+           350ms console-setup.service
+           328ms keyboard-setup.service
+           305ms rpcbind.service
+           285ms grub-common.service
+           285ms systemd-udev-trigger.service
+           278ms iscsid.service
+           256ms dev-loop0.device
+           239ms ssh.service
+           237ms dev-loop1.device
+           230ms ondemand.service
+           226ms systemd-modules-load.service
+           219ms systemd-logind.service
+           217ms dev-loop2.device
+           184ms polkitd.service
+           168ms systemd-timesyncd.service
+           163ms rsyslog.service
+           162ms rc-local.service
+           156ms systemd-journald.service
+           146ms snapd.seeded.service
+           125ms run-rpc_pipefs.mount
+           119ms networking.service
+           110ms resolvconf.service
+           102ms systemd-udevd.service
+            99ms systemd-journal-flush.service
+            87ms open-iscsi.service
+            83ms snap-snapd-9721.mount
+            75ms ufw.service
+            72ms systemd-tmpfiles-setup-dev.service
+            67ms sys-kernel-debug.mount
+            64ms systemd-random-seed.service
+            62ms kmod-static-nodes.service
+            60ms dev-hugepages.mount
+            58ms user@1001.service
+            55ms nfs-config.service
+            55ms snap-oracle\x2dcloud\x2dagent-10.mount
+            54ms systemd-remount-fs.service
+            53ms systemd-tmpfiles-setup.service
+            50ms plymouth-read-write.service
+            49ms snapd.apparmor.service
+            48ms systemd-user-sessions.service
+            44ms dev-mqueue.mount
+            44ms systemd-sysctl.service
+            43ms systemd-update-utmp.service
+            41ms snapd.socket
+            37ms snap-core18-1932.mount
+            33ms lxd.socket
+            30ms plymouth-quit.service
+            29ms systemd-update-utmp-runlevel.service
+            28ms setvtrgb.service
+            17ms sys-fs-fuse-connections.mount
+            16ms plymouth-quit-wait.service
+            16ms iscsi-cleanup.service
+            16ms sys-kernel-config.mount
+            15ms boot-efi.mount
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.00500s +00.00100s
+|`->no local data found from DataSourceOpenStackLocal @00.03700s +00.07400s
+Finished stage: (init-local) 00.14100 seconds
+
+Starting stage: init-network
+|`->no cache found @00.71300s +00.00000s
+|`->found network data from DataSourceOpenStack @00.72000s +05.06400s
+|`->setting up datasource @06.04500s +00.00000s
+|`->reading and applying user-data @06.06000s +00.00500s
+|`->reading and applying vendor-data @06.06500s +00.00000s
+|`->activating datasource @06.09400s +00.00200s
+|`->config-migrator ran successfully @06.16900s +00.00100s
+|`->config-seed_random ran successfully @06.17000s +00.00100s
+|`->config-bootcmd ran successfully @06.17100s +00.00100s
+|`->config-write-files ran successfully @06.17200s +00.00100s
+|`->config-growpart ran successfully @06.17300s +00.06200s
+|`->config-resizefs ran successfully @06.23600s +00.01500s
+|`->config-disk_setup ran successfully @06.25400s +00.00200s
+|`->config-mounts ran successfully @06.25600s +00.03900s
+|`->config-set_hostname ran successfully @06.29500s +00.00700s
+|`->config-update_hostname ran successfully @06.30200s +00.00200s
+|`->config-update_etc_hosts ran successfully @06.30400s +00.00000s
+|`->config-ca-certs ran successfully @06.30500s +00.00100s
+|`->config-rsyslog ran successfully @06.30600s +00.00100s
+|`->config-users-groups ran successfully @06.30700s +00.03400s
+|`->config-ssh ran successfully @06.34200s +00.53700s
+Finished stage: (init-network) 06.18200 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @10.68200s +00.00000s
+|`->config-snap ran successfully @10.68300s +00.00100s
+|`->config-ssh-import-id ran successfully @10.68400s +00.00200s
+|`->config-locale ran successfully @10.68700s +00.00200s
+|`->config-set-passwords ran successfully @10.68900s +00.00100s
+|`->config-grub-dpkg ran successfully @10.69100s +00.56200s
+|`->config-apt-pipelining ran successfully @11.25500s +00.00200s
+|`->config-apt-configure ran successfully @11.25800s +00.16700s
+|`->config-ubuntu-advantage ran successfully @11.42600s +00.00200s
+|`->config-ntp ran successfully @11.42800s +00.00100s
+|`->config-timezone ran successfully @11.43000s +00.00100s
+|`->config-disable-ec2-metadata ran successfully @11.43200s +00.00000s
+|`->config-runcmd ran successfully @11.43200s +00.00100s
+|`->config-byobu ran successfully @11.43400s +00.00100s
+Finished stage: (modules-config) 00.87600 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @12.25400s +00.00200s
+|`->config-fan ran successfully @12.25600s +00.00200s
+|`->config-landscape ran successfully @12.25800s +00.00100s
+|`->config-lxd ran successfully @12.26000s +00.00100s
+|`->config-ubuntu-drivers ran successfully @12.26200s +00.00100s
+|`->config-puppet ran successfully @12.26300s +00.00200s
+|`->config-chef ran successfully @12.26500s +00.00100s
+|`->config-mcollective ran successfully @12.26600s +00.00200s
+|`->config-salt-minion ran successfully @12.26800s +00.00100s
+|`->config-reset_rmc ran successfully @12.27000s +00.00100s
+|`->config-refresh_rmc_and_interface ran successfully @12.27200s +00.00000s
+|`->config-rightscale_userdata ran successfully @12.27300s +00.00100s
+|`->config-scripts-vendor ran successfully @12.27500s +00.00100s
+|`->config-scripts-per-once ran successfully @12.27600s +00.00200s
+|`->config-scripts-per-boot ran successfully @12.27800s +00.00100s
+|`->config-scripts-per-instance ran successfully @12.27900s +00.00200s
+|`->config-scripts-user ran successfully @12.28100s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @12.28300s +00.11400s
+|`->config-keys-to-console ran successfully @12.39800s +00.12400s
+|`->config-phone-home ran successfully @12.52300s +00.00200s
+|`->config-final-message ran successfully @12.52600s +00.00700s
+|`->config-power-state-change ran successfully @12.53300s +00.00200s
+Finished stage: (modules-final) 00.36800 seconds
+
+Total Time: 7.56700 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     05.06400s (init-network/search-OpenStack)
+     00.56200s (modules-config/config-grub-dpkg)
+     00.53700s (init-network/config-ssh)
+     00.16700s (modules-config/config-apt-configure)
+     00.12400s (modules-final/config-keys-to-console)
+     00.11400s (modules-final/config-ssh-authkey-fingerprints)
+     00.07400s (init-local/search-OpenStackLocal)
+     00.06200s (init-network/config-growpart)
+     00.03900s (init-network/config-mounts)
+     00.03400s (init-network/config-users-groups)
+     00.01500s (init-network/config-resizefs)
+     00.00700s (modules-final/config-final-message)
+     00.00700s (init-network/config-set_hostname)
+     00.00500s (init-network/consume-user-data)
+     00.00200s (modules-final/config-scripts-per-once)
+     00.00200s (modules-final/config-scripts-per-instance)
+     00.00200s (modules-final/config-puppet)
+     00.00200s (modules-final/config-power-state-change)
+     00.00200s (modules-final/config-phone-home)
+     00.00200s (modules-final/config-package-update-upgrade-install)
+     00.00200s (modules-final/config-mcollective)
+     00.00200s (modules-final/config-fan)
+     00.00200s (modules-config/config-ubuntu-advantage)
+     00.00200s (modules-config/config-ssh-import-id)
+     00.00200s (modules-config/config-locale)
+     00.00200s (modules-config/config-apt-pipelining)
+     00.00200s (init-network/config-update_hostname)
+     00.00200s (init-network/config-disk_setup)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-ubuntu-drivers)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-boot)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-reset_rmc)
+     00.00100s (modules-final/config-lxd)
+     00.00100s (modules-final/config-landscape)
+     00.00100s (modules-final/config-chef)
+     00.00100s (modules-config/config-timezone)
+     00.00100s (modules-config/config-snap)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-runcmd)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-byobu)
+     00.00100s (init-network/config-write-files)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-ca-certs)
+     00.00100s (init-network/config-bootcmd)
+     00.00100s (init-local/check-cache)
+     00.00000s (modules-final/config-refresh_rmc_and_interface)
+     00.00000s (modules-config/config-emit_upstart)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-update_etc_hosts)
+     00.00000s (init-network/check-cache)
+
+1 boot records analyzed

--- a/manual/oracle-sru-20.4.0/test_upgrade_oci_xenial_before_201211154608.log
+++ b/manual/oracle-sru-20.4.0/test_upgrade_oci_xenial_before_201211154608.log
@@ -1,0 +1,226 @@
+===== hostname =====
+SRU-worked
+===== dpkg-query --show cloud-init =====
+cloud-init	20.3-2-g371b392c-0ubuntu1~16.04.1
+===== cat /run/cloud-init/result.json =====
+{
+ "v1": {
+  "datasource": "DataSourceOpenStack [net,ver=2]",
+  "errors": []
+ }
+}
+===== cloud-init initgrep Trace /var/log/cloud-init.log =====
+
+===== cloud-idcat /etc/network/interfaces.d/50-cloud-init.cfg =====
+
+===== systemd-analyze =====
+Startup finished in 12.234s (kernel) + 27.918s (userspace) = 40.152s
+===== systemd-analyze blame =====
+         13.609s snapd.seeded.service
+          6.616s cloud-init.service
+          2.571s cloud-config.service
+          1.968s apparmor.service
+          1.837s cloud-init-local.service
+          1.328s console-setup.service
+          1.281s snapd.service
+          1.256s pollinate.service
+          1.074s dev-sda1.device
+           683ms cloud-final.service
+           488ms netfilter-persistent.service
+           467ms accounts-daemon.service
+           464ms lxd-containers.service
+           326ms keyboard-setup.service
+           286ms mdadm.service
+           267ms lvm2-monitor.service
+           248ms grub-common.service
+           246ms rsyslog.service
+           235ms systemd-udev-trigger.service
+           206ms apport.service
+           203ms ondemand.service
+           201ms irqbalance.service
+           200ms systemd-journald.service
+           193ms systemd-modules-load.service
+           186ms iscsid.service
+           141ms rpcbind.service
+           135ms resolvconf.service
+           133ms systemd-timesyncd.service
+           130ms networking.service
+           111ms sys-kernel-debug.mount
+           104ms systemd-udevd.service
+           100ms dev-mqueue.mount
+            98ms run-rpc_pipefs.mount
+            93ms systemd-logind.service
+            80ms ufw.service
+            76ms plymouth-read-write.service
+            74ms systemd-machine-id-commit.service
+            70ms systemd-remount-fs.service
+            70ms systemd-tmpfiles-setup.service
+            62ms user@1001.service
+            59ms systemd-tmpfiles-setup-dev.service
+            57ms snapd.socket
+            56ms setvtrgb.service
+            53ms lxd.socket
+            50ms nfs-config.service
+            47ms ssh.service
+            47ms open-iscsi.service
+            46ms systemd-journal-flush.service
+            44ms kmod-static-nodes.service
+            43ms dev-hugepages.mount
+            42ms polkitd.service
+            41ms snap-snapd-9721.mount
+            38ms systemd-update-utmp.service
+            38ms snap-oracle\x2dcloud\x2dagent-10.mount
+            37ms systemd-user-sessions.service
+            34ms snap-core18-1932.mount
+            33ms plymouth-quit-wait.service
+            31ms plymouth-quit.service
+            31ms rc-local.service
+            28ms systemd-sysctl.service
+            27ms snapd.apparmor.service
+            21ms sys-fs-fuse-connections.mount
+            21ms sys-kernel-config.mount
+            18ms systemd-random-seed.service
+            17ms systemd-update-utmp-runlevel.service
+            16ms boot-efi.mount
+            15ms iscsi-cleanup.service
+             7ms dev-loop0.device
+             4ms dev-loop2.device
+             3ms dev-loop1.device
+===== cloud-init analyze show =====
+-- Boot Record 01 --
+The total time elapsed since completing an event is printed after the "@" character.
+The time the event takes is printed after the "+" character.
+
+Starting stage: init-local
+|`->no cache found @00.01100s +00.00000s
+|`->no local data found from DataSourceOpenStackLocal @00.02900s +00.15200s
+Finished stage: (init-local) 00.25100 seconds
+
+Starting stage: init-network
+|`->no cache found @01.03200s +00.00000s
+|`->found network data from DataSourceOpenStack @01.03900s +05.17700s
+|`->setting up datasource @06.31700s +00.00000s
+|`->reading and applying user-data @06.33100s +00.00400s
+|`->reading and applying vendor-data @06.33500s +00.00000s
+|`->activating datasource @06.36400s +00.00200s
+|`->config-migrator ran successfully @06.39100s +00.00100s
+|`->config-seed_random ran successfully @06.39200s +00.00100s
+|`->config-bootcmd ran successfully @06.39300s +00.00000s
+|`->config-write-files ran successfully @06.39400s +00.00000s
+|`->config-growpart ran successfully @06.39500s +00.11100s
+|`->config-resizefs ran successfully @06.50700s +00.07400s
+|`->config-disk_setup ran successfully @06.58100s +00.00100s
+|`->config-mounts ran successfully @06.58300s +00.02800s
+|`->config-set_hostname ran successfully @06.61100s +00.00600s
+|`->config-update_hostname ran successfully @06.61800s +00.00100s
+|`->config-update_etc_hosts ran successfully @06.61900s +00.00100s
+|`->config-ca-certs ran successfully @06.62100s +00.00100s
+|`->config-rsyslog ran successfully @06.62200s +00.00100s
+|`->config-users-groups ran successfully @06.62300s +00.11800s
+|`->config-ssh ran successfully @06.74100s +00.34500s
+Finished stage: (init-network) 06.07400 seconds
+
+Starting stage: modules-config
+|`->config-emit_upstart ran successfully @22.46600s +00.00100s
+|`->config-snap ran successfully @22.46700s +00.00200s
+|`->config-ssh-import-id ran successfully @22.46900s +00.00200s
+|`->config-locale ran successfully @22.47100s +01.00700s
+|`->config-set-passwords ran successfully @23.47900s +00.00100s
+|`->config-grub-dpkg ran successfully @23.48100s +00.24100s
+|`->config-apt-pipelining ran successfully @23.72300s +00.00100s
+|`->config-apt-configure ran successfully @23.72500s +00.55000s
+|`->config-ubuntu-advantage ran successfully @24.27600s +00.00100s
+|`->config-ntp ran successfully @24.27800s +00.00100s
+|`->config-timezone ran successfully @24.27900s +00.00200s
+|`->config-disable-ec2-metadata ran successfully @24.28100s +00.00000s
+|`->config-runcmd ran successfully @24.28200s +00.00000s
+|`->config-byobu ran successfully @24.28300s +00.00000s
+Finished stage: (modules-config) 01.86200 seconds
+
+Starting stage: modules-final
+|`->config-package-update-upgrade-install ran successfully @24.78300s +00.00100s
+|`->config-fan ran successfully @24.78500s +00.00000s
+|`->config-landscape ran successfully @24.78600s +00.00000s
+|`->config-lxd ran successfully @24.78700s +00.00000s
+|`->config-ubuntu-drivers ran successfully @24.78800s +00.00000s
+|`->config-puppet ran successfully @24.78900s +00.00000s
+|`->config-chef ran successfully @24.79000s +00.00000s
+|`->config-mcollective ran successfully @24.79000s +00.00100s
+|`->config-salt-minion ran successfully @24.79100s +00.00100s
+|`->config-rightscale_userdata ran successfully @24.79200s +00.00100s
+|`->config-scripts-vendor ran successfully @24.79300s +00.00100s
+|`->config-scripts-per-once ran successfully @24.79400s +00.00100s
+|`->config-scripts-per-boot ran successfully @24.79500s +00.00000s
+|`->config-scripts-per-instance ran successfully @24.79500s +00.00100s
+|`->config-scripts-user ran successfully @24.79600s +00.00100s
+|`->config-ssh-authkey-fingerprints ran successfully @24.79700s +00.03100s
+|`->config-keys-to-console ran successfully @24.82900s +00.06600s
+|`->config-phone-home ran successfully @24.89600s +00.00200s
+|`->config-final-message ran successfully @24.89900s +00.01000s
+|`->config-power-state-change ran successfully @24.91000s +00.00200s
+Finished stage: (modules-final) 00.16700 seconds
+
+Total Time: 8.35400 seconds
+
+1 boot records analyzed
+===== cloud-init analyze blame =====
+-- Boot Record 01 --
+     05.17700s (init-network/search-OpenStack)
+     01.00700s (modules-config/config-locale)
+     00.55000s (modules-config/config-apt-configure)
+     00.34500s (init-network/config-ssh)
+     00.24100s (modules-config/config-grub-dpkg)
+     00.15200s (init-local/search-OpenStackLocal)
+     00.11800s (init-network/config-users-groups)
+     00.11100s (init-network/config-growpart)
+     00.07400s (init-network/config-resizefs)
+     00.06600s (modules-final/config-keys-to-console)
+     00.03100s (modules-final/config-ssh-authkey-fingerprints)
+     00.02800s (init-network/config-mounts)
+     00.01000s (modules-final/config-final-message)
+     00.00600s (init-network/config-set_hostname)
+     00.00400s (init-network/consume-user-data)
+     00.00200s (modules-final/config-power-state-change)
+     00.00200s (modules-final/config-phone-home)
+     00.00200s (modules-config/config-timezone)
+     00.00200s (modules-config/config-ssh-import-id)
+     00.00200s (modules-config/config-snap)
+     00.00200s (init-network/activate-datasource)
+     00.00100s (modules-final/config-scripts-vendor)
+     00.00100s (modules-final/config-scripts-user)
+     00.00100s (modules-final/config-scripts-per-once)
+     00.00100s (modules-final/config-scripts-per-instance)
+     00.00100s (modules-final/config-salt-minion)
+     00.00100s (modules-final/config-rightscale_userdata)
+     00.00100s (modules-final/config-package-update-upgrade-install)
+     00.00100s (modules-final/config-mcollective)
+     00.00100s (modules-config/config-ubuntu-advantage)
+     00.00100s (modules-config/config-set-passwords)
+     00.00100s (modules-config/config-ntp)
+     00.00100s (modules-config/config-emit_upstart)
+     00.00100s (modules-config/config-apt-pipelining)
+     00.00100s (init-network/config-update_hostname)
+     00.00100s (init-network/config-update_etc_hosts)
+     00.00100s (init-network/config-seed_random)
+     00.00100s (init-network/config-rsyslog)
+     00.00100s (init-network/config-migrator)
+     00.00100s (init-network/config-disk_setup)
+     00.00100s (init-network/config-ca-certs)
+     00.00000s (modules-final/config-ubuntu-drivers)
+     00.00000s (modules-final/config-scripts-per-boot)
+     00.00000s (modules-final/config-puppet)
+     00.00000s (modules-final/config-lxd)
+     00.00000s (modules-final/config-landscape)
+     00.00000s (modules-final/config-fan)
+     00.00000s (modules-final/config-chef)
+     00.00000s (modules-config/config-runcmd)
+     00.00000s (modules-config/config-disable-ec2-metadata)
+     00.00000s (modules-config/config-byobu)
+     00.00000s (init-network/setup-datasource)
+     00.00000s (init-network/consume-vendor-data)
+     00.00000s (init-network/config-write-files)
+     00.00000s (init-network/config-bootcmd)
+     00.00000s (init-network/check-cache)
+     00.00000s (init-local/check-cache)
+
+1 boot records analyzed


### PR DESCRIPTION
These look a little different because we have the test_upgrade.py script now that generates logs that need to be manually compared. The "normal" text file for each text contains the test run output, and I've also uploaded the before and after logs for each test run.